### PR TITLE
style(lint): fix ruff import-sort and black formatting on main

### DIFF
--- a/backends.py
+++ b/backends.py
@@ -276,9 +276,7 @@ def _resolve_uptrace(bc: BackendConfig) -> _ResolvedBackend:
         ["OTEL_UPTRACE_DSN", "UPTRACE_DSN"],
     )
     if not dsn:
-        raise ValueError(
-            "uptrace requires dsn (e.g. http://<project_token>@host:14318?grpc=14317)"
-        )
+        raise ValueError("uptrace requires dsn (e.g. http://<project_token>@host:14318?grpc=14317)")
     headers: Dict[str, str] = {"uptrace-dsn": dsn}
     headers.update(bc.headers or {})
     return _ResolvedBackend(

--- a/tests/unit/test_log_handler.py
+++ b/tests/unit/test_log_handler.py
@@ -16,10 +16,8 @@ import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from hermes_otel import log_handler
 from hermes_otel.backends import _ResolvedBackend
-
 
 # ── resolve_level ──────────────────────────────────────────────────────────
 
@@ -200,8 +198,7 @@ class TestInstallHandler:
             level=logging.INFO,
         )
         markers = [
-            h for h in clean_root_logger.handlers
-            if getattr(h, log_handler._HANDLER_MARKER, False)
+            h for h in clean_root_logger.handlers if getattr(h, log_handler._HANDLER_MARKER, False)
         ]
         assert len(markers) == 1
 
@@ -214,14 +211,12 @@ class TestInstallHandler:
         )
         target = logging.getLogger("hermes_otel_test_scoped")
         try:
-            markers = [
-                h for h in target.handlers
-                if getattr(h, log_handler._HANDLER_MARKER, False)
-            ]
+            markers = [h for h in target.handlers if getattr(h, log_handler._HANDLER_MARKER, False)]
             assert len(markers) == 1
             # Root gets nothing — scoped install must not leak.
             root_markers = [
-                h for h in clean_root_logger.handlers
+                h
+                for h in clean_root_logger.handlers
                 if getattr(h, log_handler._HANDLER_MARKER, False)
             ]
             assert root_markers == []
@@ -247,8 +242,7 @@ class TestInstallHandler:
             level=logging.INFO,
         )
         markers = [
-            h for h in clean_root_logger.handlers
-            if getattr(h, log_handler._HANDLER_MARKER, False)
+            h for h in clean_root_logger.handlers if getattr(h, log_handler._HANDLER_MARKER, False)
         ]
         assert len(markers) == 1, "should replace, not stack, prior installs"
 
@@ -423,9 +417,7 @@ class TestOpenObserveBackendType:
         from hermes_otel.plugin_config import BackendConfig
 
         with pytest.raises(ValueError, match="endpoint"):
-            backends.resolve(
-                BackendConfig(type="openobserve", user="u", password="p")
-            )
+            backends.resolve(BackendConfig(type="openobserve", user="u", password="p"))
 
     def test_openobserve_requires_credentials(self):
         from hermes_otel import backends
@@ -550,8 +542,7 @@ class TestTracerLogsPipelineWiring:
         assert len(plugin._log_processors) == 1
         # Handler reached the root logger with our marker.
         markers = [
-            h for h in clean_root_logger.handlers
-            if getattr(h, log_handler._HANDLER_MARKER, False)
+            h for h in clean_root_logger.handlers if getattr(h, log_handler._HANDLER_MARKER, False)
         ]
         assert len(markers) == 1
 
@@ -562,9 +553,7 @@ class TestTracerLogsPipelineWiring:
 
         cfg = HermesOtelConfig(capture_logs=True)
         plugin = HermesOTelPlugin(config=cfg)
-        traces_only = _ResolvedBackend(
-            type="tempo", endpoint="x", supports_logs=False
-        )
+        traces_only = _ResolvedBackend(type="tempo", endpoint="x", supports_logs=False)
 
         with caplog.at_level("WARNING", logger="hermes_otel"):
             plugin._init_logs_pipeline(Resource.create({}), [traces_only])


### PR DESCRIPTION
## Summary
- Fixes the lint failure CI is currently flagging on main (run 24791270874).
- Only change is the single commit \`aafd871\` — formatting-only (ruff import-sort + black line-collapse on \`backends.py\` and \`tests/unit/test_log_handler.py\`).
- PR #5 was merged before its CI cleared; this restores main to green.

## Test plan
- [x] \`ruff check .\` — all checks passed
- [x] \`black --check .\` — 39 files unchanged
- [x] \`pytest tests/unit tests/integration\` — 366 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)