### PR TITLE
feat(hooks): capture gateway sender identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ root_span_ttl_ms: 600000        # orphan-sweep threshold (10 min default)
 flush_interval_ms: 60000        # metrics export cadence
 preview_max_chars: 1200         # clip_preview truncation limit
 capture_previews: true          # false = suppress all input.value / output.value
-capture_sender_id: false        # true = add platform user ID to llm/session spans
+capture_sender_id: false        # true = add platform-prefixed user.id to spans
 project_name: hermes-prod       # supersedes OTEL_PROJECT_NAME
 global_tags:
   team: platform
@@ -379,7 +379,7 @@ Every field can be overridden by env var with prefix `HERMES_OTEL_` (scalars onl
 
 Set `capture_previews: false` (or `HERMES_OTEL_CAPTURE_PREVIEWS=false`) to suppress every `input.value` / `output.value` attribute. Useful for shared deployments where message content can't leave the process. A one-line startup banner confirms the mode is active.
 
-Set `capture_sender_id: true` (or `HERMES_OTEL_CAPTURE_SENDER_ID=true`) to attach the gateway platform user ID to `llm.*` and root session spans as `hermes.sender.id`. This is opt-in because IDs from Discord, Telegram, Slack, and similar platforms can identify users. CLI sessions usually omit it.
+Set `capture_sender_id: true` (or `HERMES_OTEL_CAPTURE_SENDER_ID=true`) to attach gateway sender identity to spans. The plugin emits the raw platform ID as `hermes.sender.id` and the backend-neutral user key as `user.id={platform}:{sender_id}`. For example, Slack user `U0B074344DP` becomes `user.id=slack:U0B074344DP`. The platform is already available on LLM spans as `llm.provider`. This is opt-in because IDs from Discord, Telegram, Slack, email, SMS, and similar platforms can identify users. CLI sessions usually omit it.
 
 ### Per-turn summary attributes
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ root_span_ttl_ms: 600000        # orphan-sweep threshold (10 min default)
 flush_interval_ms: 60000        # metrics export cadence
 preview_max_chars: 1200         # clip_preview truncation limit
 capture_previews: true          # false = suppress all input.value / output.value
+capture_sender_id: false        # true = add platform user ID to llm/session spans
 project_name: hermes-prod       # supersedes OTEL_PROJECT_NAME
 global_tags:
   team: platform
@@ -364,6 +365,7 @@ Every field can be overridden by env var with prefix `HERMES_OTEL_` (scalars onl
 | `flush_interval_ms` | `HERMES_OTEL_FLUSH_INTERVAL_MS` |
 | `preview_max_chars` | `HERMES_OTEL_PREVIEW_MAX_CHARS` |
 | `capture_previews` | `HERMES_OTEL_CAPTURE_PREVIEWS` |
+| `capture_sender_id` | `HERMES_OTEL_CAPTURE_SENDER_ID` |
 | `project_name` | `HERMES_OTEL_PROJECT_NAME` |
 | `span_batch_max_queue_size` | `HERMES_OTEL_SPAN_BATCH_MAX_QUEUE_SIZE` |
 | `span_batch_schedule_delay_ms` | `HERMES_OTEL_SPAN_BATCH_SCHEDULE_DELAY_MS` |
@@ -376,6 +378,8 @@ Every field can be overridden by env var with prefix `HERMES_OTEL_` (scalars onl
 #### Privacy mode
 
 Set `capture_previews: false` (or `HERMES_OTEL_CAPTURE_PREVIEWS=false`) to suppress every `input.value` / `output.value` attribute. Useful for shared deployments where message content can't leave the process. A one-line startup banner confirms the mode is active.
+
+Set `capture_sender_id: true` (or `HERMES_OTEL_CAPTURE_SENDER_ID=true`) to attach the gateway platform user ID to `llm.*` and root session spans as `hermes.sender.id`. This is opt-in because IDs from Discord, Telegram, Slack, and similar platforms can identify users. CLI sessions usually omit it.
 
 ### Per-turn summary attributes
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -57,10 +57,12 @@
 # Metadata (tool names, durations, token counts) is still recorded.
 # capture_previews: true
 
-# Platform sender ID capture. When true, gateway sessions add
-# hermes.sender.id to llm.* and root session spans when Hermes exposes it.
-# This is the platform user ID (for example Discord, Telegram, or Slack),
-# not a display name. CLI sessions usually leave it empty.
+# Platform sender ID capture. When true, gateway sessions add the raw
+# platform sender ID as hermes.sender.id and a backend-neutral user.id
+# formatted as "{platform}:{sender_id}". The platform is already emitted
+# on LLM spans as llm.provider.
+# This can identify users (for example Discord, Telegram, Slack, email, SMS),
+# so keep it opt-in. CLI sessions usually leave it empty.
 # capture_sender_id: false
 
 # Put the entire conversation_history the model is about to see on the

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -57,6 +57,12 @@
 # Metadata (tool names, durations, token counts) is still recorded.
 # capture_previews: true
 
+# Platform sender ID capture. When true, gateway sessions add
+# hermes.sender.id to llm.* and root session spans when Hermes exposes it.
+# This is the platform user ID (for example Discord, Telegram, or Slack),
+# not a display name. CLI sessions usually leave it empty.
+# capture_sender_id: false
+
 # Put the entire conversation_history the model is about to see on the
 # llm.* span's input.value. The api.* spans don't carry message-level
 # detail, so flipping this on is the easiest way to see what the model saw.

--- a/hooks.py
+++ b/hooks.py
@@ -221,6 +221,33 @@ def _preview(value: Any, max_len: int) -> Optional[str]:
     return clip_preview(value, cap)
 
 
+def _sender_attributes(sender_id: str, platform: str) -> Dict[str, str]:
+    """Return backend-neutral sender attributes for trace/user filtering."""
+    if not sender_id:
+        return {}
+    attrs = {"hermes.sender.id": sender_id}
+    attrs["user.id"] = f"{platform}:{sender_id}" if platform else sender_id
+    return attrs
+
+
+def _session_sender_attributes(tracer, session_id: Optional[str]) -> Dict[str, str]:
+    """Return sender attributes already captured for a session."""
+    if not session_id:
+        return {}
+    ps = tracer.sessions.peek(session_id)
+    return _per_session_sender_attributes(ps)
+
+
+def _per_session_sender_attributes(ps: Any) -> Dict[str, str]:
+    """Return sender attributes from a PerSession aggregator."""
+    if ps is None or not ps.sender_id:
+        return {}
+    attrs = {"hermes.sender.id": ps.sender_id}
+    if ps.user_id:
+        attrs["user.id"] = ps.user_id
+    return attrs
+
+
 def _json_default(obj: Any) -> Any:
     """Fallback for :func:`json.dumps` on objects we hand through the api hook.
 
@@ -371,8 +398,7 @@ def on_session_end(
     if ps is not None and ps.usage_updated:
         attributes.update(_usage_attributes(ps.usage))
 
-    if ps is not None and ps.sender_id:
-        attributes["hermes.sender.id"] = ps.sender_id
+    attributes.update(_per_session_sender_attributes(ps))
 
     # Per-turn summary roll-up
     if ps is not None:
@@ -448,6 +474,7 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
     # Summary roll-up (requires session_id to bucket into the right turn).
     session_id = kwargs.get("session_id")
     if session_id:
+        attributes.update(_session_sender_attributes(tracer, session_id))
         summary = tracer.sessions.get_or_create(session_id).turn_summary
         summary.add_tool(tool_name)
         summary.add_target(target)
@@ -513,6 +540,7 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
     # Summary roll-up
     session_id = kwargs.get("session_id")
     if session_id:
+        attributes.update(_session_sender_attributes(tracer, session_id))
         summary = tracer.sessions.get_or_create(session_id).turn_summary
         summary.add_outcome(outcome)
 
@@ -577,9 +605,13 @@ def on_pre_llm_call(
     if tracer.config.capture_sender_id:
         sender_id = truncate_string(kwargs.get("sender_id"), 200)
         if sender_id:
-            attributes["hermes.sender.id"] = sender_id
+            sender_platform = truncate_string(platform, 120)
+            sender_attrs = _sender_attributes(sender_id, sender_platform)
+            attributes.update(sender_attrs)
             if session_id:
-                tracer.sessions.get_or_create(session_id).sender_id = sender_id
+                ps = tracer.sessions.get_or_create(session_id)
+                ps.sender_id = sender_id
+                ps.user_id = sender_attrs["user.id"]
 
     # Opt-in: put the entire conversation the model is about to see on
     # input.value. Falls back to just the latest user_message otherwise —
@@ -707,6 +739,8 @@ def on_pre_api_request(
     }
     if max_tokens:
         attributes["llm.request.max_tokens"] = max_tokens
+
+    attributes.update(_session_sender_attributes(tracer, session_id))
 
     if tracer.config.capture_full_prompts:
         messages = kwargs.get("messages")

--- a/hooks.py
+++ b/hooks.py
@@ -371,6 +371,9 @@ def on_session_end(
     if ps is not None and ps.usage_updated:
         attributes.update(_usage_attributes(ps.usage))
 
+    if ps is not None and ps.sender_id:
+        attributes["hermes.sender.id"] = ps.sender_id
+
     # Per-turn summary roll-up
     if ps is not None:
         summary = ps.turn_summary
@@ -570,6 +573,13 @@ def on_pre_llm_call(
         "llm.model_name": model,
         "llm.provider": platform,
     }
+
+    if tracer.config.capture_sender_id:
+        sender_id = truncate_string(kwargs.get("sender_id"), 200)
+        if sender_id:
+            attributes["hermes.sender.id"] = sender_id
+            if session_id:
+                tracer.sessions.get_or_create(session_id).sender_id = sender_id
 
     # Opt-in: put the entire conversation the model is about to see on
     # input.value. Falls back to just the latest user_message otherwise —

--- a/plugin_config.py
+++ b/plugin_config.py
@@ -101,6 +101,9 @@ class HermesOtelConfig:
     # summary-level LLM span; these flags target the per-request span.
     capture_full_prompts: bool = False
     capture_full_responses: bool = False
+    # Opt-in: platform user identifier from Hermes gateway sessions. Hermes
+    # currently exposes this as ``sender_id`` only on pre_llm_call.
+    capture_sender_id: bool = False
     # ── OTel logs signal ────────────────────────────────────────────────
     # Opt-in: when enabled, attach an OTel ``LoggingHandler`` to Python's
     # logging so stdlib ``logger.info(...)`` calls ship to any log-capable
@@ -247,6 +250,7 @@ def _coerce_from_yaml(key: str, value: Any) -> Any:
         "capture_logs",
         "capture_full_prompts",
         "capture_full_responses",
+        "capture_sender_id",
     ):
         if isinstance(value, bool):
             return value
@@ -319,6 +323,7 @@ def _load_env_overrides() -> Dict[str, Any]:
     take("capture_logs", _parse_bool)
     take("capture_full_prompts", _parse_bool)
     take("capture_full_responses", _parse_bool)
+    take("capture_sender_id", _parse_bool)
 
     proj = os.getenv(_ENV_PREFIX + "PROJECT_NAME", "").strip()
     if proj:

--- a/session_state.py
+++ b/session_state.py
@@ -90,6 +90,7 @@ class PerSession:
     usage: Dict[str, int] = field(default_factory=_empty_usage)
     usage_updated: bool = False
     sender_id: str = ""
+    user_id: str = ""
     io: Dict[str, str] = field(default_factory=lambda: {"input": "", "output": ""})
     io_captured: bool = False
     turn_summary: TurnSummary = field(default_factory=TurnSummary)

--- a/session_state.py
+++ b/session_state.py
@@ -89,6 +89,7 @@ class PerSession:
 
     usage: Dict[str, int] = field(default_factory=_empty_usage)
     usage_updated: bool = False
+    sender_id: str = ""
     io: Dict[str, str] = field(default_factory=lambda: {"input": "", "output": ""})
     io_captured: bool = False
     turn_summary: TurnSummary = field(default_factory=TurnSummary)

--- a/tests/integration/test_session_lifecycle.py
+++ b/tests/integration/test_session_lifecycle.py
@@ -229,6 +229,45 @@ class TestFullSessionLifecycle:
         # PerSession aggregator popped — no lingering state.
         assert plugin.sessions.peek("s1") is None
 
+    def test_sender_id_rolls_up_to_session_span_when_enabled(self, inmemory_otel_setup):
+        """sender_id from pre_llm_call is attached to llm and session spans when opted in."""
+        from hermes_otel.plugin_config import HermesOtelConfig
+
+        exporter, plugin = inmemory_otel_setup
+        plugin.config = HermesOtelConfig(capture_sender_id=True)
+
+        on_session_start(session_id="s1", model="gpt-4", platform="discord")
+        on_pre_llm_call(
+            session_id="s1",
+            user_message="hello",
+            conversation_history=[],
+            is_first_turn=True,
+            model="gpt-4",
+            platform="discord",
+            sender_id="123456789012345678",
+        )
+        on_post_llm_call(
+            session_id="s1",
+            user_message="hello",
+            assistant_response="hi",
+            conversation_history=[],
+            model="gpt-4",
+            platform="discord",
+        )
+        on_session_end(
+            session_id="s1",
+            completed=True,
+            interrupted=False,
+            model="gpt-4",
+            platform="discord",
+        )
+
+        spans = exporter.get_finished_spans()
+        llm_span = _span_by_name(spans, "llm.gpt-4")
+        session_span = _span_by_name(spans, "agent")
+        assert llm_span.attributes["hermes.sender.id"] == "123456789012345678"
+        assert session_span.attributes["hermes.sender.id"] == "123456789012345678"
+
     def test_interrupted_session(self, inmemory_otel_setup):
         """An interrupted session should still export with status ok."""
         exporter, _ = inmemory_otel_setup

--- a/tests/integration/test_session_lifecycle.py
+++ b/tests/integration/test_session_lifecycle.py
@@ -165,6 +165,75 @@ class TestFullSessionLifecycle:
         assert attrs["input.value"] == "What files are here?"
         assert "file.txt" in attrs["output.value"]
 
+    def test_sender_id_propagates_to_api_and_tool_spans(self, inmemory_otel_setup):
+        from hermes_otel.plugin_config import HermesOtelConfig
+
+        exporter, plugin = inmemory_otel_setup
+        plugin.config = HermesOtelConfig(capture_sender_id=True)
+
+        on_session_start(session_id="s1", model="gpt-4", platform="slack")
+        on_pre_llm_call(
+            session_id="s1",
+            user_message="run code",
+            conversation_history=[],
+            is_first_turn=True,
+            model="gpt-4",
+            platform="slack",
+            sender_id="U0B074344DP",
+        )
+        on_pre_api_request(
+            task_id="api1",
+            session_id="s1",
+            platform="slack",
+            model="gpt-4",
+            provider="openai",
+            base_url="",
+            api_mode="chat",
+            api_call_count=1,
+            message_count=1,
+            tool_count=1,
+            approx_input_tokens=100,
+            request_char_count=500,
+            max_tokens=0,
+        )
+        on_pre_tool_call(
+            tool_name="execute_code",
+            args={"code": "print('hi')"},
+            task_id="tool1",
+            session_id="s1",
+        )
+        on_post_tool_call(
+            tool_name="execute_code",
+            args={"code": "print('hi')"},
+            result="hi",
+            task_id="tool1",
+            session_id="s1",
+        )
+        on_post_api_request(
+            task_id="api1",
+            session_id="s1",
+            platform="slack",
+            model="gpt-4",
+            provider="openai",
+            base_url="",
+            api_mode="chat",
+            api_call_count=1,
+            api_duration=0.1,
+            finish_reason="stop",
+            message_count=1,
+            response_model="gpt-4",
+            usage={},
+            assistant_content_chars=0,
+            assistant_tool_call_count=0,
+        )
+
+        spans = exporter.get_finished_spans()
+        api_span = _span_by_name(spans, "api.gpt-4")
+        tool_span = _span_by_name(spans, "tool.execute_code")
+        for span in [api_span, tool_span]:
+            assert span.attributes["hermes.sender.id"] == "U0B074344DP"
+            assert span.attributes["user.id"] == "slack:U0B074344DP"
+
     def test_module_state_cleaned_after_session_end(self, inmemory_otel_setup):
         """Verify that per-session aggregators are popped at session end."""
         exporter, plugin = inmemory_otel_setup
@@ -230,7 +299,7 @@ class TestFullSessionLifecycle:
         assert plugin.sessions.peek("s1") is None
 
     def test_sender_id_rolls_up_to_session_span_when_enabled(self, inmemory_otel_setup):
-        """sender_id from pre_llm_call is attached to llm and session spans when opted in."""
+        """sender_id from pre_llm_call is emitted as a platform-prefixed user.id."""
         from hermes_otel.plugin_config import HermesOtelConfig
 
         exporter, plugin = inmemory_otel_setup
@@ -266,7 +335,9 @@ class TestFullSessionLifecycle:
         llm_span = _span_by_name(spans, "llm.gpt-4")
         session_span = _span_by_name(spans, "agent")
         assert llm_span.attributes["hermes.sender.id"] == "123456789012345678"
+        assert llm_span.attributes["user.id"] == "discord:123456789012345678"
         assert session_span.attributes["hermes.sender.id"] == "123456789012345678"
+        assert session_span.attributes["user.id"] == "discord:123456789012345678"
 
     def test_interrupted_session(self, inmemory_otel_setup):
         """An interrupted session should still export with status ok."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -25,6 +25,7 @@ _ENV_VARS = [
     "HERMES_OTEL_SPAN_BATCH_MAX_EXPORT_BATCH_SIZE",
     "HERMES_OTEL_SPAN_BATCH_EXPORT_TIMEOUT_MS",
     "HERMES_OTEL_FORCE_FLUSH_ON_SESSION_END",
+    "HERMES_OTEL_CAPTURE_SENDER_ID",
 ]
 
 
@@ -298,6 +299,25 @@ class TestCaptureFullFlags:
         cfg = load_config(path=path)
         assert cfg.capture_full_prompts is True
         assert cfg.capture_full_responses is True
+
+
+class TestCaptureSenderId:
+    def test_defaults_off(self, tmp_path):
+        cfg = load_config(path=tmp_path / "missing.yaml")
+        assert cfg.capture_sender_id is False
+
+    def test_env_toggle(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_OTEL_CAPTURE_SENDER_ID", "true")
+        cfg = load_config(path=tmp_path / "missing.yaml")
+        assert cfg.capture_sender_id is True
+
+    def test_yaml_value(self, tmp_path):
+        if not _has_yaml():
+            pytest.skip("pyyaml not installed")
+        path = tmp_path / "config.yaml"
+        path.write_text("capture_sender_id: true\n")
+        cfg = load_config(path=path)
+        assert cfg.capture_sender_id is True
 
 
 class TestBackendsYaml:

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -335,9 +335,10 @@ class TestOnPreLlmCall:
         )
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
         assert "hermes.sender.id" not in attrs
+        assert "user.id" not in attrs
         assert mock_tracer.sessions.peek("s1").sender_id == ""
 
-    def test_sender_id_captured_when_enabled(self, mock_tracer):
+    def test_sender_id_captured_as_platform_prefixed_user_id_when_enabled(self, mock_tracer):
         from hermes_otel.plugin_config import HermesOtelConfig
 
         mock_tracer.config = HermesOtelConfig(capture_sender_id=True)
@@ -352,7 +353,10 @@ class TestOnPreLlmCall:
         )
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
         assert attrs["hermes.sender.id"] == "123456789012345678"
-        assert mock_tracer.sessions.peek("s1").sender_id == "123456789012345678"
+        assert attrs["user.id"] == "discord:123456789012345678"
+        ps = mock_tracer.sessions.peek("s1")
+        assert ps.sender_id == "123456789012345678"
+        assert ps.user_id == "discord:123456789012345678"
 
     def test_empty_sender_id_is_ignored_when_enabled(self, mock_tracer):
         from hermes_otel.plugin_config import HermesOtelConfig
@@ -369,6 +373,7 @@ class TestOnPreLlmCall:
         )
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
         assert "hermes.sender.id" not in attrs
+        assert "user.id" not in attrs
         assert mock_tracer.sessions.peek("s1").sender_id == ""
 
     def test_noop_when_disabled(self, disabled_tracer):
@@ -500,6 +505,29 @@ class TestOnPreApiRequest:
         assert attrs["llm.provider"] == "openai"
         assert attrs["llm.request.message_count"] == 10
         assert attrs["llm.request.max_tokens"] == 2048
+
+    def test_includes_session_user_id_when_available(self, mock_tracer):
+        ps = mock_tracer.sessions.get_or_create("s1")
+        ps.sender_id = "U0B074344DP"
+        ps.user_id = "slack:U0B074344DP"
+        on_pre_api_request(
+            task_id="t1",
+            session_id="s1",
+            platform="slack",
+            model="gpt-4",
+            provider="openai",
+            base_url="",
+            api_mode="chat",
+            api_call_count=1,
+            message_count=10,
+            tool_count=0,
+            approx_input_tokens=500,
+            request_char_count=2000,
+            max_tokens=2048,
+        )
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert attrs["hermes.sender.id"] == "U0B074344DP"
+        assert attrs["user.id"] == "slack:U0B074344DP"
 
     def test_noop_when_disabled(self, disabled_tracer):
         on_pre_api_request(

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -323,6 +323,54 @@ class TestOnPreLlmCall:
         )
         assert result is None
 
+    def test_sender_id_not_captured_by_default(self, mock_tracer):
+        on_pre_llm_call(
+            session_id="s1",
+            user_message="hello",
+            conversation_history=[],
+            is_first_turn=True,
+            model="gpt-4",
+            platform="discord",
+            sender_id="123456789012345678",
+        )
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert "hermes.sender.id" not in attrs
+        assert mock_tracer.sessions.peek("s1").sender_id == ""
+
+    def test_sender_id_captured_when_enabled(self, mock_tracer):
+        from hermes_otel.plugin_config import HermesOtelConfig
+
+        mock_tracer.config = HermesOtelConfig(capture_sender_id=True)
+        on_pre_llm_call(
+            session_id="s1",
+            user_message="hello",
+            conversation_history=[],
+            is_first_turn=True,
+            model="gpt-4",
+            platform="discord",
+            sender_id="123456789012345678",
+        )
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert attrs["hermes.sender.id"] == "123456789012345678"
+        assert mock_tracer.sessions.peek("s1").sender_id == "123456789012345678"
+
+    def test_empty_sender_id_is_ignored_when_enabled(self, mock_tracer):
+        from hermes_otel.plugin_config import HermesOtelConfig
+
+        mock_tracer.config = HermesOtelConfig(capture_sender_id=True)
+        on_pre_llm_call(
+            session_id="s1",
+            user_message="hello",
+            conversation_history=[],
+            is_first_turn=True,
+            model="gpt-4",
+            platform="cli",
+            sender_id="",
+        )
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert "hermes.sender.id" not in attrs
+        assert mock_tracer.sessions.peek("s1").sender_id == ""
+
     def test_noop_when_disabled(self, disabled_tracer):
         on_pre_llm_call(
             session_id="s1",


### PR DESCRIPTION
## Summary
- Add opt-in `capture_sender_id` support for Hermes gateway sender IDs.
- Emit raw sender IDs as `hermes.sender.id` and backend-neutral platform-prefixed `user.id` values.
- Propagate sender identity to session, LLM, API, and tool spans when session context is available.

## Testing
- `uv run --extra dev pytest`

## Notes
- Sender identity capture is disabled by default because platform IDs can identify users.
- No Langfuse-specific `langfuse.*` user/session attributes are emitted; backends can use standard `user.id`.