### PR TITLE
Add correlation.id propagation across spans

### DIFF
--- a/hooks.py
+++ b/hooks.py
@@ -238,6 +238,64 @@ def _session_sender_attributes(tracer, session_id: Optional[str]) -> Dict[str, s
     return _per_session_sender_attributes(ps)
 
 
+def _extract_correlation_id(extra_kwargs: dict) -> str:
+    """Return an incoming correlation identifier from hook kwargs, if present.
+
+    Different callers spell this value differently. Accept the common Python
+    snake_case form, the canonical OTel attribute key, and the HTTP/W3C-ish
+    hyphenated form so gateways, cron, webhooks, and API callers can pass it
+    through without adapter-specific glue.
+    """
+
+    for key in (
+        "correlation_id",
+        "correlation.id",
+        "correlation-id",
+        "x_correlation_id",
+        "x-correlation-id",
+    ):
+        raw = extra_kwargs.get(key)
+        if raw is None:
+            continue
+        value = truncate_string(raw, 200)
+        if value:
+            return value
+    return ""
+
+
+def _correlation_attributes(tracer, session_id: Optional[str], extra_kwargs: dict) -> Dict[str, str]:
+    """Build stable correlation attributes for a hook callback.
+
+    Preference order:
+    1. Incoming correlation ID supplied by the host app/hook kwargs.
+    2. Previously resolved per-session correlation ID.
+    3. The Hermes session ID as deterministic fallback.
+
+    Using the session ID fallback keeps today's Hermes traces queryable by a
+    stable ``correlation.id`` without requiring gateway/core changes first.
+    When a true upstream boundary provides a correlation ID, it wins and is
+    reused for all later spans in the same session.
+    """
+
+    incoming = _extract_correlation_id(extra_kwargs)
+    session_text = truncate_string(session_id, 200)
+    correlation_id = incoming
+
+    if session_text:
+        ps = tracer.sessions.get_or_create(session_text)
+        if incoming:
+            ps.correlation_id = incoming
+        elif ps.correlation_id:
+            correlation_id = ps.correlation_id
+        else:
+            correlation_id = session_text
+            ps.correlation_id = correlation_id
+
+    if not correlation_id:
+        return {}
+    return {"correlation.id": correlation_id}
+
+
 def _per_session_sender_attributes(ps: Any) -> Dict[str, str]:
     """Return sender attributes from a PerSession aggregator."""
     if ps is None or not ps.sender_id:
@@ -329,6 +387,7 @@ def _start_session_span(
         "llm.model_name": truncate_string(model, 200),
         "llm.provider": truncate_string(platform, 120),
     }
+    attributes.update(_correlation_attributes(tracer, session_id, extra_kwargs))
     if synthesized:
         attributes["hermes.session.synthesized"] = True
 
@@ -384,6 +443,7 @@ def on_session_end(
         "llm.model_name": truncate_string(model, 200),
         "llm.provider": truncate_string(platform, 120),
     }
+    attributes.update(_correlation_attributes(tracer, session_id, kwargs))
 
     # Drain the aggregators in one shot. Everything this session buffered
     # — I/O, usage totals, turn summary — comes back in a single PerSession.
@@ -474,6 +534,7 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
     # Summary roll-up (requires session_id to bucket into the right turn).
     session_id = kwargs.get("session_id")
     if session_id:
+        attributes.update(_correlation_attributes(tracer, session_id, kwargs))
         attributes.update(_session_sender_attributes(tracer, session_id))
         summary = tracer.sessions.get_or_create(session_id).turn_summary
         summary.add_tool(tool_name)
@@ -540,6 +601,7 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
     # Summary roll-up
     session_id = kwargs.get("session_id")
     if session_id:
+        attributes.update(_correlation_attributes(tracer, session_id, kwargs))
         attributes.update(_session_sender_attributes(tracer, session_id))
         summary = tracer.sessions.get_or_create(session_id).turn_summary
         summary.add_outcome(outcome)
@@ -601,6 +663,7 @@ def on_pre_llm_call(
         "llm.model_name": model,
         "llm.provider": platform,
     }
+    attributes.update(_correlation_attributes(tracer, session_id, kwargs))
 
     if tracer.config.capture_sender_id:
         sender_id = truncate_string(kwargs.get("sender_id"), 200)
@@ -684,6 +747,7 @@ def on_post_llm_call(
         "session.id": truncate_string(session_id, 200),
         "session_id": truncate_string(session_id, 200),
     }
+    attributes.update(_correlation_attributes(tracer, session_id, kwargs))
     preview = _preview(assistant_response, 500)
     if preview is not None:
         attributes["output.value"] = preview
@@ -737,6 +801,7 @@ def on_pre_api_request(
         "llm.request.message_count": message_count,
         "llm.request.approx_input_tokens": approx_input_tokens,
     }
+    attributes.update(_correlation_attributes(tracer, session_id, kwargs))
     if max_tokens:
         attributes["llm.request.max_tokens"] = max_tokens
 
@@ -796,6 +861,7 @@ def on_post_api_request(
 
     # Build final attributes
     attributes: Dict[str, Any] = {}
+    attributes.update(_correlation_attributes(tracer, session_id, kwargs))
 
     # Token usage — dual convention (gen_ai.usage.* + llm.token_count.*).
     # See _usage_attributes for the full attribute list.

--- a/hooks.py
+++ b/hooks.py
@@ -279,10 +279,11 @@ def _correlation_attributes(tracer, session_id: Optional[str], extra_kwargs: dic
 
     incoming = _extract_correlation_id(extra_kwargs)
     session_text = truncate_string(session_id, 200)
+    session_key = str(session_id) if session_id else ""
     correlation_id = incoming
 
-    if session_text:
-        ps = tracer.sessions.get_or_create(session_text)
+    if session_key:
+        ps = tracer.sessions.get_or_create(session_key)
         if incoming:
             ps.correlation_id = incoming
         elif ps.correlation_id:
@@ -293,7 +294,7 @@ def _correlation_attributes(tracer, session_id: Optional[str], extra_kwargs: dic
 
     if not correlation_id:
         return {}
-    return {"correlation.id": correlation_id}
+    return {"correlation.id": truncate_string(correlation_id, 200)}
 
 
 def _per_session_sender_attributes(ps: Any) -> Dict[str, str]:

--- a/session_state.py
+++ b/session_state.py
@@ -91,6 +91,7 @@ class PerSession:
     usage_updated: bool = False
     sender_id: str = ""
     user_id: str = ""
+    correlation_id: str = ""
     io: Dict[str, str] = field(default_factory=lambda: {"input": "", "output": ""})
     io_captured: bool = False
     turn_summary: TurnSummary = field(default_factory=TurnSummary)

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -78,8 +78,20 @@ class TestOnSessionStart:
         on_session_start(session_id="s1", model="gpt-4o", platform="telegram")
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
         assert attrs["session_id"] == "s1"
+        assert attrs["correlation.id"] == "s1"
         assert attrs["llm.model_name"] == "gpt-4o"
         assert attrs["llm.provider"] == "telegram"
+
+    def test_incoming_correlation_id_wins(self, mock_tracer):
+        on_session_start(
+            session_id="s1",
+            model="gpt-4o",
+            platform="telegram",
+            correlation_id="corr-123",
+        )
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert attrs["correlation.id"] == "corr-123"
+        assert mock_tracer.sessions.peek("s1").correlation_id == "corr-123"
 
     def test_includes_cron_job_id(self, mock_tracer):
         on_session_start(session_id="s1", model="gpt-4", platform="cli", job_id="j123")
@@ -253,6 +265,22 @@ class TestOnPreLlmCall:
         assert kw["name"] == "llm.gpt-4"
         assert kw["key"] == "llm:s1"
         assert kw["kind"] == "llm"
+        assert kw["attributes"]["correlation.id"] == "s1"
+
+    def test_reuses_session_correlation_id_on_child_span(self, mock_tracer):
+        mock_tracer.spans._active_spans["session:s1"] = MagicMock()
+        mock_tracer.sessions.get_or_create("s1").correlation_id = "corr-123"
+
+        on_pre_llm_call(
+            session_id="s1",
+            user_message="hello",
+            conversation_history=[],
+            is_first_turn=True,
+            model="gpt-4",
+            platform="cli",
+        )
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert attrs["correlation.id"] == "corr-123"
 
     def test_pushes_parent(self, mock_tracer):
         mock_tracer.spans._active_spans["session:s1"] = MagicMock()

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -282,6 +282,23 @@ class TestOnPreLlmCall:
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
         assert attrs["correlation.id"] == "corr-123"
 
+    def test_session_state_uses_full_session_id_for_correlation(self, mock_tracer):
+        long_session_id = "s" * 250
+        mock_tracer.spans._active_spans[f"session:{long_session_id}"] = MagicMock()
+
+        on_pre_llm_call(
+            session_id=long_session_id,
+            user_message="hello",
+            conversation_history=[],
+            is_first_turn=True,
+            model="gpt-4",
+            platform="cli",
+            correlation_id="corr-123",
+        )
+
+        assert mock_tracer.sessions.peek(long_session_id).correlation_id == "corr-123"
+        assert mock_tracer.sessions.peek(long_session_id[:200]) is None
+
     def test_pushes_parent(self, mock_tracer):
         mock_tracer.spans._active_spans["session:s1"] = MagicMock()
 


### PR DESCRIPTION
## Summary

Adds a stable `correlation.id` span attribute across Hermes OTel spans.

Resolution order:

1. Incoming hook kwarg correlation ID wins (`correlation_id`, `correlation.id`, `correlation-id`, `x_correlation_id`, `x-correlation-id`).
2. Existing per-session correlation ID is reused for child/later spans.
3. Falls back to `session_id` when no incoming correlation ID exists.

This keeps correlation dynamic per session and avoids static config tags that would give every trace the same correlation ID.

Fixes #10.

## Verification

- `uv run python -m pytest -q`
  - `409 passed, 3 skipped, 6 deselected`
- Local Tempo smoke test emitted trace `d423a7d5466323449cc157f617f29558` with both `agent` and `llm.smoke-model` spans carrying:
  - `correlation.id=corr-1779773094`
  - `session.id=smoke-session-1779773094`
