### PR TITLE
feat: allow disabling trace export per backend

### DIFF
--- a/backends.py
+++ b/backends.py
@@ -68,6 +68,7 @@ class _ResolvedBackend:
     endpoint: str
     display_name: str = "OTLP"
     headers: Optional[Dict[str, str]] = None
+    supports_traces: bool = True
     supports_metrics: bool = True
     supports_logs: bool = False
 
@@ -85,6 +86,14 @@ def _logs_for(backend_type: str, override: Optional[bool]) -> bool:
     if override is not None:
         return override
     return backend_type in _LOGS_CAPABLE
+
+
+def _traces_for(override: Optional[bool]) -> bool:
+    # Traces are the primary signal for every existing backend. ``False`` is
+    # opt-in for query-only/dashboard-only entries that should not receive span
+    # exports (for example, querying Tempo directly while exporting through an
+    # OTel Collector).
+    return True if override is None else override
 
 
 def _resolve_secret(
@@ -125,6 +134,7 @@ def _resolve_phoenix(bc: BackendConfig) -> _ResolvedBackend:
         endpoint=ep,
         display_name=_display(bc, "phoenix"),
         headers=extra or None,
+        supports_traces=_traces_for(bc.traces),
         supports_metrics=_metrics_for("phoenix", bc.metrics),
         supports_logs=_logs_for("phoenix", bc.logs),
     )
@@ -159,6 +169,7 @@ def _resolve_langfuse(bc: BackendConfig) -> _ResolvedBackend:
         endpoint=ep,
         display_name=_display(bc, "langfuse"),
         headers=headers,
+        supports_traces=_traces_for(bc.traces),
         supports_metrics=_metrics_for("langfuse", bc.metrics),
         supports_logs=_logs_for("langfuse", bc.logs),
     )
@@ -182,6 +193,7 @@ def _resolve_signoz(bc: BackendConfig) -> _ResolvedBackend:
         endpoint=ep,
         display_name=_display(bc, "signoz"),
         headers=headers or None,
+        supports_traces=_traces_for(bc.traces),
         supports_metrics=_metrics_for("signoz", bc.metrics),
         supports_logs=_logs_for("signoz", bc.logs),
     )
@@ -197,6 +209,7 @@ def _resolve_jaeger(bc: BackendConfig) -> _ResolvedBackend:
         endpoint=ep,
         display_name=_display(bc, "jaeger"),
         headers=extra or None,
+        supports_traces=_traces_for(bc.traces),
         supports_metrics=_metrics_for("jaeger", bc.metrics),
         supports_logs=_logs_for("jaeger", bc.logs),
     )
@@ -212,6 +225,7 @@ def _resolve_tempo(bc: BackendConfig) -> _ResolvedBackend:
         endpoint=ep,
         display_name=_display(bc, "tempo"),
         headers=extra or None,
+        supports_traces=_traces_for(bc.traces),
         supports_metrics=_metrics_for("tempo", bc.metrics),
         supports_logs=_logs_for("tempo", bc.logs),
     )
@@ -229,6 +243,7 @@ def _resolve_otlp(bc: BackendConfig) -> _ResolvedBackend:
         endpoint=ep,
         display_name=bc.name or "OTLP",
         headers=extra or None,
+        supports_traces=_traces_for(bc.traces),
         supports_metrics=_metrics_for("otlp", bc.metrics),
         supports_logs=_logs_for("otlp", bc.logs),
     )
@@ -254,6 +269,7 @@ def _resolve_lgtm(bc: BackendConfig) -> _ResolvedBackend:
         endpoint=ep,
         display_name=_display(bc, "lgtm"),
         headers=extra or None,
+        supports_traces=_traces_for(bc.traces),
         supports_metrics=_metrics_for("lgtm", bc.metrics),
         supports_logs=_logs_for("lgtm", bc.logs),
     )
@@ -284,6 +300,7 @@ def _resolve_uptrace(bc: BackendConfig) -> _ResolvedBackend:
         endpoint=ep,
         display_name=_display(bc, "uptrace"),
         headers=headers,
+        supports_traces=_traces_for(bc.traces),
         supports_metrics=_metrics_for("uptrace", bc.metrics),
         supports_logs=_logs_for("uptrace", bc.logs),
     )
@@ -325,6 +342,7 @@ def _resolve_openobserve(bc: BackendConfig) -> _ResolvedBackend:
         endpoint=ep,
         display_name=_display(bc, "openobserve"),
         headers=headers,
+        supports_traces=_traces_for(bc.traces),
         supports_metrics=_metrics_for("openobserve", bc.metrics),
         supports_logs=_logs_for("openobserve", bc.logs),
     )

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -147,7 +147,10 @@
 #                  Uses HTTP Basic auth — set `user:` + `password:` (or the
 #                  `*_env` variants) and the plugin builds the header for you.
 #
-# `metrics: true|false` per entry overrides the auto default if needed.
+# `traces: false`, `metrics: false`, or `logs: false` per entry opt a backend
+# out of that signal. This is useful when an entry is dashboard/query-only
+# (for example Tempo query URL) while trace export still goes through an OTel
+# Collector entry. `trace: false` is accepted as a friendly alias.
 #
 # When `backends:` is absent or empty, the plugin falls back to single-backend
 # env-var detection (LANGSMITH_TRACING, OTEL_LANGFUSE_*, OTEL_SIGNOZ_ENDPOINT,

--- a/plugin_config.py
+++ b/plugin_config.py
@@ -44,6 +44,7 @@ class BackendConfig:
     name: Optional[str] = None  # display name (defaults to type)
     endpoint: Optional[str] = None  # OTLP HTTP traces URL
     headers: Optional[Dict[str, str]] = None  # extra/override HTTP headers
+    traces: Optional[bool] = None  # None = on. False = dashboard/query-only, no trace export.
     metrics: Optional[bool] = None  # None = auto (off for langfuse/jaeger/tempo)
     logs: Optional[bool] = None  # None = auto (on for signoz/otlp/lgtm/uptrace/openobserve)
     # Langfuse credentials
@@ -207,13 +208,19 @@ def _coerce_backends(value: Any) -> Optional[Tuple[BackendConfig, ...]]:
             continue
         kwargs: Dict[str, Any] = {}
         for k, v in raw.items():
+            if k == "trace":
+                # Friendly alias for users who naturally mirror the singular
+                # signal name in prose. ``traces`` wins when both are present.
+                if "traces" in raw:
+                    continue
+                k = "traces"
             if k not in _BACKEND_ALLOWED_KEYS:
                 continue
             if k == "headers":
                 if isinstance(v, dict):
                     kwargs[k] = {str(kk): str(vv) for kk, vv in v.items()}
                 continue
-            if k in ("metrics", "logs"):
+            if k in ("traces", "metrics", "logs"):
                 if isinstance(v, bool):
                     kwargs[k] = v
                 elif isinstance(v, str):

--- a/tests/integration/test_multi_backend.py
+++ b/tests/integration/test_multi_backend.py
@@ -211,6 +211,42 @@ class TestConfigBackendsRouting:
         endpoints = [call.kwargs.get("endpoint") for call in mock_exp.call_args_list]
         assert endpoints == ["http://yaml-jaeger/v1/traces"]
 
+    def test_traces_false_backend_is_query_only_not_trace_export_target(self, monkeypatch):
+        """``traces: false`` keeps a dashboard backend out of trace export fan-out."""
+        _clear_backend_env(monkeypatch)
+        cfg = HermesOtelConfig(
+            backends=(
+                BackendConfig(
+                    type="otlp",
+                    name="collector",
+                    endpoint="http://collector:4318/v1/traces",
+                    metrics=True,
+                    logs=True,
+                ),
+                BackendConfig(
+                    type="tempo",
+                    name="tempo-query",
+                    endpoint="http://tempo:4318/v1/traces",
+                    traces=False,
+                    metrics=False,
+                    logs=False,
+                ),
+            ),
+        )
+        plugin = HermesOTelPlugin(config=cfg)
+        with (
+            patch("hermes_otel.tracer.OTLPSpanExporter") as mock_span_exp,
+            patch("hermes_otel.tracer.OTLPMetricExporter"),
+            patch("hermes_otel.tracer.trace.set_tracer_provider"),
+            patch("hermes_otel.tracer.metrics.set_meter_provider"),
+        ):
+            assert plugin.init() is True
+
+        span_endpoints = [call.kwargs.get("endpoint") for call in mock_span_exp.call_args_list]
+        assert span_endpoints == ["http://collector:4318/v1/traces"]
+        assert len(plugin._span_processors) == 1
+        assert len(plugin._metric_readers) == 1
+
     def test_invalid_backend_skipped_others_still_initialize(self, monkeypatch):
         """A bad entry (missing endpoint) is skipped; valid entries still initialize."""
         _clear_backend_env(monkeypatch)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -388,6 +388,34 @@ class TestBackendsYaml:
         assert b.name == "my-collector"
         assert b.headers == {"X-Auth": "secret", "X-Tenant": "acme"}
 
+    def test_loads_per_backend_traces_toggle(self, tmp_path):
+        if not _has_yaml():
+            pytest.skip("pyyaml not installed")
+        path = tmp_path / "config.yaml"
+        path.write_text(
+            "backends:\n"
+            "  - type: tempo\n"
+            "    endpoint: http://tempo:4318/v1/traces\n"
+            "    traces: false\n"
+        )
+        cfg = load_config(path=path)
+        assert cfg.backends is not None
+        assert cfg.backends[0].traces is False
+
+    def test_trace_alias_maps_to_traces_toggle(self, tmp_path):
+        if not _has_yaml():
+            pytest.skip("pyyaml not installed")
+        path = tmp_path / "config.yaml"
+        path.write_text(
+            "backends:\n"
+            "  - type: tempo\n"
+            "    endpoint: http://tempo:4318/v1/traces\n"
+            "    trace: false\n"
+        )
+        cfg = load_config(path=path)
+        assert cfg.backends is not None
+        assert cfg.backends[0].traces is False
+
     def test_skips_entry_without_type(self, tmp_path, caplog):
         if not _has_yaml():
             pytest.skip("pyyaml not installed")

--- a/tracer.py
+++ b/tracer.py
@@ -290,20 +290,21 @@ class HermesOTelPlugin:
 
             for b in backends:
                 hdrs = self._merge_headers(b.headers)
-                try:
-                    exporter = OTLPSpanExporter(endpoint=b.endpoint, headers=hdrs)
-                    processor = BatchSpanProcessor(
-                        exporter,
-                        max_queue_size=self.config.span_batch_max_queue_size,
-                        schedule_delay_millis=self.config.span_batch_schedule_delay_ms,
-                        max_export_batch_size=self.config.span_batch_max_export_batch_size,
-                        export_timeout_millis=self.config.span_batch_export_timeout_ms,
-                    )
-                    provider.add_span_processor(processor)
-                    self._span_processors.append(processor)
-                except Exception as e:
-                    logger.error(f"[hermes-otel] ✗ {b.display_name} traces init failed: {e}")
-                    continue
+                if b.supports_traces:
+                    try:
+                        exporter = OTLPSpanExporter(endpoint=b.endpoint, headers=hdrs)
+                        processor = BatchSpanProcessor(
+                            exporter,
+                            max_queue_size=self.config.span_batch_max_queue_size,
+                            schedule_delay_millis=self.config.span_batch_schedule_delay_ms,
+                            max_export_batch_size=self.config.span_batch_max_export_batch_size,
+                            export_timeout_millis=self.config.span_batch_export_timeout_ms,
+                        )
+                        provider.add_span_processor(processor)
+                        self._span_processors.append(processor)
+                    except Exception as e:
+                        logger.error(f"[hermes-otel] ✗ {b.display_name} traces init failed: {e}")
+                        continue
 
                 if b.supports_metrics and _METRICS_AVAILABLE:
                     metrics_endpoint = self._derive_metrics_endpoint(b.endpoint)
@@ -321,7 +322,8 @@ class HermesOTelPlugin:
                 self._backend_summaries.append(f"{b.display_name} → {b.endpoint}")
                 logger.info(
                     f"[hermes-otel] ✓ {b.display_name} at {b.endpoint}"
-                    + (" (traces only)" if not b.supports_metrics else "")
+                    + (" (query only)" if not b.supports_traces else "")
+                    + (" (traces only)" if b.supports_traces and not b.supports_metrics else "")
                 )
 
             if not self._span_processors:

--- a/website/docs/backends/multi-backend.md
+++ b/website/docs/backends/multi-backend.md
@@ -67,9 +67,37 @@ Each backend runs in **its own worker thread with its own bounded queue**:
 - If one backend is completely unreachable, the plugin logs the failed POST attempts and drops the oldest spans in that queue when the buffer fills. The others continue.
 - No backend's latency is on Hermes' hot path. `span.end()` is still a queue push.
 
-## Per-backend metrics override
+## Per-backend signal overrides
 
-By default, backends that don't accept OTLP metrics (`langfuse`, `jaeger`, `tempo`) get metrics-export auto-disabled. You can force the opposite with `metrics: true|false`:
+By default, every backend receives trace exports. Backends that don't accept
+OTLP metrics (`langfuse`, `jaeger`, `tempo`) get metrics-export
+auto-disabled, and logs export is enabled only for log-capable backends.
+Use `traces: true|false`, `metrics: true|false`, or `logs: true|false` to
+override a signal per backend:
+
+```yaml
+backends:
+  - type: otlp
+    name: collector
+    endpoint: http://collector:4318/v1/traces
+    metrics: true
+    logs: true
+
+  # Dashboard/query-only Tempo entry: visible to the OTel Traces tab, but it
+  # does not receive duplicate span exports because traces are disabled here.
+  - type: tempo
+    name: tempo-query
+    endpoint: http://tempo:3200
+    query_port: 3200
+    traces: false
+    metrics: false
+    logs: false
+```
+
+`trace: false` is accepted as a friendly alias for `traces: false`; use the
+plural spelling in new configs to match `metrics` and `logs`.
+
+Legacy metrics-only example:
 
 ```yaml
 backends:

--- a/website/docs/reference/config-schema.md
+++ b/website/docs/reference/config-schema.md
@@ -45,6 +45,7 @@ Shared fields (all optional unless noted):
 | `type` | string | **Required.** One of: `phoenix`, `langfuse`, `langsmith`, `signoz`, `jaeger`, `tempo`, `otlp`, `lgtm`, `uptrace`, `openobserve` |
 | `name` | string | Friendly name shown in logs (default: `type`) |
 | `endpoint` | string | Full OTLP endpoint URL (backend-specific defaults — see below) |
+| `traces` | bool | Override trace-export default (`true`). Set `false` for dashboard/query-only backends that should not receive span exports. `trace` is accepted as an alias. |
 | `metrics` | bool | Override metrics-export default for this backend |
 | `logs` | bool | Override logs-export default (on for `signoz`, `otlp`, `lgtm`, `uptrace`, `openobserve`; off elsewhere) |
 | `headers` | map | Per-backend HTTP headers (merged onto top-level `headers`) |


### PR DESCRIPTION
## Summary
- Add a per-backend `traces` toggle, plus `trace` as a friendly alias, to opt a backend out of span export.
- Preserve default trace export behavior for existing backends.
- Keep dashboard/query-only backends visible to the dashboard without adding an extra BatchSpanProcessor.
- Document per-signal backend overrides.

## Test plan
- `PYTHONPATH=/Users/agent/.hermes/plugins pytest -q`
- Live local dashboard smoke check: dashboard status selected a Tempo query backend while mocked export initialization only created one trace exporter for the collector backend.`