### PR TITLE
feat(config): apply per-category preview_max_chars truncation limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,12 @@ enabled: true
 sample_rate: 0.25               # ParentBased(TraceIdRatioBased) — null/omit = sample everything
 root_span_ttl_ms: 600000        # orphan-sweep threshold (10 min default)
 flush_interval_ms: 60000        # metrics export cadence
-preview_max_chars: 1200         # clip_preview truncation limit
+preview_max_chars: 1200         # global clip_preview truncation fallback
+# Per-category overrides (each defaults to preview_max_chars when unset)
+tool_input_preview_max_chars: 1200
+tool_output_preview_max_chars: 2000
+llm_input_preview_max_chars: 1200
+llm_output_preview_max_chars: 1200
 capture_previews: true          # false = suppress all input.value / output.value
 capture_sender_id: false        # true = add platform-prefixed user.id to spans
 project_name: hermes-prod       # supersedes OTEL_PROJECT_NAME
@@ -364,6 +369,10 @@ Every field can be overridden by env var with prefix `HERMES_OTEL_` (scalars onl
 | `root_span_ttl_ms` | `HERMES_OTEL_ROOT_SPAN_TTL_MS` |
 | `flush_interval_ms` | `HERMES_OTEL_FLUSH_INTERVAL_MS` |
 | `preview_max_chars` | `HERMES_OTEL_PREVIEW_MAX_CHARS` |
+| `tool_input_preview_max_chars` | `HERMES_OTEL_TOOL_INPUT_PREVIEW_MAX_CHARS` |
+| `tool_output_preview_max_chars` | `HERMES_OTEL_TOOL_OUTPUT_PREVIEW_MAX_CHARS` |
+| `llm_input_preview_max_chars` | `HERMES_OTEL_LLM_INPUT_PREVIEW_MAX_CHARS` |
+| `llm_output_preview_max_chars` | `HERMES_OTEL_LLM_OUTPUT_PREVIEW_MAX_CHARS` |
 | `capture_previews` | `HERMES_OTEL_CAPTURE_PREVIEWS` |
 | `capture_sender_id` | `HERMES_OTEL_CAPTURE_SENDER_ID` |
 | `project_name` | `HERMES_OTEL_PROJECT_NAME` |

--- a/hooks.py
+++ b/hooks.py
@@ -212,13 +212,12 @@ def _detect_session_kind(platform: str, kwargs: dict) -> str:
     return "session"
 
 
-def _preview(value: Any, max_len: int) -> Optional[str]:
+def _preview(value: Any, max_chars: int) -> Optional[str]:
     """Apply the configured preview policy: capture toggle + clip_preview."""
     tracer = get_tracer()
     if not tracer.config.capture_previews:
         return None
-    cap = min(max_len, tracer.config.preview_max_chars)
-    return clip_preview(value, cap)
+    return clip_preview(value, max_chars)
 
 
 def _sender_attributes(sender_id: str, platform: str) -> Dict[str, str]:
@@ -515,7 +514,10 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
     attributes: Dict[str, Any] = {
         "tool.name": tool_name,
     }
-    preview = _preview(json.dumps(args) if args else "{}", 500)
+    preview = _preview(
+        json.dumps(args) if args else "{}",
+        tracer.config.tool_input_preview_max_chars or tracer.config.preview_max_chars,
+    )
     if preview is not None:
         attributes["input.value"] = preview
 
@@ -597,7 +599,10 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
             attributes["error.message"] = error_msg
 
     # OpenInference output value — Phoenix shows this in Info
-    preview = _preview(result, 2000)
+    preview = _preview(
+        result,
+        tracer.config.tool_output_preview_max_chars or tracer.config.preview_max_chars,
+    )
     if preview is not None:
         attributes["output.value"] = preview
 
@@ -656,7 +661,13 @@ def on_pre_llm_call(
     if session_id:
         ps = tracer.sessions.get_or_create(session_id)
         if not ps.io_captured:
-            ps.io["input"] = _preview(user_message, 500) or ""
+            ps.io["input"] = (
+                _preview(
+                    user_message,
+                    tracer.config.llm_input_preview_max_chars or tracer.config.preview_max_chars,
+                )
+                or ""
+            )
             ps.io_captured = True
 
     # OpenInference attributes — Phoenix Info panel
@@ -692,11 +703,17 @@ def on_pre_llm_call(
             attributes["input.mime_type"] = "application/json"
             attributes["hermes.conversation.message_count"] = len(conversation_history)
         else:
-            preview = _preview(user_message, 500)
+            preview = _preview(
+                user_message,
+                tracer.config.llm_input_preview_max_chars or tracer.config.preview_max_chars,
+            )
             if preview is not None:
                 attributes["input.value"] = preview
     else:
-        preview = _preview(user_message, 500)
+        preview = _preview(
+            user_message,
+            tracer.config.llm_input_preview_max_chars or tracer.config.preview_max_chars,
+        )
         if preview is not None:
             attributes["input.value"] = preview
 
@@ -739,7 +756,13 @@ def on_post_llm_call(
     if session_id:
         ps = tracer.sessions.peek(session_id)
         if ps is not None and ps.io_captured:
-            ps.io["output"] = _preview(assistant_response, 500) or ""
+            ps.io["output"] = (
+                _preview(
+                    assistant_response,
+                    tracer.config.llm_output_preview_max_chars or tracer.config.preview_max_chars,
+                )
+                or ""
+            )
 
     tracer.record_metric(
         "message_count", 1, {"session_id": session_id, "model": model, "provider": platform}
@@ -751,7 +774,10 @@ def on_post_llm_call(
         "session_id": truncate_string(session_id, 200),
     }
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
-    preview = _preview(assistant_response, 500)
+    preview = _preview(
+        assistant_response,
+        tracer.config.llm_output_preview_max_chars or tracer.config.preview_max_chars,
+    )
     if preview is not None:
         attributes["output.value"] = preview
 

--- a/plugin_config.py
+++ b/plugin_config.py
@@ -75,8 +75,14 @@ class HermesOtelConfig:
     sample_rate: Optional[float] = None  # None = AlwaysOn. 0..1 = ratio.
     root_span_ttl_ms: int = 600_000  # 10 min orphan sweep threshold
     flush_interval_ms: int = 60_000  # metrics export interval
-    preview_max_chars: int = 1200  # clip_preview truncation
+    preview_max_chars: int = 1200  # global clip_preview truncation fallback
     capture_previews: bool = True  # global privacy kill switch
+    # Per-category overrides — when set, each takes precedence over preview_max_chars
+    # for its specific span type. None = fall back to preview_max_chars.
+    tool_input_preview_max_chars: Optional[int] = None
+    tool_output_preview_max_chars: Optional[int] = None
+    llm_input_preview_max_chars: Optional[int] = None
+    llm_output_preview_max_chars: Optional[int] = None
     headers: Optional[Dict[str, str]] = None  # extra OTLP headers (all backends)
     global_tags: Optional[Dict[str, Scalar]] = None
     resource_attributes: Optional[Dict[str, Scalar]] = None
@@ -276,6 +282,10 @@ def _coerce_from_yaml(key: str, value: Any) -> Any:
         "root_span_ttl_ms",
         "flush_interval_ms",
         "preview_max_chars",
+        "tool_input_preview_max_chars",
+        "tool_output_preview_max_chars",
+        "llm_input_preview_max_chars",
+        "llm_output_preview_max_chars",
         "span_batch_max_queue_size",
         "span_batch_schedule_delay_ms",
         "span_batch_max_export_batch_size",
@@ -319,6 +329,10 @@ def _load_env_overrides() -> Dict[str, Any]:
     take("root_span_ttl_ms", _parse_int)
     take("flush_interval_ms", _parse_int)
     take("preview_max_chars", _parse_int)
+    take("tool_input_preview_max_chars", _parse_int)
+    take("tool_output_preview_max_chars", _parse_int)
+    take("llm_input_preview_max_chars", _parse_int)
+    take("llm_output_preview_max_chars", _parse_int)
     take("capture_previews", _parse_bool)
     take("span_batch_max_queue_size", _parse_int)
     take("span_batch_schedule_delay_ms", _parse_int)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -18,6 +18,10 @@ _ENV_VARS = [
     "HERMES_OTEL_ROOT_SPAN_TTL_MS",
     "HERMES_OTEL_FLUSH_INTERVAL_MS",
     "HERMES_OTEL_PREVIEW_MAX_CHARS",
+    "HERMES_OTEL_TOOL_INPUT_PREVIEW_MAX_CHARS",
+    "HERMES_OTEL_TOOL_OUTPUT_PREVIEW_MAX_CHARS",
+    "HERMES_OTEL_LLM_INPUT_PREVIEW_MAX_CHARS",
+    "HERMES_OTEL_LLM_OUTPUT_PREVIEW_MAX_CHARS",
     "HERMES_OTEL_CAPTURE_PREVIEWS",
     "HERMES_OTEL_PROJECT_NAME",
     "HERMES_OTEL_SPAN_BATCH_MAX_QUEUE_SIZE",
@@ -44,6 +48,10 @@ class TestDefaults:
         assert cfg.root_span_ttl_ms == 600_000
         assert cfg.flush_interval_ms == 60_000
         assert cfg.preview_max_chars == 1200
+        assert cfg.tool_input_preview_max_chars is None
+        assert cfg.tool_output_preview_max_chars is None
+        assert cfg.llm_input_preview_max_chars is None
+        assert cfg.llm_output_preview_max_chars is None
         assert cfg.capture_previews is True
         assert cfg.headers is None
         assert cfg.global_tags is None
@@ -97,6 +105,26 @@ class TestEnvOverrides:
         monkeypatch.setenv("HERMES_OTEL_PREVIEW_MAX_CHARS", "500")
         cfg = load_config(path=tmp_path / "nonexistent.yaml")
         assert cfg.preview_max_chars == 500
+
+    def test_env_tool_input_preview_max_chars(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_OTEL_TOOL_INPUT_PREVIEW_MAX_CHARS", "800")
+        cfg = load_config(path=tmp_path / "nonexistent.yaml")
+        assert cfg.tool_input_preview_max_chars == 800
+
+    def test_env_tool_output_preview_max_chars(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_OTEL_TOOL_OUTPUT_PREVIEW_MAX_CHARS", "3000")
+        cfg = load_config(path=tmp_path / "nonexistent.yaml")
+        assert cfg.tool_output_preview_max_chars == 3000
+
+    def test_env_llm_input_preview_max_chars(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_OTEL_LLM_INPUT_PREVIEW_MAX_CHARS", "600")
+        cfg = load_config(path=tmp_path / "nonexistent.yaml")
+        assert cfg.llm_input_preview_max_chars == 600
+
+    def test_env_llm_output_preview_max_chars(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_OTEL_LLM_OUTPUT_PREVIEW_MAX_CHARS", "700")
+        cfg = load_config(path=tmp_path / "nonexistent.yaml")
+        assert cfg.llm_output_preview_max_chars == 700
 
     def test_env_project_name(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_OTEL_PROJECT_NAME", "my-project")
@@ -215,6 +243,24 @@ class TestYaml:
         assert cfg.sample_rate == 0.9
         # yaml-only field preserved when env doesn't override
         assert cfg.preview_max_chars == 400
+
+    def test_yaml_per_category_preview_caps(self, tmp_path):
+        if not _has_yaml():
+            pytest.skip("pyyaml not installed")
+        path = tmp_path / "config.yaml"
+        path.write_text(
+            "preview_max_chars: 1200\n"
+            "tool_input_preview_max_chars: 800\n"
+            "tool_output_preview_max_chars: 4000\n"
+            "llm_input_preview_max_chars: 600\n"
+            "llm_output_preview_max_chars: 600\n"
+        )
+        cfg = load_config(path=path)
+        assert cfg.preview_max_chars == 1200
+        assert cfg.tool_input_preview_max_chars == 800
+        assert cfg.tool_output_preview_max_chars == 4000
+        assert cfg.llm_input_preview_max_chars == 600
+        assert cfg.llm_output_preview_max_chars == 600
 
     def test_yaml_without_file_uses_defaults(self, tmp_path):
         cfg = load_config(path=tmp_path / "missing.yaml")

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -486,6 +486,79 @@ class TestOnPostLlmCall:
         disabled_tracer.end_span.assert_not_called()
 
 
+class TestPerCategoryPreviewCaps:
+    """preview_max_chars is the sole governor; per-category fields override it."""
+
+    def test_tool_input_cap_governs(self, mock_tracer):
+        from hermes_otel.plugin_config import HermesOtelConfig
+
+        mock_tracer.config = HermesOtelConfig(tool_input_preview_max_chars=10)
+        on_pre_tool_call(tool_name="bash", args={"cmd": "x" * 200}, task_id="t1")
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert len(attrs["input.value"]) <= 10
+
+    def test_tool_output_cap_governs(self, mock_tracer):
+        from hermes_otel.plugin_config import HermesOtelConfig
+
+        mock_tracer.config = HermesOtelConfig(tool_output_preview_max_chars=15)
+        mock_tracer.sessions.record_tool_start("bash:t1", 1000.0)
+        on_post_tool_call(tool_name="bash", args={}, result="y" * 200, task_id="t1")
+        attrs = mock_tracer.end_span.call_args[1]["attributes"]
+        assert len(attrs["output.value"]) <= 15
+
+    def test_llm_input_cap_governs(self, mock_tracer):
+        from hermes_otel.plugin_config import HermesOtelConfig
+
+        mock_tracer.config = HermesOtelConfig(llm_input_preview_max_chars=20)
+        on_pre_llm_call(
+            session_id="s1",
+            user_message="u" * 300,
+            conversation_history=[],
+            model="m",
+            platform="cli",
+            is_first_turn=True,
+        )
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert len(attrs["input.value"]) <= 20
+
+    def test_llm_output_cap_governs(self, mock_tracer):
+        from hermes_otel.plugin_config import HermesOtelConfig
+
+        mock_tracer.config = HermesOtelConfig(llm_output_preview_max_chars=12)
+        on_post_llm_call(
+            session_id="s1",
+            user_message="hi",
+            assistant_response="r" * 300,
+            conversation_history=[],
+            model="m",
+            platform="cli",
+        )
+        attrs = mock_tracer.end_span.call_args[1]["attributes"]
+        assert len(attrs["output.value"]) <= 12
+
+    def test_preview_max_chars_fallback_when_specific_unset(self, mock_tracer):
+        from hermes_otel.plugin_config import HermesOtelConfig
+
+        mock_tracer.config = HermesOtelConfig(preview_max_chars=25)
+        on_pre_tool_call(tool_name="bash", args={"cmd": "z" * 200}, task_id="t2")
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert len(attrs["input.value"]) <= 25
+
+    def test_specific_cap_exceeds_global(self, mock_tracer):
+        """A per-category cap larger than preview_max_chars is honored."""
+        from hermes_otel.plugin_config import HermesOtelConfig
+
+        mock_tracer.config = HermesOtelConfig(
+            preview_max_chars=50, tool_output_preview_max_chars=5000
+        )
+        mock_tracer.sessions.record_tool_start("bash:t3", 1000.0)
+        long_result = "w" * 200
+        on_post_tool_call(tool_name="bash", args={}, result=long_result, task_id="t3")
+        attrs = mock_tracer.end_span.call_args[1]["attributes"]
+        # Should be 200 (full), not clipped to 50
+        assert len(attrs["output.value"]) == 200
+
+
 class TestOnPreApiRequest:
     def test_creates_api_span(self, mock_tracer):
         on_pre_api_request(


### PR DESCRIPTION
Currently, tools and outputs are truncated. the clip_preview truncation limit is ignored in tool calls etc. 

This fixes it, and introduces configurable limit parameters that are respected. 