### PR TITLE
feat(hooks): add GenAI semantic convention attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,15 +460,17 @@ Turn 1:
 
 The plugin emits **dual-convention** attributes so both backends work:
 
-| Metric | Langfuse (gen_ai) | Phoenix (OpenInference) |
-|--------|-------------------|------------------------|
+| Metric | OpenTelemetry GenAI | Phoenix (OpenInference) |
+|--------|---------------------|------------------------|
 | Prompt tokens | `gen_ai.usage.input_tokens` | `llm.token_count.prompt` |
 | Completion tokens | `gen_ai.usage.output_tokens` | `llm.token_count.completion` |
-| Total tokens | — | `llm.token_count.total` |
-| Cache read | `gen_ai.usage.cache_read_input_tokens` | `llm.token_count.cache_read` |
-| Cache write | `gen_ai.usage.cache_creation_input_tokens` | `llm.token_count.cache_write` |
+| Total tokens | `gen_ai.usage.total_tokens` | `llm.token_count.total` |
+| Cache read | `gen_ai.usage.cache_read.input_tokens` (`gen_ai.usage.cache_read_input_tokens` also kept) | `llm.token_count.prompt_details.cache_read` |
+| Cache write | `gen_ai.usage.cache_creation.input_tokens` (`gen_ai.usage.cache_creation_input_tokens` also kept) | `llm.token_count.prompt_details.cache_write` |
 
-Langfuse uses `gen_ai.content.prompt` and `gen_ai.content.completion` for text. Phoenix uses `input.value` and `output.value`. Both are set on LLM spans.
+LLM and API spans also expose standard GenAI request/response metadata where Hermes provides it, including `gen_ai.provider.name`, `gen_ai.request.model`, request parameters such as `gen_ai.request.temperature`, and response fields such as `gen_ai.response.model` and `gen_ai.response.finish_reasons`.
+
+Phoenix uses `input.value` and `output.value` for previews. When full prompt/response capture is explicitly enabled, the plugin also writes the corresponding GenAI content attributes (`gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.system_instructions`).
 
 ## File structure
 

--- a/hooks.py
+++ b/hooks.py
@@ -165,9 +165,13 @@ def _usage_attributes(totals: Dict[str, int]) -> Dict[str, Any]:
     }
     if cache_read:
         attrs["llm.token_count.prompt_details.cache_read"] = cache_read
+        # Current OTel GenAI spelling, plus the pre-existing alias for
+        # backwards compatibility with dashboards created before this change.
+        attrs["gen_ai.usage.cache_read.input_tokens"] = cache_read
         attrs["gen_ai.usage.cache_read_input_tokens"] = cache_read
     if cache_write:
         attrs["llm.token_count.prompt_details.cache_write"] = cache_write
+        attrs["gen_ai.usage.cache_creation.input_tokens"] = cache_write
         attrs["gen_ai.usage.cache_creation_input_tokens"] = cache_write
     return attrs
 
@@ -235,6 +239,91 @@ def _session_sender_attributes(tracer, session_id: Optional[str]) -> Dict[str, s
         return {}
     ps = tracer.sessions.peek(session_id)
     return _per_session_sender_attributes(ps)
+
+
+def _gen_ai_attributes(
+    session_id: Optional[str],
+    operation_name: str,
+    extra_kwargs: Optional[dict] = None,
+) -> Dict[str, str]:
+    """Return common OpenTelemetry GenAI attributes."""
+    attrs: Dict[str, str] = {
+        "gen_ai.operation.name": operation_name,
+    }
+    session_text = truncate_string(session_id, 200)
+    if session_text:
+        attrs["gen_ai.conversation.id"] = session_text
+    return attrs
+
+
+def _provider_attributes(provider: Any) -> Dict[str, str]:
+    """Return current and compatibility provider attributes."""
+    value = truncate_string(provider, 120)
+    if not value:
+        return {}
+    return {
+        "gen_ai.provider.name": value,
+        # Kept for older OTel drafts and existing dashboards.
+        "gen_ai.system": value,
+    }
+
+
+def _optional_number(value: Any) -> Optional[float]:
+    if isinstance(value, bool) or value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _gen_ai_request_param_attributes(kwargs: dict) -> Dict[str, Any]:
+    """Best-effort standard GenAI request parameter attributes."""
+    attrs: Dict[str, Any] = {}
+    for src, dest in (
+        ("temperature", "gen_ai.request.temperature"),
+        ("top_p", "gen_ai.request.top_p"),
+        ("frequency_penalty", "gen_ai.request.frequency_penalty"),
+        ("presence_penalty", "gen_ai.request.presence_penalty"),
+    ):
+        value = _optional_number(kwargs.get(src))
+        if value is not None:
+            attrs[dest] = value
+
+    top_k = kwargs.get("top_k")
+    if top_k is not None and not isinstance(top_k, bool):
+        try:
+            attrs["gen_ai.request.top_k"] = int(top_k)
+        except (TypeError, ValueError):
+            pass
+
+    for key in ("stream", "streaming", "is_streaming"):
+        if key in kwargs:
+            attrs["gen_ai.request.stream"] = bool(kwargs[key])
+            break
+
+    reasoning = (
+        kwargs.get("reasoning_level") or kwargs.get("reasoning_effort") or kwargs.get("reasoning")
+    )
+    reasoning = truncate_string(reasoning, 120) if reasoning is not None else ""
+    if reasoning:
+        attrs["gen_ai.request.reasoning.level"] = reasoning
+
+    stop_sequences = kwargs.get("stop_sequences") or kwargs.get("stop")
+    if isinstance(stop_sequences, str):
+        attrs["gen_ai.request.stop_sequences"] = [stop_sequences]
+    elif isinstance(stop_sequences, (list, tuple)) and stop_sequences:
+        attrs["gen_ai.request.stop_sequences"] = [truncate_string(v, 200) for v in stop_sequences]
+
+    choice_count = kwargs.get("choice_count") or kwargs.get("n")
+    if choice_count is not None and not isinstance(choice_count, bool):
+        try:
+            n = int(choice_count)
+            if n != 1:
+                attrs["gen_ai.request.choice.count"] = n
+        except (TypeError, ValueError):
+            pass
+    return attrs
 
 
 def _extract_correlation_id(extra_kwargs: dict) -> str:
@@ -388,7 +477,10 @@ def _start_session_span(
         "hermes.session.kind": kind,
         "llm.model_name": truncate_string(model, 200),
         "llm.provider": truncate_string(platform, 120),
+        "gen_ai.request.model": truncate_string(model, 200),
     }
+    attributes.update(_provider_attributes(extra_kwargs.get("provider") or platform))
+    attributes.update(_gen_ai_attributes(session_id, "invoke_agent", extra_kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, extra_kwargs))
     if synthesized:
         attributes["hermes.session.synthesized"] = True
@@ -444,7 +536,10 @@ def on_session_end(
         "hermes.session.interrupted": bool(interrupted),
         "llm.model_name": truncate_string(model, 200),
         "llm.provider": truncate_string(platform, 120),
+        "gen_ai.response.model": truncate_string(model, 200),
     }
+    attributes.update(_provider_attributes(kwargs.get("provider") or platform))
+    attributes.update(_gen_ai_attributes(session_id, "invoke_agent", kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
 
     # Drain the aggregators in one shot. Everything this session buffered
@@ -513,6 +608,7 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
     # OpenInference attributes — Phoenix Info panel
     attributes: Dict[str, Any] = {
         "tool.name": tool_name,
+        "gen_ai.tool.name": tool_name,
     }
     preview = _preview(
         json.dumps(args) if args else "{}",
@@ -520,6 +616,14 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
     )
     if preview is not None:
         attributes["input.value"] = preview
+    if (
+        tracer.config.capture_previews
+        and tool_name.startswith("mcp_")
+        and tracer.config.capture_full_prompts
+    ):
+        serialized_args = _serialize_full(args)
+        if serialized_args is not None:
+            attributes["gen_ai.tool.call.arguments"] = serialized_args
 
     # Richer identity — hermes.tool.* (opt-in namespace)
     target, command = resolve_tool_identity(args)
@@ -539,6 +643,7 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
     # Summary roll-up (requires session_id to bucket into the right turn).
     session_id = kwargs.get("session_id")
     if session_id:
+        attributes.update(_gen_ai_attributes(session_id, "execute_tool", kwargs))
         attributes.update(_correlation_attributes(tracer, session_id, kwargs))
         attributes.update(_session_sender_attributes(tracer, session_id))
         summary = tracer.sessions.get_or_create(session_id).turn_summary
@@ -571,7 +676,11 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
     start_time = tracer.sessions.pop_tool_start(key)
     if start_time:
         duration_ms = (time.perf_counter() - start_time) * 1000
-        tracer.record_metric("tool_duration", duration_ms, {"tool_name": tool_name})
+        tracer.record_metric(
+            "tool_duration",
+            duration_ms,
+            {"tool_name": tool_name, "gen_ai.tool.name": tool_name},
+        )
 
     # Build final attributes — OpenInference conventions for Phoenix Info
     attributes: Dict[str, Any] = {}
@@ -605,10 +714,19 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
     )
     if preview is not None:
         attributes["output.value"] = preview
+    if (
+        tracer.config.capture_previews
+        and tool_name.startswith("mcp_")
+        and tracer.config.capture_full_responses
+    ):
+        serialized_result = _serialize_full(result_json if result_json else result)
+        if serialized_result is not None:
+            attributes["gen_ai.tool.call.result"] = serialized_result
 
     # Summary roll-up
     session_id = kwargs.get("session_id")
     if session_id:
+        attributes.update(_gen_ai_attributes(session_id, "execute_tool", kwargs))
         attributes.update(_correlation_attributes(tracer, session_id, kwargs))
         attributes.update(_session_sender_attributes(tracer, session_id))
         summary = tracer.sessions.get_or_create(session_id).turn_summary
@@ -676,7 +794,10 @@ def on_pre_llm_call(
         "session_id": truncate_string(session_id, 200),
         "llm.model_name": model,
         "llm.provider": platform,
+        "gen_ai.request.model": truncate_string(model, 200),
     }
+    attributes.update(_provider_attributes(platform))
+    attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
 
     if tracer.config.capture_sender_id:
@@ -772,7 +893,10 @@ def on_post_llm_call(
     attributes: Dict[str, Any] = {
         "session.id": truncate_string(session_id, 200),
         "session_id": truncate_string(session_id, 200),
+        "gen_ai.response.model": truncate_string(model, 200),
     }
+    attributes.update(_provider_attributes(platform))
+    attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
     preview = _preview(
         assistant_response,
@@ -829,10 +953,15 @@ def on_pre_api_request(
         "llm.api_mode": api_mode,
         "llm.request.message_count": message_count,
         "llm.request.approx_input_tokens": approx_input_tokens,
+        "gen_ai.request.model": truncate_string(model, 200),
     }
+    attributes.update(_provider_attributes(provider))
+    attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
+    attributes.update(_gen_ai_request_param_attributes(kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
     if max_tokens:
         attributes["llm.request.max_tokens"] = max_tokens
+        attributes["gen_ai.request.max_tokens"] = max_tokens
 
     attributes.update(_session_sender_attributes(tracer, session_id))
 
@@ -842,10 +971,12 @@ def on_pre_api_request(
         serialized = _serialize_full(messages)
         if serialized is not None:
             attributes["llm.input_messages"] = serialized
+            attributes["gen_ai.input.messages"] = serialized
             attributes["input.value"] = serialized
             attributes["input.mime_type"] = "application/json"
         if system_prompt:
             attributes["llm.system_prompt"] = str(system_prompt)
+            attributes["gen_ai.system_instructions"] = str(system_prompt)
 
     span = tracer.start_span(
         name=f"api.{model}",
@@ -890,6 +1021,14 @@ def on_post_api_request(
 
     # Build final attributes
     attributes: Dict[str, Any] = {}
+    attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
+    attributes.update(_provider_attributes(provider))
+    response_model_value = response_model or model
+    if response_model_value:
+        attributes["gen_ai.response.model"] = truncate_string(response_model_value, 200)
+    response_id = kwargs.get("response_id") or kwargs.get("id")
+    if response_id:
+        attributes["gen_ai.response.id"] = truncate_string(response_id, 200)
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
 
     # Token usage — dual convention (gen_ai.usage.* + llm.token_count.*).
@@ -925,6 +1064,7 @@ def on_post_api_request(
         attributes["llm.response.duration_ms"] = round(api_duration * 1000, 1)
     if finish_reason:
         attributes["llm.response.finish_reason"] = finish_reason
+        attributes["gen_ai.response.finish_reasons"] = [finish_reason]
     if assistant_content_chars:
         attributes["llm.response.output_chars"] = assistant_content_chars
     if assistant_tool_call_count:
@@ -934,13 +1074,19 @@ def on_post_api_request(
         response_content = kwargs.get("response_content")
         response_tool_calls = kwargs.get("response_tool_calls")
         if response_content:
-            attributes["llm.output.content"] = str(response_content)
-            attributes["output.value"] = str(response_content)
+            response_text = str(response_content)
+            attributes["llm.output.content"] = response_text
+            attributes["gen_ai.output.messages"] = json.dumps(
+                [{"role": "assistant", "content": response_text}],
+                ensure_ascii=False,
+            )
+            attributes["output.value"] = response_text
             attributes["output.mime_type"] = "text/plain"
         tool_calls_serialized = _serialize_full(response_tool_calls)
         if tool_calls_serialized is not None:
             attributes["llm.output.tool_calls"] = tool_calls_serialized
             if not response_content:
+                attributes["gen_ai.output.messages"] = tool_calls_serialized
                 attributes["output.value"] = tool_calls_serialized
                 attributes["output.mime_type"] = "application/json"
 

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -81,6 +81,11 @@ class TestOnSessionStart:
         assert attrs["correlation.id"] == "s1"
         assert attrs["llm.model_name"] == "gpt-4o"
         assert attrs["llm.provider"] == "telegram"
+        assert attrs["gen_ai.conversation.id"] == "s1"
+        assert attrs["gen_ai.operation.name"] == "invoke_agent"
+        assert attrs["gen_ai.request.model"] == "gpt-4o"
+        assert attrs["gen_ai.provider.name"] == "telegram"
+        assert attrs["gen_ai.system"] == "telegram"
 
     def test_incoming_correlation_id_wins(self, mock_tracer):
         on_session_start(
@@ -191,7 +196,24 @@ class TestOnPreToolCall:
         on_pre_tool_call(tool_name="bash", args={"cmd": "ls"}, task_id="t1")
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
         assert attrs["tool.name"] == "bash"
+        assert attrs["gen_ai.tool.name"] == "bash"
         assert '"cmd"' in attrs["input.value"]
+
+    def test_full_mcp_args_follow_preview_privacy_gate(self, mock_tracer):
+        from hermes_otel.plugin_config import HermesOtelConfig
+
+        mock_tracer.config = HermesOtelConfig(
+            capture_previews=False,
+            capture_full_prompts=True,
+        )
+        on_pre_tool_call(
+            tool_name="mcp_honeycomb_run_query",
+            args={"secret": "token"},
+            task_id="t1",
+        )
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert "input.value" not in attrs
+        assert "gen_ai.tool.call.arguments" not in attrs
 
     def test_records_start_time(self, mock_tracer):
         on_pre_tool_call(tool_name="bash", args={}, task_id="t1")
@@ -215,6 +237,24 @@ class TestOnPostToolCall:
         attrs = mock_tracer.end_span.call_args[1]["attributes"]
         assert attrs["output.value"] == "file.txt"
 
+    def test_full_mcp_result_follows_preview_privacy_gate(self, mock_tracer):
+        from hermes_otel.plugin_config import HermesOtelConfig
+
+        mock_tracer.config = HermesOtelConfig(
+            capture_previews=False,
+            capture_full_responses=True,
+        )
+        mock_tracer.sessions.record_tool_start("mcp_honeycomb_run_query:t1", 1000.0)
+        on_post_tool_call(
+            tool_name="mcp_honeycomb_run_query",
+            args={},
+            result='{"secret": "token"}',
+            task_id="t1",
+        )
+        attrs = mock_tracer.end_span.call_args[1]["attributes"]
+        assert "output.value" not in attrs
+        assert "gen_ai.tool.call.result" not in attrs
+
     def test_status_ok_on_success(self, mock_tracer):
         mock_tracer.sessions.record_tool_start("bash:t1", 1000.0)
         on_post_tool_call(tool_name="bash", args={}, result="ok", task_id="t1")
@@ -232,9 +272,10 @@ class TestOnPostToolCall:
         mock_tracer.sessions.record_tool_start("bash:t1", 1000.0)
         on_post_tool_call(tool_name="bash", args={}, result="ok", task_id="t1")
         mock_tracer.record_metric.assert_called_once()
-        name, value, attrs = mock_tracer.record_metric.call_args[0]
+        name, _value, attrs = mock_tracer.record_metric.call_args[0]
         assert name == "tool_duration"
         assert attrs["tool_name"] == "bash"
+        assert attrs["gen_ai.tool.name"] == "bash"
 
     def test_cleans_up_start_time(self, mock_tracer):
         mock_tracer.sessions.record_tool_start("bash:t1", 1000.0)
@@ -623,6 +664,38 @@ class TestOnPreApiRequest:
         assert attrs["llm.provider"] == "openai"
         assert attrs["llm.request.message_count"] == 10
         assert attrs["llm.request.max_tokens"] == 2048
+        assert attrs["gen_ai.conversation.id"] == "s1"
+        assert attrs["gen_ai.operation.name"] == "chat"
+        assert attrs["gen_ai.request.model"] == "gpt-4"
+        assert attrs["gen_ai.provider.name"] == "openai"
+        assert attrs["gen_ai.system"] == "openai"
+
+    def test_includes_standard_request_params(self, mock_tracer):
+        on_pre_api_request(
+            task_id="t1",
+            session_id="s1",
+            platform="cli",
+            model="gpt-4",
+            provider="openai",
+            base_url="",
+            api_mode="chat",
+            api_call_count=1,
+            message_count=10,
+            tool_count=0,
+            approx_input_tokens=500,
+            request_char_count=2000,
+            max_tokens=2048,
+            temperature=0.2,
+            top_p=0.9,
+            stream=True,
+            reasoning_effort="high",
+        )
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert attrs["gen_ai.request.max_tokens"] == 2048
+        assert attrs["gen_ai.request.temperature"] == 0.2
+        assert attrs["gen_ai.request.top_p"] == 0.9
+        assert attrs["gen_ai.request.stream"] is True
+        assert attrs["gen_ai.request.reasoning.level"] == "high"
 
     def test_includes_session_user_id_when_available(self, mock_tracer):
         ps = mock_tracer.sessions.get_or_create("s1")
@@ -710,6 +783,11 @@ class TestOnPostApiRequest:
         assert attrs["gen_ai.usage.input_tokens"] == 100
         assert attrs["gen_ai.usage.output_tokens"] == 50
         assert attrs["gen_ai.usage.total_tokens"] == 150
+        assert attrs["gen_ai.conversation.id"] == "s1"
+        assert attrs["gen_ai.operation.name"] == "chat"
+        assert attrs["gen_ai.response.model"] == "gpt-4"
+        assert attrs["gen_ai.provider.name"] == "openai"
+        assert attrs["gen_ai.system"] == "openai"
 
     def test_cache_token_attributes(self, mock_tracer):
         usage = {
@@ -722,8 +800,10 @@ class TestOnPostApiRequest:
         self._call_post_api(mock_tracer, usage=usage)
         attrs = mock_tracer.end_span.call_args[1]["attributes"]
         assert attrs["llm.token_count.prompt_details.cache_read"] == 30
+        assert attrs["gen_ai.usage.cache_read.input_tokens"] == 30
         assert attrs["gen_ai.usage.cache_read_input_tokens"] == 30
         assert attrs["llm.token_count.prompt_details.cache_write"] == 15
+        assert attrs["gen_ai.usage.cache_creation.input_tokens"] == 15
         assert attrs["gen_ai.usage.cache_creation_input_tokens"] == 15
 
     def test_session_usage_rollup(self, mock_tracer):
@@ -842,12 +922,14 @@ class TestFullCaptureFlags:
         on_pre_api_request(**self._pre_kwargs(messages=messages, system_prompt="the-system-prompt"))
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
         assert attrs["llm.system_prompt"] == "the-system-prompt"
+        assert attrs["gen_ai.system_instructions"] == "the-system-prompt"
         assert attrs["input.mime_type"] == "application/json"
         # Full, untruncated payload round-trips
         import json as _json
 
         parsed = _json.loads(attrs["llm.input_messages"])
         assert parsed == messages
+        assert _json.loads(attrs["gen_ai.input.messages"]) == messages
         assert len(attrs["input.value"]) > 5000
 
     def test_pre_handles_empty_messages(self, mock_tracer):
@@ -880,6 +962,7 @@ class TestFullCaptureFlags:
         )
         attrs = mock_tracer.end_span.call_args[1]["attributes"]
         assert attrs["llm.output.content"] == big_response
+        assert "gen_ai.output.messages" in attrs
         assert attrs["output.value"] == big_response
         assert attrs["output.mime_type"] == "text/plain"
 


### PR DESCRIPTION
Add standard OpenTelemetry GenAI span attributes, such as:
  - `gen_ai.provider.name`
  - `gen_ai.request.model`
  - `gen_ai.request.max_tokens`
  - `gen_ai.request.temperature`
  - `gen_ai.request.top_p`
  - `gen_ai.request.stream`
  - `gen_ai.request.reasoning.level`
  - `gen_ai.response.model`
  - `gen_ai.response.finish_reasons`
  - `gen_ai.response.id`

Also add current dotted cache-token usage attributes while preserving existing aliases:
  - `gen_ai.usage.cache_read.input_tokens`
  - `gen_ai.usage.cache_creation.input_tokens`

Keep privacy-sensitive content fields opt-in by mapping existing capture toggles to standard aliases:
  - `gen_ai.system_instructions`
  - `gen_ai.input.messages`
  - `gen_ai.output.messages`
  - `gen_ai.tool.call.arguments`
  - `gen_ai.tool.call.result`

OpenTelemetry GenAI semantic conventions are still in development and subject to change: https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/README.md

## Evidence

I have been running this version of Hermes' OTel plugin locally and verified these fields in Honeycomb traces.

<img width="1122" height="641" alt="image" src="https://github.com/user-attachments/assets/711df542-1d06-4da6-84dc-a4e74a52d2f8" />

<img width="1011" height="1006" alt="image" src="https://github.com/user-attachments/assets/70f0e23b-0651-4e04-b10c-cbacb755c9b5" />

## Local checks

- `uv run --extra dev pytest` — 427 passed, 3 skipped, 6 deselected
- `uv run --extra dev ruff check .` — passed
- `uv run --extra dev black --check .` — passed
