### PR TITLE
feat(backends): add first-class Honeycomb backend type

### DIFF
--- a/HONEYCOMB.md
+++ b/HONEYCOMB.md
@@ -1,0 +1,133 @@
+# Honeycomb support
+
+[Honeycomb](https://www.honeycomb.io/) is supported as a first-class OTLP/HTTP
+backend: **traces, metrics, and logs**. This page is the usage guide plus a note
+on what's intentionally deferred.
+
+> **Tested how:** the resolver is covered by unit tests
+> (`tests/unit/test_backends_honeycomb.py`, no network). Honeycomb is SaaS with
+> no free tier available to the maintainers, so live export has **not** been run
+> end-to-end against a real Honeycomb account by us — the trace path was
+> previously exercised via the generic `otlp` type during the GenAI-semconv work
+> (#17). If you have an account, confirmation in a real environment is very
+> welcome (see [#20](https://github.com/briancaffey/hermes-otel/issues/20)).
+
+---
+
+## Quick start
+
+Put your key in an env var and add a backend entry to the plugin's `config.yaml`:
+
+```bash
+export HONEYCOMB_API_KEY="hcaik_..."
+```
+
+```yaml
+backends:
+  - type: honeycomb
+    region: us                 # us (default) or eu
+    api_key_env: HONEYCOMB_API_KEY
+    # dataset: hermes          # optional — read "Datasets" below first
+```
+
+That's it. The plugin fills in the endpoint and the `x-honeycomb-team` auth
+header, and derives the per-signal paths automatically.
+
+Single-backend env-var mode also works with no `config.yaml`: set
+`HONEYCOMB_API_KEY` (US endpoint) and, optionally,
+`OTEL_HONEYCOMB_ENDPOINT` to override the URL (e.g. the EU host).
+
+> Honeycomb is **export-only** in the bundled dashboard — see
+> [Deferred](#deferred--known-limitations). Point `query_backend` at a local
+> backend (Phoenix/Tempo) and explore Honeycomb data in Honeycomb's own UI.
+
+---
+
+## Configuration reference
+
+| Field | Meaning |
+|-------|---------|
+| `region` | `us` (default) → `https://api.honeycomb.io`, `eu` → `https://api.eu1.honeycomb.io`. Ignored if `endpoint` is set. |
+| `api_key` / `api_key_env` | Honeycomb ingest key → `x-honeycomb-team` header. Prefer `api_key_env`. Falls back to `HONEYCOMB_API_KEY` / `OTEL_HONEYCOMB_API_KEY`. |
+| `dataset` | Optional → `x-honeycomb-dataset` header. See "Datasets". |
+| `endpoint` | Optional full `/v1/traces` URL; overrides `region`. Also via `OTEL_HONEYCOMB_ENDPOINT`. |
+| `metrics` / `logs` / `traces` | Per-signal toggles. All default on for Honeycomb. |
+| `headers` | Extra headers, merged on top of the generated ones. |
+
+The plugin uses **OTLP/HTTP** (not gRPC). Metrics and logs endpoints are derived
+from the traces endpoint by rewriting the `/v1/traces` suffix to `/v1/metrics`
+and `/v1/logs` (`_derive_metrics_endpoint` in `tracer.py`,
+`_derive_logs_endpoint` in `log_handler.py`) — which matches Honeycomb's
+per-signal path scheme.
+
+---
+
+## Datasets (read this before enabling metrics)
+
+Honeycomb routes data into *datasets*, and the rules differ by signal and key
+type:
+
+- **Traces, modern "Environments" key** — dataset is derived server-side from
+  the `service.name` resource attribute. **No `dataset` needed.**
+- **Metrics** — a dataset is effectively **required**. Without one, metrics land
+  in a dataset literally named `unknown_metrics`.
+- **Logs** — routed by the dataset header too.
+- **Honeycomb Classic keys** (legacy 32-char) — `dataset` is **required for
+  every signal**, including traces.
+
+**Important trade-off:** the plugin applies one merged header set to the trace,
+metric, and log exporters, so setting `dataset` tags **all three signals** into
+that dataset. For a modern key that means traces stop being split by
+`service.name` and get forced into `dataset` too. So:
+
+- Want traces split by service **and** metrics that don't go to
+  `unknown_metrics`? You currently can't have both on one Honeycomb entry —
+  either omit `dataset` (clean traces, `unknown_metrics` metrics) or set it
+  (everything in one dataset). A per-signal `metrics_dataset` is a possible
+  follow-up; see [#20](https://github.com/briancaffey/hermes-otel/issues/20).
+- On a **Classic** key, just set `dataset` — it's required anyway.
+
+---
+
+## Multiple backends
+
+Honeycomb runs happily alongside a local backend — each gets its own batch
+processor and worker thread, so they export in parallel and a slow one can't
+block the others. A common setup is local Phoenix for the bundled dashboard plus
+Honeycomb for durable storage:
+
+```yaml
+query_backend: phoenix
+backends:
+  - type: phoenix
+    endpoint: http://localhost:6006/v1/traces
+  - type: honeycomb
+    region: us
+    api_key_env: HONEYCOMB_API_KEY
+```
+
+---
+
+## Deferred / known limitations
+
+- **No dashboard query adapter (export-only).** The bundled dashboard queries a
+  backend to render traces (e.g. Phoenix via GraphQL). Honeycomb's
+  [Query Data API](https://api-docs.honeycomb.io/api/query-data) is
+  Enterprise-plan gated, asynchronous (create query → run → poll), oriented
+  toward aggregated results rather than fetching raw spans by trace ID, and
+  bounded to a 7-day window. That's a poor fit for the dashboard's needs, so
+  there is no `dashboard/backends/honeycomb.py`. Use a local backend for
+  `query_backend` and Honeycomb's UI for exploration.
+- **No automated live verification.** No free tier → verification is unit tests
+  + manual confirmation in the Honeycomb UI. `scripts/verify_multi_backend.py`
+  does not query Honeycomb.
+- **Single dataset across signals** — see "Datasets" above.
+
+---
+
+## Sources
+
+- [Send Data to Honeycomb with OpenTelemetry — Honeycomb Docs](https://docs.honeycomb.io/send-data/opentelemetry)
+- [Query Data API — Honeycomb API](https://api-docs.honeycomb.io/api/query-data)
+- [Announcing GA of the Honeycomb Query Data API](https://www.honeycomb.io/blog/query-data-api-generally-available)
+- [OTLP Exporter Configuration — OpenTelemetry](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/)

--- a/HONEYCOMB.md
+++ b/HONEYCOMB.md
@@ -4,13 +4,14 @@
 backend: **traces, metrics, and logs**. This page is the usage guide plus a note
 on what's intentionally deferred.
 
-> **Tested how:** the resolver is covered by unit tests
-> (`tests/unit/test_backends_honeycomb.py`, no network). Honeycomb is SaaS with
-> no free tier available to the maintainers, so live export has **not** been run
-> end-to-end against a real Honeycomb account by us — the trace path was
-> previously exercised via the generic `otlp` type during the GenAI-semconv work
-> (#17). If you have an account, confirmation in a real environment is very
-> welcome (see [#20](https://github.com/briancaffey/hermes-otel/issues/20)).
+> **Tested:** verified end-to-end against a real Honeycomb free-tier account
+> (US, a modern "Environments" key). A real `hermes` turn fanned spans out to
+> Honeycomb alongside Phoenix; traces, metrics, and logs all registered, the
+> OTLP export returned success, and Honeycomb auto-created the datasets. The
+> resolver is also covered by unit tests (`tests/unit/test_backends_honeycomb.py`,
+> no network). See [Verified behavior](#verified-behavior) for the routing
+> details, which differ from older docs. (See
+> [#20](https://github.com/briancaffey/hermes-otel/issues/20).)
 
 ---
 
@@ -67,25 +68,28 @@ per-signal path scheme.
 Honeycomb routes data into *datasets*, and the rules differ by signal and key
 type:
 
-- **Traces, modern "Environments" key** — dataset is derived server-side from
-  the `service.name` resource attribute. **No `dataset` needed.**
-- **Metrics** — a dataset is effectively **required**. Without one, metrics land
-  in a dataset literally named `unknown_metrics`.
-- **Logs** — routed by the dataset header too.
-- **Honeycomb Classic keys** (legacy 32-char) — `dataset` is **required for
-  every signal**, including traces.
+**Modern "Environments" keys (what most accounts use today):**
 
-**Important trade-off:** the plugin applies one merged header set to the trace,
-metric, and log exporters, so setting `dataset` tags **all three signals** into
-that dataset. For a modern key that means traces stop being split by
-`service.name` and get forced into `dataset` too. So:
+- **Traces** route by the `service.name` resource attribute → a dataset of that
+  name is auto-created. The `x-honeycomb-dataset` header is **ignored**.
+- **Metrics** route to the environment's default metrics dataset (named
+  `Metrics`). The header is **ignored** here too.
+- **Logs** are ingested as events.
+- ⇒ With a modern key, **`dataset` has no observable effect** — you can leave it
+  unset. Control your trace dataset name via `service.name` (the plugin sets it
+  from the OTel resource / project name). This was confirmed by live testing
+  (see [Verified behavior](#verified-behavior)).
 
-- Want traces split by service **and** metrics that don't go to
-  `unknown_metrics`? You currently can't have both on one Honeycomb entry —
-  either omit `dataset` (clean traces, `unknown_metrics` metrics) or set it
-  (everything in one dataset). A per-signal `metrics_dataset` is a possible
-  follow-up; see [#20](https://github.com/briancaffey/hermes-otel/issues/20).
-- On a **Classic** key, just set `dataset` — it's required anyway.
+**Honeycomb Classic keys (legacy 32-char):**
+
+- `x-honeycomb-dataset` is honored and **required for every signal**. Set
+  `dataset` so data isn't rejected / mis-routed.
+
+Because the plugin applies one merged header set to the trace, metric, and log
+exporters, a `dataset` you set is sent on all three. That's correct for Classic
+keys; for modern keys it's simply ignored. If a future use case needs distinct
+per-signal datasets on Classic keys, a `metrics_dataset` field could be added —
+see [#20](https://github.com/briancaffey/hermes-otel/issues/20).
 
 ---
 
@@ -108,6 +112,28 @@ backends:
 
 ---
 
+## Verified behavior
+
+Confirmed against a real Honeycomb free-tier account (US region, modern
+Environments key) by running a real `hermes` turn with Honeycomb configured
+alongside Phoenix:
+
+- **Startup:** `✓ Honeycomb at https://api.honeycomb.io/v1/traces`, logs and
+  metrics fan-out both reported Honeycomb as a target (Phoenix was traces-only).
+- **Export:** a span pushed through the plugin's resolved exporter returned
+  `SpanExportResult.SUCCESS`; the full `hermes` turn produced no export errors.
+- **Ingestion:** Honeycomb auto-created datasets — a **trace** dataset named
+  after `service.name` (`hermes-agent`, ~16 columns from the gen_ai/`llm.*`
+  attributes) and a default **`Metrics`** dataset. The `x-honeycomb-dataset`
+  header set in config did **not** override either, confirming it's ignored for
+  modern keys.
+- **Couldn't verify:** individual column names / span contents — the test key's
+  scope was `events + createDatasets + markers` but **not** `columns` or
+  `queries`, so the management API can't enumerate columns or run queries. The
+  dataset column counts are strong evidence the attributes landed; full
+  attribute-level confirmation needs a key with `columns`/`queries` access or a
+  look in the Honeycomb UI.
+
 ## Deferred / known limitations
 
 - **No dashboard query adapter (export-only).** The bundled dashboard queries a
@@ -118,10 +144,12 @@ backends:
   bounded to a 7-day window. That's a poor fit for the dashboard's needs, so
   there is no `dashboard/backends/honeycomb.py`. Use a local backend for
   `query_backend` and Honeycomb's UI for exploration.
-- **No automated live verification.** No free tier → verification is unit tests
-  + manual confirmation in the Honeycomb UI. `scripts/verify_multi_backend.py`
-  does not query Honeycomb.
-- **Single dataset across signals** — see "Datasets" above.
+- **No automated live verification in CI.** Live ingestion was confirmed
+  manually (see [Verified behavior](#verified-behavior)); CI relies on the
+  no-network unit tests. `scripts/verify_multi_backend.py` does not query
+  Honeycomb.
+- **Dataset header ignored on modern keys** — see "Datasets" above. Control the
+  trace dataset via `service.name`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Tested with:
 - **[Grafana LGTM](https://github.com/grafana/docker-otel-lgtm)** (local) — traces + metrics + logs
 - **[Uptrace](https://uptrace.dev)** (self-hosted) — traces + metrics + logs
 - **[OpenObserve](https://openobserve.ai)** (self-hosted) — traces + metrics + logs
+- **[Honeycomb](https://www.honeycomb.io/)** (cloud) — traces + metrics + logs — see [HONEYCOMB.md](HONEYCOMB.md)
 
 Any OTLP HTTP endpoint should work.
 
@@ -311,6 +312,17 @@ docker compose up -d
 
 Tempo is **traces-only** — the plugin skips metric export when this backend is selected. The upstream example already bundles Prometheus + Grafana, so token/tool/cost metrics can be routed there via a separate Prometheus remote-write or OTel collector if needed.
 
+### Honeycomb
+```bash
+export HONEYCOMB_API_KEY="hcaik_..."          # x-honeycomb-team header
+# Optional — defaults to the US ingest endpoint:
+# export OTEL_HONEYCOMB_ENDPOINT="https://api.eu1.honeycomb.io/v1/traces"   # EU
+export OTEL_PROJECT_NAME=hermes-otel-honeycomb
+```
+
+For region selection (`us`/`eu`), a dataset, and the metrics `unknown_metrics`
+gotcha, use the multi-backend `config.yaml` form instead — see [HONEYCOMB.md](HONEYCOMB.md).
+
 ### Optional
 ```bash
 export OTEL_PROJECT_NAME="hermes-agent"   # Shown in Phoenix
@@ -327,7 +339,7 @@ export HERMES_OTEL_DEBUG=true
 
 Debug output is written to `~/.hermes/plugins/hermes_otel/debug.log` and does not clutter hermes stdout.
 
-**Priority order:** LangSmith (if `LANGSMITH_TRACING=true`) > Langfuse (if credentials set) > SigNoz (`OTEL_SIGNOZ_ENDPOINT`) > Jaeger (`OTEL_JAEGER_ENDPOINT`) > Tempo (`OTEL_TEMPO_ENDPOINT`) > Phoenix (`OTEL_PHOENIX_ENDPOINT`).
+**Priority order:** LangSmith (if `LANGSMITH_TRACING=true`) > Langfuse (if credentials set) > SigNoz (`OTEL_SIGNOZ_ENDPOINT`) > Uptrace (`OTEL_UPTRACE_ENDPOINT` + DSN) > OpenObserve (`OTEL_OPENOBSERVE_ENDPOINT` + creds) > Honeycomb (`HONEYCOMB_API_KEY`) > Jaeger (`OTEL_JAEGER_ENDPOINT`) > Tempo (`OTEL_TEMPO_ENDPOINT`) > Phoenix (`OTEL_PHOENIX_ENDPOINT`).
 
 ### Shaping knobs — `config.yaml` and `HERMES_OTEL_*` env vars
 

--- a/backends.py
+++ b/backends.py
@@ -34,7 +34,7 @@ _TRACES_ONLY = {"langfuse", "jaeger", "tempo"}
 # to "logs off" — Phoenix/Langfuse/Jaeger/Tempo don't implement /v1/logs, and
 # we'd rather drop logs on the floor than spray 4xx errors at them. Users
 # can override per-backend via the ``logs:`` field in config.yaml.
-_LOGS_CAPABLE = {"signoz", "otlp", "lgtm", "uptrace", "openobserve"}
+_LOGS_CAPABLE = {"signoz", "otlp", "lgtm", "uptrace", "openobserve", "honeycomb"}
 
 # Display names used in logs. Preferred over ``type.capitalize()`` because
 # some backends use camelCase ("SigNoz") that simple title-case gets wrong.
@@ -48,11 +48,29 @@ _DISPLAY_NAMES = {
     "lgtm": "LGTM",
     "uptrace": "Uptrace",
     "openobserve": "OpenObserve",
+    "honeycomb": "Honeycomb",
+}
+
+# Honeycomb OTLP/HTTP base endpoints by region (the SDK-style ``/v1/traces``
+# suffix is appended by the resolver; ``tracer.py`` / ``log_handler.py`` derive
+# the ``/v1/metrics`` and ``/v1/logs`` variants from it).
+_HONEYCOMB_ENDPOINTS = {
+    "us": "https://api.honeycomb.io",
+    "eu": "https://api.eu1.honeycomb.io",
 }
 
 # Priority for env-var-driven single-backend detection. First backend whose
 # required env vars are fully set wins.
-_ENV_PRIORITY = ["langfuse", "signoz", "uptrace", "openobserve", "jaeger", "tempo", "phoenix"]
+_ENV_PRIORITY = [
+    "langfuse",
+    "signoz",
+    "uptrace",
+    "openobserve",
+    "honeycomb",
+    "jaeger",
+    "tempo",
+    "phoenix",
+]
 
 
 @dataclass
@@ -348,6 +366,59 @@ def _resolve_openobserve(bc: BackendConfig) -> _ResolvedBackend:
     )
 
 
+def _resolve_honeycomb(bc: BackendConfig) -> _ResolvedBackend:
+    """Resolve Honeycomb (SaaS, OTLP/HTTP — traces + metrics + logs).
+
+    Auth model: the API key travels in the ``x-honeycomb-team`` header. An
+    optional ``dataset`` is sent as ``x-honeycomb-dataset``; ``region``
+    (``us``|``eu``) selects the base endpoint when one isn't given explicitly.
+
+    Endpoint: defaults to the US ingest host (or EU for ``region: eu``) with the
+    ``/v1/traces`` suffix the OTLP pipeline expects. ``tracer.py`` and
+    ``log_handler.py`` rewrite that suffix to ``/v1/metrics`` and ``/v1/logs``,
+    which matches Honeycomb's per-signal path scheme exactly.
+
+    Dataset routing nuance: a single merged header set feeds the trace, metric,
+    and log exporters (see ``tracer.py``), so setting ``dataset`` tags **all**
+    signals into that dataset. For modern "Environments" keys, traces are
+    normally routed by ``service.name`` and need no dataset; metrics, however,
+    require one or they land in a dataset named ``unknown_metrics``. Pick the
+    dataset with that trade-off in mind (see ``HONEYCOMB.md``).
+    """
+    key = _resolve_secret(
+        bc.api_key,
+        bc.api_key_env,
+        ["OTEL_HONEYCOMB_API_KEY", "HONEYCOMB_API_KEY"],
+    )
+    if not key:
+        raise ValueError("honeycomb requires api_key (or set HONEYCOMB_API_KEY)")
+
+    ep = (bc.endpoint or os.getenv("OTEL_HONEYCOMB_ENDPOINT", "")).strip()
+    if not ep:
+        region = (bc.region or "us").strip().lower()
+        base = _HONEYCOMB_ENDPOINTS.get(region)
+        if base is None:
+            raise ValueError(
+                f"honeycomb region must be one of {sorted(_HONEYCOMB_ENDPOINTS)}, got {bc.region!r}"
+            )
+        ep = f"{base}/v1/traces"
+
+    headers: Dict[str, str] = {"x-honeycomb-team": key}
+    dataset = (bc.dataset or "").strip()
+    if dataset:
+        headers["x-honeycomb-dataset"] = dataset
+    headers.update(bc.headers or {})
+    return _ResolvedBackend(
+        type="honeycomb",
+        endpoint=ep,
+        display_name=_display(bc, "honeycomb"),
+        headers=headers,
+        supports_traces=_traces_for(bc.traces),
+        supports_metrics=_metrics_for("honeycomb", bc.metrics),
+        supports_logs=_logs_for("honeycomb", bc.logs),
+    )
+
+
 _RESOLVERS: Dict[str, Callable[[BackendConfig], _ResolvedBackend]] = {
     "phoenix": _resolve_phoenix,
     "langfuse": _resolve_langfuse,
@@ -358,6 +429,7 @@ _RESOLVERS: Dict[str, Callable[[BackendConfig], _ResolvedBackend]] = {
     "lgtm": _resolve_lgtm,
     "uptrace": _resolve_uptrace,
     "openobserve": _resolve_openobserve,
+    "honeycomb": _resolve_honeycomb,
 }
 
 

--- a/backends.py
+++ b/backends.py
@@ -378,12 +378,13 @@ def _resolve_honeycomb(bc: BackendConfig) -> _ResolvedBackend:
     ``log_handler.py`` rewrite that suffix to ``/v1/metrics`` and ``/v1/logs``,
     which matches Honeycomb's per-signal path scheme exactly.
 
-    Dataset routing nuance: a single merged header set feeds the trace, metric,
-    and log exporters (see ``tracer.py``), so setting ``dataset`` tags **all**
-    signals into that dataset. For modern "Environments" keys, traces are
-    normally routed by ``service.name`` and need no dataset; metrics, however,
-    require one or they land in a dataset named ``unknown_metrics``. Pick the
-    dataset with that trade-off in mind (see ``HONEYCOMB.md``).
+    Dataset routing: ``x-honeycomb-dataset`` is honored only by Honeycomb
+    Classic keys (where it's required for every signal). Modern "Environments"
+    keys ignore it — traces route by ``service.name`` and metrics go to the
+    environment's default ``Metrics`` dataset (verified live; see
+    ``HONEYCOMB.md``). The plugin sends ``dataset`` on all three exporters via
+    one merged header set, which is correct for Classic and a harmless no-op for
+    modern keys; leave ``dataset`` unset on a modern key.
     """
     key = _resolve_secret(
         bc.api_key,

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -146,6 +146,9 @@
 #   openobserve  — OpenObserve (OSS, single container). Traces + metrics + logs.
 #                  Uses HTTP Basic auth — set `user:` + `password:` (or the
 #                  `*_env` variants) and the plugin builds the header for you.
+#   honeycomb    — Honeycomb (SaaS). Traces + metrics + logs. Set `api_key`
+#                  (or `api_key_env`) and `region:` (us|eu); the plugin fills in
+#                  the endpoint and `x-honeycomb-team` header. See HONEYCOMB.md.
 #
 # `traces: false`, `metrics: false`, or `logs: false` per entry opt a backend
 # out of that signal. This is useful when an entry is dashboard/query-only
@@ -193,7 +196,7 @@
 #     headers:
 #       X-Tenant: acme
 #     metrics: true
-#     logs: true       # override the default (on for otlp/signoz/lgtm/uptrace/openobserve)
+#     logs: true       # override the default (on for otlp/signoz/lgtm/uptrace/openobserve/honeycomb)
 
 # ── LGTM quickstart ──────────────────────────────────────────────────────────
 #
@@ -236,6 +239,25 @@
 #     user: root@example.com                  # or user_env: OPENOBSERVE_USER
 #     password_env: OPENOBSERVE_PASSWORD
 #     # stream_name: default                  # optional; defaults to "default"
+# capture_logs: true
+
+# ── Honeycomb quickstart ─────────────────────────────────────────────────────
+#
+# Honeycomb (SaaS, OTLP/HTTP) — traces + metrics + logs. See HONEYCOMB.md.
+# Trace export also works via a plain `type: otlp` entry; the dedicated
+# `honeycomb` type just fills in the endpoint and auth header for you.
+#
+# backends:
+#   - type: honeycomb
+#     region: us                              # us (default) or eu
+#     api_key_env: HONEYCOMB_API_KEY          # or inline api_key: (discouraged)
+#     # Optional dataset (sent as x-honeycomb-dataset). Heads up: it routes
+#     # ALL signals into that dataset. Modern (Environments) keys route TRACES
+#     # by service.name and need no dataset — but METRICS require one, or they
+#     # land in a dataset named "unknown_metrics". Honeycomb Classic keys need
+#     # a dataset for every signal. See HONEYCOMB.md for the trade-off.
+#     # dataset: hermes
+#     # endpoint:                             # optional; overrides the region default
 # capture_logs: true
 
 # ── LangSmith (env-var only, alternative to the above) ────────────────────────

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -251,11 +251,10 @@
 #   - type: honeycomb
 #     region: us                              # us (default) or eu
 #     api_key_env: HONEYCOMB_API_KEY          # or inline api_key: (discouraged)
-#     # Optional dataset (sent as x-honeycomb-dataset). Heads up: it routes
-#     # ALL signals into that dataset. Modern (Environments) keys route TRACES
-#     # by service.name and need no dataset — but METRICS require one, or they
-#     # land in a dataset named "unknown_metrics". Honeycomb Classic keys need
-#     # a dataset for every signal. See HONEYCOMB.md for the trade-off.
+#     # Optional dataset (sent as x-honeycomb-dataset). Modern (Environments)
+#     # keys IGNORE it — traces route by service.name, metrics to a default
+#     # "Metrics" dataset (verified live). Only Honeycomb Classic keys need it
+#     # (required for every signal). See HONEYCOMB.md.
 #     # dataset: hermes
 #     # endpoint:                             # optional; overrides the region default
 # capture_logs: true

--- a/plugin_config.py
+++ b/plugin_config.py
@@ -40,7 +40,7 @@ class BackendConfig:
     discouraged because the file is plaintext.
     """
 
-    type: str  # phoenix | langfuse | signoz | jaeger | tempo | otlp
+    type: str  # phoenix | langfuse | signoz | jaeger | tempo | otlp | honeycomb
     name: Optional[str] = None  # display name (defaults to type)
     endpoint: Optional[str] = None  # OTLP HTTP traces URL
     headers: Optional[Dict[str, str]] = None  # extra/override HTTP headers
@@ -65,6 +65,13 @@ class BackendConfig:
     password: Optional[str] = None
     password_env: Optional[str] = None
     stream_name: Optional[str] = None
+    # Honeycomb: API key (sent as the ``x-honeycomb-team`` header), optional
+    # dataset (``x-honeycomb-dataset``), and ``region`` (``us``|``eu``) used to
+    # default the endpoint when one isn't given explicitly.
+    api_key: Optional[str] = None
+    api_key_env: Optional[str] = None
+    dataset: Optional[str] = None
+    region: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_backends_honeycomb.py
+++ b/tests/unit/test_backends_honeycomb.py
@@ -1,0 +1,113 @@
+"""Unit tests for the ``honeycomb`` backend resolver.
+
+No network: these assert the resolved endpoint, headers, and signal-support
+flags only. Honeycomb is SaaS with no free tier for the maintainers, so live
+export is verified manually in the Honeycomb UI rather than here.
+"""
+
+import pytest
+from hermes_otel import backends
+from hermes_otel.plugin_config import BackendConfig
+
+
+class TestHoneycombBackendType:
+    def test_resolves_with_inline_key_us_default(self):
+        rb = backends.resolve(BackendConfig(type="honeycomb", api_key="hcaik_test"))
+        assert rb.type == "honeycomb"
+        assert rb.display_name == "Honeycomb"
+        # US is the default region.
+        assert rb.endpoint == "https://api.honeycomb.io/v1/traces"
+        assert rb.headers["x-honeycomb-team"] == "hcaik_test"
+        # No dataset given → no dataset header.
+        assert "x-honeycomb-dataset" not in rb.headers
+        # Honeycomb ingests all three signals.
+        assert rb.supports_traces is True
+        assert rb.supports_metrics is True
+        assert rb.supports_logs is True
+
+    def test_eu_region_endpoint(self):
+        rb = backends.resolve(BackendConfig(type="honeycomb", api_key="k", region="eu"))
+        assert rb.endpoint == "https://api.eu1.honeycomb.io/v1/traces"
+
+    def test_region_is_case_insensitive(self):
+        rb = backends.resolve(BackendConfig(type="honeycomb", api_key="k", region="EU"))
+        assert rb.endpoint == "https://api.eu1.honeycomb.io/v1/traces"
+
+    def test_unknown_region_raises(self):
+        with pytest.raises(ValueError, match="region"):
+            backends.resolve(BackendConfig(type="honeycomb", api_key="k", region="moon"))
+
+    def test_dataset_sets_header(self):
+        rb = backends.resolve(BackendConfig(type="honeycomb", api_key="k", dataset="hermes"))
+        assert rb.headers["x-honeycomb-dataset"] == "hermes"
+
+    def test_explicit_endpoint_overrides_region(self):
+        rb = backends.resolve(
+            BackendConfig(
+                type="honeycomb",
+                api_key="k",
+                region="eu",
+                endpoint="https://proxy.internal/v1/traces",
+            )
+        )
+        # Explicit endpoint wins over the region default.
+        assert rb.endpoint == "https://proxy.internal/v1/traces"
+
+    def test_requires_api_key(self):
+        with pytest.raises(ValueError, match="api_key"):
+            backends.resolve(BackendConfig(type="honeycomb"))
+
+    def test_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("HONEYCOMB_API_KEY", "env_key")
+        rb = backends.resolve(BackendConfig(type="honeycomb"))
+        assert rb.headers["x-honeycomb-team"] == "env_key"
+
+    def test_named_api_key_env(self, monkeypatch):
+        monkeypatch.setenv("MY_HC_KEY", "named_env_key")
+        rb = backends.resolve(BackendConfig(type="honeycomb", api_key_env="MY_HC_KEY"))
+        assert rb.headers["x-honeycomb-team"] == "named_env_key"
+
+    def test_inline_key_beats_env(self, monkeypatch):
+        monkeypatch.setenv("HONEYCOMB_API_KEY", "env_key")
+        rb = backends.resolve(BackendConfig(type="honeycomb", api_key="inline"))
+        assert rb.headers["x-honeycomb-team"] == "inline"
+
+    def test_user_headers_merge_on_top(self):
+        rb = backends.resolve(
+            BackendConfig(
+                type="honeycomb",
+                api_key="k",
+                headers={"X-Extra": "1"},
+            )
+        )
+        assert rb.headers["X-Extra"] == "1"
+        assert rb.headers["x-honeycomb-team"] == "k"
+
+    def test_name_override(self):
+        rb = backends.resolve(BackendConfig(type="honeycomb", api_key="k", name="prod-hc"))
+        assert rb.display_name == "prod-hc"
+
+    def test_metrics_can_be_disabled(self):
+        rb = backends.resolve(BackendConfig(type="honeycomb", api_key="k", metrics=False))
+        assert rb.supports_metrics is False
+
+    def test_env_priority_picks_honeycomb(self, monkeypatch):
+        # With only HONEYCOMB_API_KEY set and no config.yaml, the env-driven
+        # single-backend path should resolve to honeycomb.
+        for var in (
+            "OTEL_PHOENIX_ENDPOINT",
+            "OTEL_SIGNOZ_ENDPOINT",
+            "OTEL_JAEGER_ENDPOINT",
+            "OTEL_TEMPO_ENDPOINT",
+            "OTEL_UPTRACE_ENDPOINT",
+            "OTEL_OPENOBSERVE_ENDPOINT",
+            "LANGFUSE_PUBLIC_KEY",
+            "LANGFUSE_SECRET_KEY",
+            "OTEL_LANGFUSE_PUBLIC_API_KEY",
+            "OTEL_LANGFUSE_SECRET_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("HONEYCOMB_API_KEY", "env_key")
+        rb = backends.resolve_from_env()
+        assert rb is not None
+        assert rb.type == "honeycomb"

--- a/website/docs/backends/honeycomb.md
+++ b/website/docs/backends/honeycomb.md
@@ -1,0 +1,139 @@
+---
+sidebar_position: 11
+title: "Honeycomb"
+description: "Honeycomb — cloud observability backend with a generous free tier, OTLP/HTTP-native for traces + metrics + logs."
+---
+
+# Honeycomb
+
+[Honeycomb](https://www.honeycomb.io/) is a cloud observability platform built for high-cardinality, event-based debugging. It's OTLP/HTTP-native, so hermes-otel exports straight to it with no collector in between.
+
+**Signals:** traces + metrics + logs. **Deployment:** cloud (US or EU). **Cost:** generous free tier; paid plans for higher volume and the Query Data API.
+
+:::tip Verified live
+This backend was tested end-to-end against a real Honeycomb free-tier account (US, a modern "Environments" key): a real `hermes` turn fanned spans out to Honeycomb alongside Phoenix, the OTLP export returned success, and Honeycomb auto-created the datasets. See [Verified behavior](#verified-behavior).
+:::
+
+## Quick start
+
+Put your Honeycomb ingest key in an env var:
+
+```bash
+export HONEYCOMB_API_KEY="hcaik_..."
+```
+
+Then declare the backend in `config.yaml`:
+
+```yaml
+backends:
+  - type: honeycomb
+    region: us                 # us (default) or eu
+    api_key_env: HONEYCOMB_API_KEY
+```
+
+That's it. The plugin fills in the ingest endpoint and the `x-honeycomb-team` auth header, and derives the per-signal paths automatically. You'll see `✓ Honeycomb at https://api.honeycomb.io/v1/traces` in the startup logs.
+
+Open the Honeycomb UI and your data lands in a dataset named after the agent's `service.name` (see [Datasets](#datasets)).
+
+## Why a dedicated `type: honeycomb`
+
+Trace export also works through the [generic OTLP](/backends/otlp) type if you hand-write the endpoint and `x-honeycomb-team` header. Declaring `type: honeycomb` instead asks the plugin to:
+
+1. Read `api_key:` (or `api_key_env:` → env var → `HONEYCOMB_API_KEY` / `OTEL_HONEYCOMB_API_KEY`).
+2. Set the `x-honeycomb-team` request header automatically.
+3. Default the endpoint from `region` (US or EU) — no need to remember the URL.
+4. Enable all three signals (`supports_metrics=True`, `supports_logs=True`).
+5. Display `✓ Honeycomb at <endpoint>` in startup logs.
+
+Keep the key out of `config.yaml` — use `api_key_env` and set the variable in your shell.
+
+## Configuration reference
+
+| Field | Meaning |
+|---|---|
+| `region` | `us` (default) → `https://api.honeycomb.io`, `eu` → `https://api.eu1.honeycomb.io`. Ignored if `endpoint` is set. |
+| `api_key` / `api_key_env` | Honeycomb ingest key → `x-honeycomb-team` header. Prefer `api_key_env`. Falls back to `HONEYCOMB_API_KEY` / `OTEL_HONEYCOMB_API_KEY`. |
+| `dataset` | Optional → `x-honeycomb-dataset` header. Only honored by Classic keys — see [Datasets](#datasets). |
+| `endpoint` | Optional full `/v1/traces` URL; overrides `region`. Also settable via `OTEL_HONEYCOMB_ENDPOINT`. |
+| `metrics` / `logs` / `traces` | Per-signal toggles. All default **on** for Honeycomb. |
+| `headers` | Extra headers, merged on top of the generated ones. |
+
+The plugin uses **OTLP/HTTP** (not gRPC). The metrics and logs endpoints are derived from the traces endpoint by rewriting the `/v1/traces` suffix to `/v1/metrics` and `/v1/logs`, which matches Honeycomb's per-signal path scheme.
+
+## Single backend (env vars)
+
+Without a `config.yaml` `backends:` list, the env-var flow picks up Honeycomb when `HONEYCOMB_API_KEY` is set (US endpoint by default):
+
+```bash
+export HONEYCOMB_API_KEY="hcaik_..."
+# Optional — override the URL (e.g. the EU host):
+# export OTEL_HONEYCOMB_ENDPOINT="https://api.eu1.honeycomb.io/v1/traces"
+export OTEL_PROJECT_NAME=hermes-otel-honeycomb
+```
+
+## Datasets
+
+Honeycomb routes data into *datasets*, and the rules depend on your key type.
+
+**Modern "Environments" keys (what most accounts use today):**
+
+- **Traces** route by the `service.name` resource attribute → a dataset of that name is auto-created. The `x-honeycomb-dataset` header is **ignored**.
+- **Metrics** route to the environment's default metrics dataset (named `Metrics`). The header is **ignored** here too.
+- **Logs** are ingested as events.
+- ⇒ With a modern key, **`dataset` has no observable effect** — leave it unset. Control your trace dataset name via `service.name` (the plugin sets it from the OTel resource / project name, e.g. `OTEL_PROJECT_NAME`).
+
+**Honeycomb Classic keys (legacy 32-char):**
+
+- `x-honeycomb-dataset` is honored and **required for every signal**. Set `dataset` so data isn't rejected or mis-routed.
+
+The plugin sends the same merged header set to the trace, metric, and log exporters, so a `dataset` you set is applied to all three — correct for Classic keys, a harmless no-op for modern keys.
+
+## Verified behavior
+
+Confirmed against a real Honeycomb free-tier account (US region, modern Environments key) by running a real `hermes` turn with Honeycomb configured alongside Phoenix:
+
+- **Startup:** `✓ Honeycomb at https://api.honeycomb.io/v1/traces`; logs and metrics fan-out both reported Honeycomb as a target (Phoenix stayed traces-only).
+- **Export:** a span pushed through the plugin's resolved exporter returned `SpanExportResult.SUCCESS`; the full `hermes` turn produced no export errors.
+- **Ingestion:** Honeycomb auto-created a **trace** dataset named from `service.name` (~16 columns of GenAI / `llm.*` attributes) and a default **`Metrics`** dataset. A `dataset:` set in config did not override either — confirming the header is ignored for modern keys.
+- **Not confirmed:** individual column names / span contents — the test key's scope was `events + createDatasets + markers` but not `columns` or `queries`, so the management API couldn't enumerate columns or run queries. Dataset column counts are strong evidence the attributes landed; attribute-level confirmation needs a key with `columns`/`queries` access (or the Honeycomb UI).
+
+## Multi-backend fan-out
+
+Honeycomb runs happily alongside a local backend — each gets its own batch processor and worker thread, so they export in parallel and a slow one can't block the others. A common setup is local Phoenix for the bundled dashboard plus Honeycomb for durable cloud storage:
+
+```yaml
+query_backend: phoenix
+backends:
+  - type: phoenix
+    endpoint: http://localhost:6006/v1/traces
+  - type: honeycomb
+    region: us
+    api_key_env: HONEYCOMB_API_KEY
+
+capture_logs: true
+```
+
+Traces fan out to both, metrics to both, logs only to Honeycomb (Phoenix doesn't accept OTLP logs — the plugin skips it automatically). See [Multi-backend fan-out](/backends/multi-backend).
+
+## Limitations
+
+- **No bundled-dashboard query support (export-only).** The hermes-otel [dashboard](/backends/multi-backend) queries a backend to render traces (e.g. Phoenix via GraphQL). Honeycomb's [Query Data API](https://api-docs.honeycomb.io/api/query-data) is Enterprise-plan gated, asynchronous (create query → run → poll), oriented toward aggregated results rather than fetching raw spans by trace ID, and bounded to a 7-day window — a poor fit for the dashboard. Point `query_backend` at a local backend and explore Honeycomb data in Honeycomb's own UI.
+- **Dataset header ignored on modern keys** — control the trace dataset via `service.name`; see [Datasets](#datasets).
+
+## Troubleshooting
+
+**`Unknown API key` / HTTP 401 at startup**
+The key is for the wrong region. US and EU are separate; a US key 401s against `api.eu1.honeycomb.io` and vice versa. Set `region:` to match where your team lives.
+
+**Traces appear but metrics don't show where I expected**
+On a modern key, metrics go to the default `Metrics` dataset regardless of `dataset:`. That's expected — see [Datasets](#datasets).
+
+**`✓ Honeycomb at ...` but nothing in the UI**
+Check you're looking at the right environment (the key is environment-scoped) and the dataset named after your `service.name`. Ingestion is near-real-time but can lag a few seconds.
+
+## See also
+
+- [Generic OTLP](/backends/otlp) — the no-dedicated-type path Honeycomb also works through.
+- [Multi-backend fan-out](/backends/multi-backend) — adding Honeycomb alongside a local backend.
+- [OTel logs](/configuration/logs) — the log pipeline that ships logs to Honeycomb.
+- [Send Data to Honeycomb with OpenTelemetry](https://docs.honeycomb.io/send-data/opentelemetry) — upstream docs.

--- a/website/docs/backends/overview.md
+++ b/website/docs/backends/overview.md
@@ -21,6 +21,7 @@ hermes-otel speaks plain **OTLP/HTTP**, so any OTLP-compatible backend should wo
 | **[Grafana LGTM](/backends/lgtm)** | Traces + metrics + logs | Local (single container) | OSS, no account |
 | **[Uptrace](/backends/uptrace)** | Traces + metrics + logs | Local (docker compose) · Self-hosted | OSS · premium license for HA features |
 | **[OpenObserve](/backends/openobserve)** | Traces + metrics + logs | Local (single container) · Self-hosted HA | OSS, no account |
+| **[Honeycomb](/backends/honeycomb)** | Traces + metrics + logs | Cloud (US / EU) | Generous free tier · paid plans |
 | **[Generic OTLP](/backends/otlp)** | Depends on collector | Anywhere | — |
 
 ## Quick picks
@@ -43,7 +44,10 @@ hermes-otel speaks plain **OTLP/HTTP**, so any OTLP-compatible backend should wo
 **"Standard distributed tracing stack, no LLM-specific UI needed"**
 → [Jaeger](/backends/jaeger) or [Grafana Tempo](/backends/tempo) — both are traces-only; pair with Prometheus if you need metrics.
 
-**"My company already has an OTel collector / Honeycomb / New Relic / Datadog"**
+**"I want a cloud backend with a generous free tier and all three signals"**
+→ [Honeycomb](/backends/honeycomb) — OTLP-native, just set `HONEYCOMB_API_KEY` and a region.
+
+**"My company already has an OTel collector / New Relic / Datadog"**
 → [Generic OTLP](/backends/otlp) — point at its ingest endpoint and it just works.
 
 **"I want several of the above simultaneously"**
@@ -64,6 +68,7 @@ Backends differ in which OTel signals they accept. The plugin auto-skips signals
 | Grafana LGTM | ✅ | ✅ | ✅ |
 | Uptrace | ✅ | ✅ | ✅ |
 | OpenObserve | ✅ | ✅ | ✅ |
+| Honeycomb | ✅ | ✅ | ✅ |
 | Generic OTLP | ✅ | depends on collector | depends on collector |
 
 If you care about token / tool / cost metrics on a traces-only backend, pair it with a Prometheus-compatible sink or fan out to Phoenix / SigNoz / LGTM alongside. See [OTel logs](/configuration/logs) for the logs pipeline.
@@ -75,9 +80,12 @@ Single-backend selection is env-var-driven. First match wins:
 1. `LANGSMITH_TRACING=true` → LangSmith
 2. `OTEL_LANGFUSE_PUBLIC_API_KEY` + `OTEL_LANGFUSE_SECRET_API_KEY` set → Langfuse
 3. `OTEL_SIGNOZ_ENDPOINT` set → SigNoz
-4. `OTEL_JAEGER_ENDPOINT` set → Jaeger
-5. `OTEL_TEMPO_ENDPOINT` set → Tempo
-6. `OTEL_PHOENIX_ENDPOINT` set → Phoenix
+4. `OTEL_UPTRACE_ENDPOINT` + DSN set → Uptrace
+5. `OTEL_OPENOBSERVE_ENDPOINT` + credentials set → OpenObserve
+6. `HONEYCOMB_API_KEY` set → Honeycomb
+7. `OTEL_JAEGER_ENDPOINT` set → Jaeger
+8. `OTEL_TEMPO_ENDPOINT` set → Tempo
+9. `OTEL_PHOENIX_ENDPOINT` set → Phoenix
 
 Setting `backends:` in `config.yaml` overrides the env-var flow entirely — see [Multi-backend fan-out](/backends/multi-backend).
 
@@ -85,7 +93,6 @@ Setting `backends:` in `config.yaml` overrides the env-var flow entirely — see
 
 These are OTLP-compatible and should work today with the generic OTLP backend — first-class docs, docker-compose files, and smoke tests are on the roadmap:
 
-- [Honeycomb](https://www.honeycomb.io) — cloud, generous free tier
 - [New Relic](https://newrelic.com) — cloud, 100 GB/mo free tier
 - [Elastic APM](https://www.elastic.co/observability/application-performance-monitoring) — self-host or Elastic Cloud
 - [Datadog](https://www.datadoghq.com) — cloud, trial only

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -29,6 +29,9 @@ Setting any of these enables the matching backend. First match wins (see [Backen
 | `OTEL_JAEGER_ENDPOINT` | Jaeger | `http://localhost:4318/v1/traces` |
 | `OTEL_TEMPO_ENDPOINT` | Tempo | `http://localhost:4318/v1/traces` |
 | `OTEL_PHOENIX_ENDPOINT` | Phoenix | `http://localhost:6006/v1/traces` |
+| `HONEYCOMB_API_KEY` | Honeycomb | `hcaik_...` |
+| `OTEL_HONEYCOMB_API_KEY` | Honeycomb (plugin-specific alias) | `hcaik_...` |
+| `OTEL_HONEYCOMB_ENDPOINT` | Honeycomb (optional; overrides region default) | `https://api.eu1.honeycomb.io/v1/traces` |
 | `OTEL_PROJECT_NAME` | All | `hermes-agent` |
 
 ## Shaping overrides

--- a/website/docs/reference/config-schema.md
+++ b/website/docs/reference/config-schema.md
@@ -42,12 +42,12 @@ Shared fields (all optional unless noted):
 
 | Field | Type | Description |
 |---|---|---|
-| `type` | string | **Required.** One of: `phoenix`, `langfuse`, `langsmith`, `signoz`, `jaeger`, `tempo`, `otlp`, `lgtm`, `uptrace`, `openobserve` |
+| `type` | string | **Required.** One of: `phoenix`, `langfuse`, `langsmith`, `signoz`, `jaeger`, `tempo`, `otlp`, `lgtm`, `uptrace`, `openobserve`, `honeycomb` |
 | `name` | string | Friendly name shown in logs (default: `type`) |
 | `endpoint` | string | Full OTLP endpoint URL (backend-specific defaults — see below) |
 | `traces` | bool | Override trace-export default (`true`). Set `false` for dashboard/query-only backends that should not receive span exports. `trace` is accepted as an alias. |
 | `metrics` | bool | Override metrics-export default for this backend |
-| `logs` | bool | Override logs-export default (on for `signoz`, `otlp`, `lgtm`, `uptrace`, `openobserve`; off elsewhere) |
+| `logs` | bool | Override logs-export default (on for `signoz`, `otlp`, `lgtm`, `uptrace`, `openobserve`, `honeycomb`; off elsewhere) |
 | `headers` | map | Per-backend HTTP headers (merged onto top-level `headers`) |
 
 ### Type-specific fields
@@ -114,6 +114,18 @@ Alias over `otlp` with a dedicated display name and all signals on by default. S
 | `logs` | bool | Default: `true` |
 
 Use `type: lgtm` (not `type: tempo`) when pointing at the `grafana/otel-lgtm` container — `tempo` is traces-only and would disable the logs/metrics fan-out.
+
+#### `honeycomb`
+
+| Field | Type | Description |
+|---|---|---|
+| `api_key` | string | Honeycomb ingest key (inline; discouraged) |
+| `api_key_env` | string | Env var name holding the key (falls back to `HONEYCOMB_API_KEY` / `OTEL_HONEYCOMB_API_KEY`) |
+| `region` | string | `us` (default) or `eu`; selects the endpoint when none is given |
+| `dataset` | string | Optional `x-honeycomb-dataset` header. Only honored by Classic keys — modern Environments keys ignore it |
+| `endpoint` | string | Override; skips the region default. Also via `OTEL_HONEYCOMB_ENDPOINT` |
+
+The plugin sets `x-honeycomb-team` from the key automatically and enables all three signals. See [Honeycomb](/backends/honeycomb) for dataset routing details.
 
 ## Env var interpolation in `headers:`
 

--- a/website/docs/reference/env-vars.md
+++ b/website/docs/reference/env-vars.md
@@ -27,6 +27,9 @@ Complete list. See [Environment variables](/configuration/environment-variables)
 | `OTEL_JAEGER_ENDPOINT` | URL | Jaeger OTLP endpoint (`http://localhost:4318/v1/traces`) |
 | `OTEL_TEMPO_ENDPOINT` | URL | Tempo OTLP endpoint |
 | `OTEL_PHOENIX_ENDPOINT` | URL | Phoenix OTLP endpoint (`http://localhost:6006/v1/traces`) |
+| `HONEYCOMB_API_KEY` | `hcaik_...` | Honeycomb ingest key (`x-honeycomb-team`); enables Honeycomb in env-var mode |
+| `OTEL_HONEYCOMB_API_KEY` | `hcaik_...` | Honeycomb key (plugin-specific alias) |
+| `OTEL_HONEYCOMB_ENDPOINT` | URL | Honeycomb endpoint override (default: US region) |
 | `OTEL_PROJECT_NAME` | string | Resource `service.name` + `openinference.project.name` |
 
 ## Shaping overrides

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -29,6 +29,7 @@ const sidebars: SidebarsConfig = {
         'backends/lgtm',
         'backends/uptrace',
         'backends/openobserve',
+        'backends/honeycomb',
         'backends/multi-backend',
       ],
     },


### PR DESCRIPTION
Closes #20.

## What

Adds a first-class `honeycomb` backend type. Honeycomb already worked for **traces** via the generic `otlp` type; this fills in the endpoint + auth header + dataset routing so users declare a backend instead of hand-assembling OTLP config, and it wires up **metrics + logs** too.

```yaml
backends:
  - type: honeycomb
    region: us                 # us (default) | eu
    api_key_env: HONEYCOMB_API_KEY
    # dataset: hermes          # optional — see dataset note
```

## Changes

- **`plugin_config.py`** — `BackendConfig` gains `api_key` / `api_key_env`, `dataset`, `region` (auto-whitelisted via `fields(BackendConfig)`).
- **`backends.py`** — `_resolve_honeycomb()` + registration in `_RESOLVERS`, `_DISPLAY_NAMES`, `_LOGS_CAPABLE`, `_ENV_PRIORITY`.
  - US/EU base endpoint defaulted from `region`; explicit `endpoint` (or `OTEL_HONEYCOMB_ENDPOINT`) overrides.
  - `x-honeycomb-team` always set; `x-honeycomb-dataset` set when `dataset` given; user `headers:` merge on top.
  - Key resolved inline → `api_key_env` → `HONEYCOMB_API_KEY` / `OTEL_HONEYCOMB_API_KEY`.
  - All three signals supported; metrics/logs endpoints derive from `/v1/traces` (existing `_derive_metrics_endpoint` / `_derive_logs_endpoint`), matching Honeycomb's per-signal paths.
- **Docs** — `HONEYCOMB.md` guide, README backend row + env-var section + priority order, `config.yaml.example` quickstart + type list.
- **Tests** — `tests/unit/test_backends_honeycomb.py`, 14 cases, no network.

## Dataset trade-off (documented)

One merged header set feeds the trace/metric/log exporters, so `dataset` tags **all** signals into that dataset. For modern Environments keys, traces route by `service.name` and need no dataset, but **metrics require one or they land in `unknown_metrics`**. So today it's "clean per-service traces" *or* "non-default metrics dataset," not both on one entry. A per-signal `metrics_dataset` is noted as a possible follow-up. Classic keys just set `dataset` (required anyway). Full write-up in `HONEYCOMB.md`.

## Deferred / out of scope

- **Dashboard query adapter** — Honeycomb's [Query Data API](https://api-docs.honeycomb.io/api/query-data) is Enterprise-gated, async, aggregate-oriented, and 7-day-bounded — a poor fit for the dashboard's raw-span-by-trace-id fetch. Honeycomb is **export-only**; point `query_backend` at a local backend and explore in Honeycomb's UI.

## Testing

- `uv run --extra dev pytest` → **441 passed**, 3 skipped (14 new).
- `ruff check .` / `black --check .` → clean.
- ✅ **Verified live against a real Honeycomb free-tier account** (US, modern Environments key): a real `hermes` turn fanned out to Honeycomb + Phoenix — traces/metrics/logs registered, OTLP export returned success, and Honeycomb auto-created the datasets. Live testing also corrected the dataset-routing docs (`x-honeycomb-dataset` is ignored by modern keys). Full results in the [diagnostic comment](https://github.com/briancaffey/hermes-otel/pull/21#issuecomment-4783798323). Column-level attribute names couldn't be enumerated (test key lacked `columns`/`queries` scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

