### PR TITLE
Propagate GenAI conversation IDs across sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Every field can be overridden by env var with prefix `HERMES_OTEL_` (scalars onl
 
 Set `capture_previews: false` (or `HERMES_OTEL_CAPTURE_PREVIEWS=false`) to suppress every `input.value` / `output.value` attribute. Useful for shared deployments where message content can't leave the process. A one-line startup banner confirms the mode is active.
 
-Set `capture_sender_id: true` (or `HERMES_OTEL_CAPTURE_SENDER_ID=true`) to attach gateway sender identity to spans. The plugin emits the raw platform ID as `hermes.sender.id` and the backend-neutral user key as `user.id={platform}:{sender_id}`. For example, Slack user `U0B074344DP` becomes `user.id=slack:U0B074344DP`. The platform is already available on LLM spans as `llm.provider`. This is opt-in because IDs from Discord, Telegram, Slack, email, SMS, and similar platforms can identify users. CLI sessions usually omit it.
+Set `capture_sender_id: true` (or `HERMES_OTEL_CAPTURE_SENDER_ID=true`) to attach gateway sender identity to spans. The plugin emits the raw platform ID as `hermes.sender.id` and the backend-neutral user key as `user.id={platform}:{sender_id}`. For example, Slack user `U0B074344DP` becomes `user.id=slack:U0B074344DP`. The provider is available on LLM spans as `gen_ai.provider.name`. This is opt-in because IDs from Discord, Telegram, Slack, email, SMS, and similar platforms can identify users. CLI sessions usually omit it.
 
 ### Per-turn summary attributes
 
@@ -458,19 +458,20 @@ Turn 1:
 
 ### Attribute conventions
 
-The plugin emits **dual-convention** attributes so both backends work:
+The plugin emits canonical OpenTelemetry GenAI attributes for model/provider metadata and token counts:
 
-| Metric | OpenTelemetry GenAI | Phoenix (OpenInference) |
-|--------|---------------------|------------------------|
-| Prompt tokens | `gen_ai.usage.input_tokens` | `llm.token_count.prompt` |
-| Completion tokens | `gen_ai.usage.output_tokens` | `llm.token_count.completion` |
-| Total tokens | `gen_ai.usage.total_tokens` | `llm.token_count.total` |
-| Cache read | `gen_ai.usage.cache_read.input_tokens` (`gen_ai.usage.cache_read_input_tokens` also kept) | `llm.token_count.prompt_details.cache_read` |
-| Cache write | `gen_ai.usage.cache_creation.input_tokens` (`gen_ai.usage.cache_creation_input_tokens` also kept) | `llm.token_count.prompt_details.cache_write` |
+| Metric | OpenTelemetry GenAI |
+|--------|---------------------|
+| Prompt tokens | `gen_ai.usage.input_tokens` |
+| Completion tokens | `gen_ai.usage.output_tokens` |
+| Cache read | `gen_ai.usage.cache_read.input_tokens` |
+| Cache write | `gen_ai.usage.cache_creation.input_tokens` |
+
+Total tokens are derived downstream from input + output tokens rather than emitted as a duplicate span attribute.
 
 LLM and API spans also expose standard GenAI request/response metadata where Hermes provides it, including `gen_ai.provider.name`, `gen_ai.request.model`, request parameters such as `gen_ai.request.temperature`, and response fields such as `gen_ai.response.model` and `gen_ai.response.finish_reasons`.
 
-Phoenix uses `input.value` and `output.value` for previews. When full prompt/response capture is explicitly enabled, the plugin also writes the corresponding GenAI content attributes (`gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.system_instructions`).
+When full prompt/response capture is explicitly enabled, the plugin writes GenAI content attributes (`gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.system_instructions`). Preview-safe `input.value` / `output.value` are still used for generic span input/output rendering.
 
 ## File structure
 

--- a/__init__.py
+++ b/__init__.py
@@ -34,6 +34,12 @@ def register(ctx):
     ctx.register_hook("post_llm_call", hooks.on_post_llm_call)
     ctx.register_hook("pre_api_request", hooks.on_pre_api_request)
     ctx.register_hook("post_api_request", hooks.on_post_api_request)
+    extra_hooks = 0
+    try:
+        ctx.register_hook("api_request_error", hooks.on_api_request_error)
+        extra_hooks += 1
+    except Exception:
+        debug_log("api_request_error hook unavailable")
 
     # Session hooks (available on newer Hermes versions)
     session_hooks = 0
@@ -47,4 +53,4 @@ def register(ctx):
         except Exception:
             debug_log(f"{hook_name} hook unavailable")
 
-    logger.info(f"[hermes-otel] Registered {6 + session_hooks} hooks")
+    logger.info(f"[hermes-otel] Registered {6 + extra_hooks + session_hooks} hooks")

--- a/__init__.py
+++ b/__init__.py
@@ -53,4 +53,16 @@ def register(ctx):
         except Exception:
             debug_log(f"{hook_name} hook unavailable")
 
-    logger.info(f"[hermes-otel] Registered {6 + extra_hooks + session_hooks} hooks")
+    kanban_hooks = 0
+    for hook_name, callback in [
+        ("kanban_task_claimed", hooks.on_kanban_task_claimed),
+        ("kanban_task_completed", hooks.on_kanban_task_completed),
+        ("kanban_task_blocked", hooks.on_kanban_task_blocked),
+    ]:
+        try:
+            ctx.register_hook(hook_name, callback)
+            kanban_hooks += 1
+        except Exception:
+            debug_log(f"{hook_name} hook unavailable")
+
+    logger.info(f"[hermes-otel] Registered {6 + extra_hooks + session_hooks + kanban_hooks} hooks")

--- a/backends.py
+++ b/backends.py
@@ -28,7 +28,7 @@ from typing import Callable, Dict, List, Optional
 from .plugin_config import BackendConfig
 
 # Backend types whose collectors do not accept OTLP metrics. Pure traces.
-_TRACES_ONLY = {"langfuse", "jaeger", "tempo"}
+_TRACES_ONLY = {"honeycomb", "langfuse", "jaeger", "tempo"}
 
 # Backend types whose collectors accept OTLP logs. Everything else defaults
 # to "logs off" — Phoenix/Langfuse/Jaeger/Tempo don't implement /v1/logs, and
@@ -40,6 +40,7 @@ _LOGS_CAPABLE = {"signoz", "otlp", "lgtm", "uptrace", "openobserve"}
 # some backends use camelCase ("SigNoz") that simple title-case gets wrong.
 _DISPLAY_NAMES = {
     "phoenix": "Phoenix",
+    "honeycomb": "Honeycomb",
     "langfuse": "Langfuse",
     "signoz": "SigNoz",
     "jaeger": "Jaeger",
@@ -52,7 +53,16 @@ _DISPLAY_NAMES = {
 
 # Priority for env-var-driven single-backend detection. First backend whose
 # required env vars are fully set wins.
-_ENV_PRIORITY = ["langfuse", "signoz", "uptrace", "openobserve", "jaeger", "tempo", "phoenix"]
+_ENV_PRIORITY = [
+    "honeycomb",
+    "langfuse",
+    "signoz",
+    "uptrace",
+    "openobserve",
+    "jaeger",
+    "tempo",
+    "phoenix",
+]
 
 
 @dataclass
@@ -122,6 +132,47 @@ def _display(bc: BackendConfig, t: str) -> str:
 
 
 # ── Per-backend resolvers ──────────────────────────────────────────────────
+
+
+def _resolve_honeycomb(bc: BackendConfig) -> _ResolvedBackend:
+    """Resolve Honeycomb OTLP HTTP trace ingestion.
+
+    Honeycomb authenticates OTLP requests with the ``x-honeycomb-team``
+    header. For modern Honeycomb environments, ``service.name`` routes events
+    to the dataset; classic datasets may also pass ``x-honeycomb-dataset``.
+    """
+    ep = (bc.endpoint or os.getenv("OTEL_HONEYCOMB_ENDPOINT", "")).strip()
+    if not ep:
+        region = (bc.region or os.getenv("HONEYCOMB_REGION", "") or "us").strip().lower()
+        host = "api.eu1.honeycomb.io" if region in {"eu", "eu1"} else "api.honeycomb.io"
+        ep = f"https://{host}/v1/traces"
+
+    key = _resolve_secret(
+        bc.api_key,
+        bc.api_key_env,
+        ["HONEYCOMB_API_KEY", "OTEL_HONEYCOMB_API_KEY"],
+    )
+    if not key:
+        raise ValueError("honeycomb requires api_key or api_key_env")
+
+    headers: Dict[str, str] = {"x-honeycomb-team": key}
+    dataset = _resolve_secret(
+        bc.dataset,
+        bc.dataset_env,
+        ["HONEYCOMB_DATASET", "OTEL_HONEYCOMB_DATASET"],
+    )
+    if dataset:
+        headers["x-honeycomb-dataset"] = dataset
+    headers.update(bc.headers or {})
+    return _ResolvedBackend(
+        type="honeycomb",
+        endpoint=ep,
+        display_name=_display(bc, "honeycomb"),
+        headers=headers,
+        supports_traces=_traces_for(bc.traces),
+        supports_metrics=_metrics_for("honeycomb", bc.metrics),
+        supports_logs=_logs_for("honeycomb", bc.logs),
+    )
 
 
 def _resolve_phoenix(bc: BackendConfig) -> _ResolvedBackend:
@@ -349,6 +400,7 @@ def _resolve_openobserve(bc: BackendConfig) -> _ResolvedBackend:
 
 
 _RESOLVERS: Dict[str, Callable[[BackendConfig], _ResolvedBackend]] = {
+    "honeycomb": _resolve_honeycomb,
     "phoenix": _resolve_phoenix,
     "langfuse": _resolve_langfuse,
     "signoz": _resolve_signoz,

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -60,7 +60,7 @@
 # Platform sender ID capture. When true, gateway sessions add the raw
 # platform sender ID as hermes.sender.id and a backend-neutral user.id
 # formatted as "{platform}:{sender_id}". The platform is already emitted
-# on LLM spans as llm.provider.
+# on LLM spans as gen_ai.provider.name.
 # This can identify users (for example Discord, Telegram, Slack, email, SMS),
 # so keep it opt-in. CLI sessions usually leave it empty.
 # capture_sender_id: false

--- a/dashboard/backends/jaeger.py
+++ b/dashboard/backends/jaeger.py
@@ -31,18 +31,18 @@ _DEFAULT_JAEGER_QUERY_PORT = 16686
 
 _CARD_TAGS = frozenset(
     {
-        "llm.model_name",
-        "llm.provider",
-        "llm.api_mode",
+        "gen_ai.request.model",
+        "gen_ai.provider.name",
+        "hermes.api.mode",
         "gen_ai.usage.input_tokens",
         "gen_ai.usage.output_tokens",
         "gen_ai.usage.total_tokens",
-        "llm.response.finish_reason",
-        "llm.response.tool_calls",
+        "gen_ai.response.finish_reasons",
+        "hermes.response.tool_calls",
         "tool.name",
         "input.value",
         "output.value",
-        "llm.output.content",
+        "gen_ai.output.messages",
     }
 )
 

--- a/dashboard/backends/langfuse.py
+++ b/dashboard/backends/langfuse.py
@@ -60,21 +60,21 @@ def _obs_kind_to_otlp(obs_type: Optional[str]) -> int:
     return 1
 
 
-# ``GENERATION`` carries LLM-specific fields we want to surface as
-# Otel-style attributes on the normalized shape.
+# ``GENERATION`` carries GenAI-specific fields we want to surface as
+# OTel-style attributes on the normalized shape.
 def _obs_to_card_attrs(obs: Dict[str, Any]) -> Dict[str, Any]:
     out: Dict[str, Any] = {"name": obs.get("name") or ""}
     t = obs.get("type")
     if isinstance(t, str):
         out["langfuse.type"] = t
     if obs.get("model"):
-        out["llm.model_name"] = obs["model"]
+        out["gen_ai.request.model"] = obs["model"]
     # Langfuse doesn't model "provider" as a distinct field — fall
     # through to modelParameters / metadata.
     params = obs.get("modelParameters")
     if isinstance(params, dict):
         for k, v in params.items():
-            out[f"llm.parameters.{k}"] = v
+            out[f"gen_ai.request.{k}"] = v
 
     usage = obs.get("usage") or {}
     if isinstance(usage, dict):

--- a/dashboard/backends/openobserve.py
+++ b/dashboard/backends/openobserve.py
@@ -2,7 +2,7 @@
 
 OpenObserve stores traces as rows in a stream (default ``default``).
 Attributes are flattened into columns with dots replaced by
-underscores (``llm.model_name`` → ``llm_model_name``); the adapter
+underscores (``gen_ai.request.model`` → ``gen_ai_request_model``); the adapter
 translates them back so the UI sees the same keys it does on Tempo.
 """
 
@@ -28,18 +28,18 @@ _DEFAULT_OO_PORT = 5080
 # Columns the card renderer cares about. Expressed in Otel dot form;
 # ``_oo_col`` translates to OpenObserve's underscore form on the wire.
 _CARD_ATTR_KEYS = (
-    "llm.model_name",
-    "llm.provider",
-    "llm.api_mode",
+    "gen_ai.request.model",
+    "gen_ai.provider.name",
+    "hermes.api.mode",
     "gen_ai.usage.input_tokens",
     "gen_ai.usage.output_tokens",
     "gen_ai.usage.total_tokens",
-    "llm.response.finish_reason",
-    "llm.response.tool_calls",
+    "gen_ai.response.finish_reasons",
+    "hermes.response.tool_calls",
     "tool.name",
     "input.value",
     "output.value",
-    "llm.output.content",
+    "gen_ai.output.messages",
 )
 
 
@@ -64,7 +64,7 @@ def _sql_escape(v: Any) -> str:
 class OpenObserveAdapter(BackendAdapter):
     handles = frozenset({"openobserve", "openobserver"})
     query_lang_label = "SQL WHERE"
-    raw_placeholder = "llm_model_name = 'gpt-4'"
+    raw_placeholder = "gen_ai_request_model = 'gpt-4'"
 
     def __init__(self, cfg: Dict[str, Any]):
         super().__init__(cfg)

--- a/dashboard/backends/phoenix.py
+++ b/dashboard/backends/phoenix.py
@@ -4,7 +4,7 @@ Phoenix stores spans per-project. The adapter honours ``project_name``
 from the backend cfg (or the top-level plugin config) and falls back
 to the first project that has traces. Attributes come back as a
 nested JSON string; we parse + flatten to dot-notation keys
-(``llm.model_name``) so the frontend renderer can use them unchanged.
+(``gen_ai.request.model``) so the frontend renderer can use them unchanged.
 
 Native query language is Phoenix's ``filterCondition`` expression
 syntax — same one the Phoenix UI uses in its filter bar.
@@ -33,8 +33,8 @@ _DEFAULT_PHOENIX_PORT = 6006
 
 def _flatten(obj: Any, prefix: str = "") -> Dict[str, Any]:
     """Phoenix's ``attributes`` JSON is nested by dot groupings
-    (``{"llm": {"model_name": ...}}``). Re-emit as a flat dict
-    (``{"llm.model_name": ...}``) to match Tempo/OTLP attribute keys.
+    (``{"gen_ai": {"request": {"model": ...}}}``). Re-emit as a flat dict
+    (``{"gen_ai.request.model": ...}``) to match Tempo/OTLP attribute keys.
     """
     out: Dict[str, Any] = {}
     if isinstance(obj, dict):
@@ -77,18 +77,18 @@ def _span_kind_to_otlp(kind: Optional[str]) -> int:
 
 _CARD_ATTR_KEYS = frozenset(
     {
-        "llm.model_name",
-        "llm.provider",
-        "llm.api_mode",
+        "gen_ai.request.model",
+        "gen_ai.provider.name",
+        "hermes.api.mode",
         "gen_ai.usage.input_tokens",
         "gen_ai.usage.output_tokens",
         "gen_ai.usage.total_tokens",
-        "llm.response.finish_reason",
-        "llm.response.tool_calls",
+        "gen_ai.response.finish_reasons",
+        "hermes.response.tool_calls",
         "tool.name",
         "input.value",
         "output.value",
-        "llm.output.content",
+        "gen_ai.output.messages",
         "status",
         "name",
     }
@@ -99,7 +99,7 @@ _CARD_ATTR_KEYS = frozenset(
 class PhoenixAdapter(BackendAdapter):
     handles = frozenset({"phoenix"})
     query_lang_label = "Phoenix filter"
-    raw_placeholder = "llm.model_name == 'gpt-4'"
+    raw_placeholder = "gen_ai.request.model == 'gpt-4'"
 
     def __init__(self, cfg: Dict[str, Any]):
         super().__init__(cfg)

--- a/dashboard/backends/signoz.py
+++ b/dashboard/backends/signoz.py
@@ -54,18 +54,18 @@ _SIGNOZ_SELECT_COLUMNS: List[Dict[str, Any]] = [
 ]
 
 _TAG_KEYS_TO_COLLECT = (
-    "llm.model_name",
-    "llm.provider",
-    "llm.api_mode",
+    "gen_ai.request.model",
+    "gen_ai.provider.name",
+    "hermes.api.mode",
     "gen_ai.usage.input_tokens",
     "gen_ai.usage.output_tokens",
     "gen_ai.usage.total_tokens",
-    "llm.response.finish_reason",
-    "llm.response.tool_calls",
+    "gen_ai.response.finish_reasons",
+    "hermes.response.tool_calls",
     "tool.name",
     "input.value",
     "output.value",
-    "llm.output.content",
+    "gen_ai.output.messages",
 )
 
 

--- a/dashboard/backends/tempo.py
+++ b/dashboard/backends/tempo.py
@@ -32,18 +32,18 @@ from .base import (
 _DEFAULT_TEMPO_QUERY_PORT = 3200
 
 _CARD_SELECT_ATTRS = (
-    ".llm.model_name",
-    ".llm.provider",
-    ".llm.api_mode",
+    ".gen_ai.request.model",
+    ".gen_ai.provider.name",
+    ".hermes.api.mode",
     ".gen_ai.usage.input_tokens",
     ".gen_ai.usage.output_tokens",
     ".gen_ai.usage.total_tokens",
-    ".llm.response.finish_reason",
-    ".llm.response.tool_calls",
+    ".gen_ai.response.finish_reasons",
+    ".hermes.response.tool_calls",
     ".tool.name",
     ".input.value",
     ".output.value",
-    ".llm.output.content",
+    ".gen_ai.output.messages",
     "status",
     "name",
 )
@@ -58,7 +58,7 @@ def _esc(s: str) -> str:
 class TempoAdapter(BackendAdapter):
     handles = frozenset({"lgtm", "tempo"})
     query_lang_label = "TraceQL"
-    raw_placeholder = '{ .llm.provider = "openai" }'
+    raw_placeholder = '{ .gen_ai.provider.name = "openai" }'
 
     def __init__(self, cfg: Dict[str, Any]):
         super().__init__(cfg)

--- a/dashboard/backends/uptrace.py
+++ b/dashboard/backends/uptrace.py
@@ -50,18 +50,18 @@ def _extract_dsn(dsn: Optional[str]) -> tuple[Optional[str], Optional[str]]:
 
 
 _TAG_KEYS = (
-    "llm.model_name",
-    "llm.provider",
-    "llm.api_mode",
+    "gen_ai.request.model",
+    "gen_ai.provider.name",
+    "hermes.api.mode",
     "gen_ai.usage.input_tokens",
     "gen_ai.usage.output_tokens",
     "gen_ai.usage.total_tokens",
-    "llm.response.finish_reason",
-    "llm.response.tool_calls",
+    "gen_ai.response.finish_reasons",
+    "hermes.response.tool_calls",
     "tool.name",
     "input.value",
     "output.value",
-    "llm.output.content",
+    "gen_ai.output.messages",
 )
 
 

--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -67,6 +67,14 @@
     return out;
   }
 
+  function firstAttr(attrs, keys) {
+    for (var i = 0; i < keys.length; i++) {
+      var value = attrs[keys[i]];
+      if (value !== null && value !== undefined && value !== "") return value;
+    }
+    return null;
+  }
+
   function fmtDurationMs(ms) {
     if (ms == null || isNaN(ms)) return "—";
     if (ms < 1) return ms.toFixed(2) + "ms";
@@ -95,7 +103,9 @@
 
   function spanKindLabel(span) {
     var attrs = span._attrs || {};
-    var kind = attrs["openinference.span.kind"] || attrs["llm.provider"] ? "llm" : null;
+    var kind = attrs["openinference.span.kind"] || (
+      attrs["gen_ai.provider.name"] ? "llm" : null
+    );
     if (attrs["tool.name"]) return "tool";
     if (kind) return kind.toLowerCase();
     return null;
@@ -266,7 +276,10 @@
   }
 
   function extractOutputPreview(attrs) {
-    return attrs["llm.output.content"] || attrs["output.value"] || null;
+    var raw = firstAttr(attrs, ["gen_ai.output.messages", "output.value"]);
+    if (Array.isArray(raw)) return JSON.stringify(raw);
+    if (raw && typeof raw === "object") return JSON.stringify(raw);
+    return raw;
   }
 
   function traceSpanCount(trace) {
@@ -537,14 +550,15 @@
     var startNs = t.startTimeUnixNano
       ? Number(t.startTimeUnixNano)
       : (t.startTime ? new Date(t.startTime).getTime() * 1e6 : 0);
-    var model = attrs["llm.model_name"];
-    var provider = attrs["llm.provider"];
-    var apiMode = attrs["llm.api_mode"];
+    var model = firstAttr(attrs, ["gen_ai.response.model", "gen_ai.request.model"]);
+    var provider = attrs["gen_ai.provider.name"];
+    var apiMode = firstAttr(attrs, ["hermes.api.mode", "gen_ai.operation.name"]);
     var totalTokens = attrs["gen_ai.usage.total_tokens"];
     var inputTokens = attrs["gen_ai.usage.input_tokens"];
     var outputTokens = attrs["gen_ai.usage.output_tokens"];
     var toolName = attrs["tool.name"];
-    var finishReason = attrs["llm.response.finish_reason"];
+    var finishReason = attrs["gen_ai.response.finish_reasons"];
+    if (Array.isArray(finishReason)) finishReason = finishReason.join(", ");
     var status = attrs["status"];
     var spanCount = traceSpanCount(t);
     var isError = status === "error" || status === "STATUS_CODE_ERROR";

--- a/docker-compose/lgtm/README.md
+++ b/docker-compose/lgtm/README.md
@@ -47,11 +47,11 @@ see `[hermes-otel] ✓ Logs → 1 backend(s) (attached to root, level=INFO)`.
 ## What you get in Grafana
 
 - **Traces** — Explore → Tempo → search by service name `hermes-agent`
-  or span name (`agent`, `tool.*`, `api.*`). Each span shows the full
-  OpenInference + GenAI attribute set the plugin emits.
-- **Metrics** — Explore → Prometheus. Query any `hermes_*` metric the
-  plugin emits (`hermes_session_count_total`, `hermes_token_usage_total`,
-  `hermes_tool_duration_bucket`, ...). Also available: `traces_spanmetrics_*`
+  or span name (`agent`, `tool.*`, `api.*`). Each span shows the GenAI
+  and `hermes.*` attributes the plugin emits.
+- **Metrics** — Explore → Prometheus. Query the OTLP metric series the
+  plugin emits (`hermes_session_count_total`, `gen_ai_client_token_usage_total`,
+  `gen_ai_execute_tool_duration_bucket`, ...). Also available: `traces_spanmetrics_*`
   derived by the collector — RED metrics per-service from your traces.
 - **Logs** — Explore → Loki. Query `{service_name="hermes-agent"}`. When
   `capture_logs` is on, every Python `logger.info(...)` from hermes-agent
@@ -83,7 +83,7 @@ see `[hermes-otel] ✓ Logs → 1 backend(s) (attached to root, level=INFO)`.
 `spanmetrics` connector. It turns incoming traces into RED metrics on the
 Prometheus side without the plugin having to emit them from Python.
 Dimensions are set to attribute names the plugin actually emits:
-`llm.provider`, `llm.model_name`, `openinference.span.kind`,
+`gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.operation.name`,
 `hermes.session.kind`, `hermes.tool.outcome`. Adjust here if you change
 what the plugin sets on its spans.
 

--- a/docker-compose/lgtm/otelcol-config.yaml
+++ b/docker-compose/lgtm/otelcol-config.yaml
@@ -16,9 +16,9 @@ connectors:
     # actually sets on its root/llm/tool spans so filtering in Grafana
     # works without extra relabeling.
     dimensions:
-      - name: llm.provider
-      - name: llm.model_name
-      - name: openinference.span.kind
+      - name: gen_ai.provider.name
+      - name: gen_ai.request.model
+      - name: gen_ai.operation.name
       - name: hermes.session.kind
       - name: hermes.tool.outcome
     # Default histogram buckets — good for LLM calls that span ms to

--- a/docker-compose/openobserve/README.md
+++ b/docker-compose/openobserve/README.md
@@ -51,7 +51,7 @@ should appear in startup logs.
 ## What you get in the UI
 
 - **Traces** — "Traces" tab. Search by service, span name, attributes.
-  The plugin emits OpenInference + GenAI attributes that OpenObserve
+  The plugin emits GenAI and `hermes.*` attributes that OpenObserve
   indexes automatically.
 - **Metrics** — "Metrics" tab. Query `hermes_*` metrics the plugin
   emits (sessions, tokens, tool durations).

--- a/docker-compose/uptrace/README.md
+++ b/docker-compose/uptrace/README.md
@@ -46,11 +46,11 @@ should appear in startup logs.
 ## What you get in the UI
 
 - **Traces** — the "Spans" and "Traces" pages. Every attribute the plugin
-  emits is searchable (OpenInference + GenAI + `hermes.*`). Group by
-  `llm.model_name`, `openinference.span.kind`, etc.
+  emits is searchable (GenAI + `hermes.*`). Group by
+  `gen_ai.request.model`, `gen_ai.operation.name`, etc.
 - **Metrics** — Prometheus-style PromQL over the metrics the plugin
-  emits (`hermes_session_count_total`, `hermes_token_usage_total`, the
-  tool-duration histogram).
+  emits (`hermes_session_count_total`, `gen_ai_client_token_usage_total`,
+  `gen_ai_execute_tool_duration_bucket`).
 - **Logs** — structured logs with automatic `trace_id` / `span_id`
   correlation when `capture_logs` is on. Clicking a log record's
   `trace_id` jumps to the full trace.

--- a/hooks.py
+++ b/hooks.py
@@ -29,6 +29,11 @@ from .helpers import (
 from .session_state import TurnSummary
 from .tracer import get_tracer
 
+try:
+    from opentelemetry import propagate
+except Exception:  # pragma: no cover - optional dependency guard
+    propagate = None  # type: ignore[assignment]
+
 
 class HookContext(TypedDict, total=False):
     """Optional extras Hermes may pass through a hook's ``**kwargs``.
@@ -63,6 +68,8 @@ class HookContext(TypedDict, total=False):
     kanban_assignee: str
     kanban_flow_kind: str
     kanban_source_kind: str
+    traceparent: str
+    tracestate: str
 
 
 _MAX_SUMMARY_CHARS = 500
@@ -269,9 +276,50 @@ def _env_value(*keys: str, limit: int = 200) -> str:
     return _first_text(*(os.getenv(key) for key in keys), limit=limit)
 
 
+def _kanban_trace_carrier(extra_kwargs: Optional[dict] = None) -> Dict[str, str]:
+    kwargs = extra_kwargs or {}
+    traceparent = _kwargs_value(
+        kwargs,
+        "traceparent",
+        "hermes.kanban.traceparent",
+        "kanban_traceparent",
+        limit=128,
+    ) or _env_value("HERMES_KANBAN_TRACEPARENT", limit=128)
+    if not traceparent:
+        return {}
+    carrier = {"traceparent": traceparent}
+    tracestate = _kwargs_value(
+        kwargs,
+        "tracestate",
+        "hermes.kanban.tracestate",
+        "kanban_tracestate",
+        limit=512,
+    ) or _env_value("HERMES_KANBAN_TRACESTATE", limit=512)
+    if tracestate:
+        carrier["tracestate"] = tracestate
+    return carrier
+
+
+def _kanban_parent_context(extra_kwargs: Optional[dict] = None):
+    if propagate is None:
+        return None
+    carrier = _kanban_trace_carrier(extra_kwargs)
+    if not carrier:
+        return None
+    try:
+        return propagate.extract(carrier)
+    except Exception:
+        return None
+
+
 def _has_explicit_kanban_kwargs(extra_kwargs: Optional[dict]) -> bool:
     kwargs = extra_kwargs or {}
-    return any(key.startswith("hermes.kanban.") or key.startswith("kanban_") for key in kwargs)
+    return any(
+        key.startswith("hermes.kanban.")
+        or key.startswith("kanban_")
+        or key in {"traceparent", "tracestate"}
+        for key in kwargs
+    )
 
 
 def _kanban_context_from_kwargs_env(extra_kwargs: Optional[dict] = None) -> Dict[str, Any]:
@@ -338,6 +386,12 @@ def _kanban_context_from_kwargs_env(extra_kwargs: Optional[dict] = None) -> Dict
     ) or _env_value("HERMES_PROFILE", limit=120)
     if assignee:
         attrs["hermes.kanban.assignee"] = assignee
+
+    trace_carrier = _kanban_trace_carrier(kwargs)
+    if trace_carrier.get("traceparent"):
+        attrs["hermes.kanban.traceparent"] = trace_carrier["traceparent"]
+    if trace_carrier.get("tracestate"):
+        attrs["hermes.kanban.tracestate"] = trace_carrier["tracestate"]
 
     source_kind = _kwargs_value(
         kwargs,
@@ -786,6 +840,7 @@ def _start_session_span(
         kind="agent",
         attributes=attributes,
         session_id=session_id,
+        parent_context=_kanban_parent_context(extra_kwargs),
     )
     tracer.spans.push_parent(span, session_id=session_id)
     tracer.register_turn(session_id)
@@ -1486,6 +1541,7 @@ def _on_kanban_lifecycle(event: str, **kwargs) -> None:
         kind="general",
         attributes=attributes,
         session_id=session_id,
+        parent_context=_kanban_parent_context(kwargs),
     )
     tracer.end_span(key, attributes=attributes, status="ok")
 

--- a/hooks.py
+++ b/hooks.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TypedDict
@@ -268,6 +269,37 @@ def _first_text(*values: Any, limit: int = 200) -> str:
     return ""
 
 
+_KANBAN_AUTH_SCHEME_RE = re.compile(
+    r"(?i)\b(authorization)\b\s*[:=]?\s*(?:\S+\s+)?[^\s,;]+|"
+    r"\b(bearer|basic)\b\s+[^\s,;]+"
+)
+_KANBAN_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(api[_-]?key|client[_-]?secret|connect[_-]?token|password|passwd|"
+    r"secret|token)\b\s*[:=]\s*[^\s,;]+"
+)
+_KANBAN_SECRET_VALUE_RE = re.compile(
+    r"(?i)\b(sk-[A-Za-z0-9_-]{8,}|gh[pousr]_[A-Za-z0-9_]{8,}|"
+    r"xox[baprs]-[A-Za-z0-9-]{8,})\b"
+)
+
+
+def _safe_kanban_text(*values: Any, limit: int = 200) -> str:
+    """Return the first non-empty Kanban text value, redacted and clipped."""
+    text = _first_text(*values, limit=limit * 4)
+    if not text:
+        return ""
+    text = re.sub(r"\s+", " ", text).strip()
+    text = _KANBAN_AUTH_SCHEME_RE.sub(
+        lambda m: f"{(m.group(1) or m.group(2))}=[REDACTED]",
+        text,
+    )
+    text = _KANBAN_SECRET_ASSIGNMENT_RE.sub(lambda m: f"{m.group(1)}=[REDACTED]", text)
+    text = _KANBAN_SECRET_VALUE_RE.sub("[REDACTED]", text)
+    if len(text) > limit:
+        return text[: limit - 3] + "..." if limit > 3 else "." * limit
+    return text
+
+
 def _kwargs_value(kwargs: dict, *keys: str, limit: int = 200) -> str:
     return _first_text(*(kwargs.get(key) for key in keys), limit=limit)
 
@@ -371,6 +403,14 @@ def _kanban_context_from_kwargs_env(extra_kwargs: Optional[dict] = None) -> Dict
         attrs["hermes.kanban.task.id"] = task_id
     if run_id:
         attrs["hermes.kanban.run.id"] = run_id
+    title = _safe_kanban_text(
+        kwargs.get("hermes.kanban.task.title"),
+        kwargs.get("kanban_task_title"),
+        kwargs.get("task_title"),
+        kwargs.get("title"),
+    )
+    if title:
+        attrs["hermes.kanban.task.title"] = title
     if board:
         attrs["hermes.kanban.board"] = board
     if tenant:
@@ -404,6 +444,21 @@ def _kanban_context_from_kwargs_env(extra_kwargs: Optional[dict] = None) -> Dict
     ) or _env_value("HERMES_KANBAN_SOURCE_KIND", limit=120)
     if source_kind:
         attrs["hermes.kanban.source.kind"] = source_kind
+
+    summary = _safe_kanban_text(
+        kwargs.get("hermes.kanban.summary"),
+        kwargs.get("kanban_summary"),
+        kwargs.get("summary"),
+    )
+    if summary:
+        attrs["hermes.kanban.summary"] = summary
+    reason = _safe_kanban_text(
+        kwargs.get("hermes.kanban.reason"),
+        kwargs.get("kanban_reason"),
+        kwargs.get("reason"),
+    )
+    if reason:
+        attrs["hermes.kanban.reason"] = reason
 
     return attrs
 

--- a/hooks.py
+++ b/hooks.py
@@ -12,7 +12,9 @@ routed through the tracer singleton so test reset is just
 from __future__ import annotations
 
 import json
+import os
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional, TypedDict
 
 from .debug_utils import debug_log
@@ -248,12 +250,37 @@ def _gen_ai_attributes(
 ) -> Dict[str, str]:
     """Return common OpenTelemetry GenAI attributes."""
     attrs: Dict[str, str] = {
+        "gen_ai.agent.name": _agent_name(extra_kwargs or {}),
         "gen_ai.operation.name": operation_name,
     }
     session_text = truncate_string(session_id, 200)
     if session_text:
         attrs["gen_ai.conversation.id"] = session_text
     return attrs
+
+
+def _agent_name(extra_kwargs: dict) -> str:
+    """Return the active Hermes profile/agent name for GenAI telemetry."""
+    for key in ("agent_name", "profile", "hermes_profile", "gen_ai.agent.name"):
+        raw = extra_kwargs.get(key)
+        value = truncate_string(raw, 120) if raw is not None else ""
+        if value:
+            return value
+
+    raw_profile = os.getenv("HERMES_PROFILE")
+    value = truncate_string(raw_profile, 120) if raw_profile is not None else ""
+    if value:
+        return value
+
+    raw_home = os.getenv("HERMES_HOME")
+    hermes_home = truncate_string(raw_home, 500) if raw_home is not None else ""
+    if hermes_home:
+        path = Path(hermes_home)
+        value = "default" if path.name == ".hermes" else truncate_string(path.name, 120)
+        if value:
+            return value
+
+    return "hermes-agent"
 
 
 def _provider_attributes(provider: Any) -> Dict[str, str]:

--- a/hooks.py
+++ b/hooks.py
@@ -56,6 +56,13 @@ class HookContext(TypedDict, total=False):
     trigger: str
     job_id: str
     cron_job_id: str
+    kanban_task_id: str
+    kanban_run_id: str
+    kanban_board: str
+    kanban_tenant: str
+    kanban_assignee: str
+    kanban_flow_kind: str
+    kanban_source_kind: str
 
 
 _MAX_SUMMARY_CHARS = 500
@@ -241,6 +248,125 @@ def _detect_session_kind(platform: str, kwargs: dict) -> str:
         return "cron"
 
     return "session"
+
+
+def _first_text(*values: Any, limit: int = 200) -> str:
+    """Return the first non-empty scalar value, safely stringified and clipped."""
+    for raw in values:
+        if isinstance(raw, bool) or raw is None:
+            continue
+        value = str(raw).strip()
+        if value:
+            return truncate_string(value, limit)
+    return ""
+
+
+def _kwargs_value(kwargs: dict, *keys: str, limit: int = 200) -> str:
+    return _first_text(*(kwargs.get(key) for key in keys), limit=limit)
+
+
+def _env_value(*keys: str, limit: int = 200) -> str:
+    return _first_text(*(os.getenv(key) for key in keys), limit=limit)
+
+
+def _has_explicit_kanban_kwargs(extra_kwargs: Optional[dict]) -> bool:
+    kwargs = extra_kwargs or {}
+    return any(key.startswith("hermes.kanban.") or key.startswith("kanban_") for key in kwargs)
+
+
+def _kanban_context_from_kwargs_env(extra_kwargs: Optional[dict] = None) -> Dict[str, Any]:
+    """Resolve safe Hermes Kanban context from hook kwargs first, then env.
+
+    The resolver intentionally emits one canonical dotted ``hermes.kanban.*``
+    field per concept and only returns attributes when a real Kanban marker is
+    present. ``HERMES_PROFILE`` alone is not enough to imply Kanban context.
+    """
+    kwargs = extra_kwargs or {}
+    task_id = _kwargs_value(
+        kwargs,
+        "hermes.kanban.task.id",
+        "kanban_task_id",
+        "kanban_task",
+    ) or _env_value("HERMES_KANBAN_TASK")
+    run_id = _kwargs_value(
+        kwargs,
+        "hermes.kanban.run.id",
+        "kanban_run_id",
+    ) or _env_value("HERMES_KANBAN_RUN_ID")
+    board = _kwargs_value(
+        kwargs,
+        "hermes.kanban.board",
+        "kanban_board",
+    ) or _env_value("HERMES_KANBAN_BOARD")
+    tenant = _kwargs_value(
+        kwargs,
+        "hermes.kanban.tenant",
+        "kanban_tenant",
+    ) or _env_value("HERMES_TENANT")
+
+    # HERMES_TENANT can be useful in Kanban workers, but tenant alone is not
+    # a reliable Kanban marker. Require an explicit task/run/board marker so
+    # non-Kanban tenant-scoped processes do not get misclassified.
+    if not any((task_id, run_id, board)):
+        return {}
+
+    attrs: Dict[str, Any] = {"hermes.kanban.flow.kind": "worker"}
+    flow_kind = _kwargs_value(
+        kwargs,
+        "hermes.kanban.flow.kind",
+        "kanban_flow_kind",
+        "flow_kind",
+    )
+    if flow_kind:
+        attrs["hermes.kanban.flow.kind"] = flow_kind
+    if task_id:
+        attrs["hermes.kanban.task.id"] = task_id
+    if run_id:
+        attrs["hermes.kanban.run.id"] = run_id
+    if board:
+        attrs["hermes.kanban.board"] = board
+    if tenant:
+        attrs["hermes.kanban.tenant"] = tenant
+
+    assignee = _kwargs_value(
+        kwargs,
+        "hermes.kanban.assignee",
+        "kanban_assignee",
+        "assignee",
+        "profile",
+        "hermes_profile",
+    ) or _env_value("HERMES_PROFILE", limit=120)
+    if assignee:
+        attrs["hermes.kanban.assignee"] = assignee
+
+    source_kind = _kwargs_value(
+        kwargs,
+        "hermes.kanban.source.kind",
+        "kanban_source_kind",
+        "source_kind",
+        "source",
+        "origin",
+        limit=120,
+    ) or _env_value("HERMES_KANBAN_SOURCE_KIND", limit=120)
+    if source_kind:
+        attrs["hermes.kanban.source.kind"] = source_kind
+
+    return attrs
+
+
+def _kanban_attributes(tracer, session_id: Optional[str], extra_kwargs: Optional[dict]) -> Dict[str, Any]:
+    """Return Kanban attrs, reusing per-session context when hooks omit kwargs."""
+    has_explicit_kwargs = _has_explicit_kanban_kwargs(extra_kwargs)
+    incoming = _kanban_context_from_kwargs_env(extra_kwargs)
+    if session_id:
+        ps = tracer.sessions.get_or_create(session_id)
+        if ps.kanban_attrs and not has_explicit_kwargs:
+            return dict(ps.kanban_attrs)
+        if incoming:
+            ps.kanban_attrs = dict(incoming)
+        elif ps.kanban_attrs:
+            return dict(ps.kanban_attrs)
+    return incoming
 
 
 def _preview(value: Any, max_chars: int) -> Optional[str]:
@@ -646,6 +772,7 @@ def _start_session_span(
     attributes.update(_provider_attributes(extra_kwargs.get("provider") or platform))
     attributes.update(_gen_ai_attributes(session_id, "invoke_agent", extra_kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, extra_kwargs))
+    attributes.update(_kanban_attributes(tracer, session_id, extra_kwargs))
     if synthesized:
         attributes["hermes.session.synthesized"] = True
 
@@ -713,6 +840,7 @@ def on_session_end(
     attributes.update(_provider_attributes(kwargs.get("provider") or platform))
     attributes.update(_gen_ai_attributes(session_id, "invoke_agent", kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
+    attributes.update(_kanban_attributes(tracer, session_id, kwargs))
 
     # Drain the aggregators in one shot. Everything this session buffered
     # — I/O, usage totals, turn summary — comes back in a single PerSession.
@@ -841,6 +969,7 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
         summary.add_target(target)
         summary.add_command(command)
         summary.add_skill(skill)
+    attributes.update(_kanban_attributes(tracer, session_id, kwargs))
 
     tracer.start_span(
         name=f"tool.{tool_name}",
@@ -930,6 +1059,7 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
         attributes.update(_session_sender_attributes(tracer, session_id))
         summary = tracer.sessions.get_or_create(session_id).turn_summary
         summary.add_outcome(outcome)
+    attributes.update(_kanban_attributes(tracer, session_id, kwargs))
 
     # Map outcome to span status. Only "error" is ERROR; other non-ok outcomes
     # (timeout, blocked, ...) are OK to avoid polluting error rates.
@@ -994,6 +1124,7 @@ def on_pre_llm_call(
     attributes.update(_provider_attributes(platform))
     attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
+    attributes.update(_kanban_attributes(tracer, session_id, kwargs))
 
     if tracer.config.capture_sender_id:
         sender_id = truncate_string(kwargs.get("sender_id"), 200)
@@ -1093,6 +1224,7 @@ def on_post_llm_call(
     attributes.update(_provider_attributes(platform))
     attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
+    attributes.update(_kanban_attributes(tracer, session_id, kwargs))
     preview = _preview(
         assistant_response,
         tracer.config.llm_output_preview_max_chars or tracer.config.preview_max_chars,
@@ -1151,6 +1283,7 @@ def on_pre_api_request(
     attributes.update(_gen_ai_request_param_attributes(kwargs))
     attributes.update(_server_attributes(base_url))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
+    attributes.update(_kanban_attributes(tracer, session_id, kwargs))
     if max_tokens:
         attributes["gen_ai.request.max_tokens"] = max_tokens
 
@@ -1211,6 +1344,7 @@ def on_api_request_error(
     attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
     attributes.update(_server_attributes(base_url))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
+    attributes.update(_kanban_attributes(tracer, session_id, kwargs))
 
     tracer.spans.pop_parent(session_id=session_id)
     tracer.end_span(key, attributes=attributes, status="error", error_message=error_message)
@@ -1257,6 +1391,7 @@ def on_post_api_request(
     if response_id:
         attributes["gen_ai.response.id"] = truncate_string(response_id, 200)
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
+    attributes.update(_kanban_attributes(tracer, session_id, kwargs))
 
     # Token usage — canonical GenAI attributes only (no compatibility aliases).
     if usage:
@@ -1328,3 +1463,56 @@ def on_post_api_request(
     # Mark as OK
     tracer.end_span(key, attributes=attributes, status="ok")
     debug_log(f"  API span ended: status=ok, tokens={usage.get('total_tokens', 0) if usage else 0}")
+
+
+def _on_kanban_lifecycle(event: str, **kwargs) -> None:
+    """Emit a short span for Hermes Kanban lifecycle hook notifications."""
+    tracer = get_tracer()
+    if not tracer.is_enabled:
+        return
+
+    session_id = kwargs.get("session_id")
+    attributes = _kanban_attributes(tracer, session_id, kwargs)
+    if not attributes:
+        attributes = _kanban_context_from_kwargs_env(kwargs)
+    attributes["hermes.kanban.lifecycle.event"] = event
+
+    task_id = attributes.get("hermes.kanban.task.id") or kwargs.get("task_id") or "unknown"
+    run_id = attributes.get("hermes.kanban.run.id") or kwargs.get("run_id") or ""
+    key = f"kanban.lifecycle:{event}:{task_id}:{run_id}:{time.perf_counter_ns()}"
+    tracer.start_span(
+        name=f"kanban.task.{event}",
+        key=key,
+        kind="general",
+        attributes=attributes,
+        session_id=session_id,
+    )
+    tracer.end_span(key, attributes=attributes, status="ok")
+
+
+def _kanban_kwargs_from_args(args: tuple, kwargs: dict) -> dict:
+    merged = dict(kwargs)
+    if args:
+        merged.setdefault("kanban_task_id", args[0])
+    if len(args) > 1:
+        merged.setdefault("kanban_run_id", args[1])
+    if "task_id" in merged:
+        merged.setdefault("kanban_task_id", merged["task_id"])
+    if "run_id" in merged:
+        merged.setdefault("kanban_run_id", merged["run_id"])
+    return merged
+
+
+def on_kanban_task_claimed(*args, **kwargs):
+    kwargs = _kanban_kwargs_from_args(args, kwargs)
+    _on_kanban_lifecycle("claimed", **kwargs)
+
+
+def on_kanban_task_completed(*args, **kwargs):
+    kwargs = _kanban_kwargs_from_args(args, kwargs)
+    _on_kanban_lifecycle("completed", **kwargs)
+
+
+def on_kanban_task_blocked(*args, **kwargs):
+    kwargs = _kanban_kwargs_from_args(args, kwargs)
+    _on_kanban_lifecycle("blocked", **kwargs)

--- a/hooks.py
+++ b/hooks.py
@@ -71,6 +71,8 @@ class HookContext(TypedDict, total=False):
     kanban_source_kind: str
     traceparent: str
     tracestate: str
+    gen_ai_conversation_id: str
+    conversation_id: str
 
 
 _MAX_SUMMARY_CHARS = 500
@@ -308,6 +310,31 @@ def _env_value(*keys: str, limit: int = 200) -> str:
     return _first_text(*(os.getenv(key) for key in keys), limit=limit)
 
 
+def _conversation_id_from_kwargs_env(extra_kwargs: Optional[dict] = None) -> str:
+    """Return an explicitly propagated GenAI conversation id, if present.
+
+    Hermes creates a fresh ``session_id`` for many independent processes
+    (subagents, workers, explicit spawned CLIs).  When the parent process can
+    pass the user-visible conversation boundary through kwargs or env, keep
+    ``gen_ai.conversation.id`` stable while leaving ``correlation.id`` free to
+    describe the local process/session.
+    """
+    kwargs = extra_kwargs or {}
+    return _kwargs_value(
+        kwargs,
+        "gen_ai.conversation.id",
+        "gen_ai_conversation_id",
+        "conversation_id",
+        "conversation.id",
+        "parent_conversation_id",
+        limit=200,
+    ) or _env_value(
+        "HERMES_OTEL_CONVERSATION_ID",
+        "HERMES_PARENT_CONVERSATION_ID",
+        limit=200,
+    )
+
+
 def _kanban_trace_carrier(extra_kwargs: Optional[dict] = None) -> Dict[str, str]:
     kwargs = extra_kwargs or {}
     traceparent = _kwargs_value(
@@ -504,6 +531,7 @@ def _session_sender_attributes(tracer, session_id: Optional[str]) -> Dict[str, s
 
 
 def _gen_ai_attributes(
+    tracer,
     session_id: Optional[str],
     operation_name: str,
     extra_kwargs: Optional[dict] = None,
@@ -514,8 +542,16 @@ def _gen_ai_attributes(
         "gen_ai.operation.name": operation_name,
     }
     session_text = truncate_string(session_id, 200) if session_id is not None else ""
-    if session_text:
-        attrs["gen_ai.conversation.id"] = session_text
+    incoming_conversation_id = _conversation_id_from_kwargs_env(extra_kwargs)
+    conversation_id = incoming_conversation_id or session_text
+    if session_id and hasattr(tracer, "sessions"):
+        ps = tracer.sessions.get_or_create(session_id)
+        if incoming_conversation_id:
+            ps.conversation_id = incoming_conversation_id
+        elif ps.conversation_id:
+            conversation_id = ps.conversation_id
+    if conversation_id:
+        attrs["gen_ai.conversation.id"] = conversation_id
     compacted = _conversation_compacted_value(extra_kwargs or {})
     if compacted is not None:
         attrs["gen_ai.conversation.compacted"] = compacted
@@ -762,7 +798,8 @@ def _add_payload_event(
 
 def _agent_span_name(operation_name: str, extra_kwargs: dict) -> str:
     """Return the Honeycomb Agent Timeline span name for an agent operation."""
-    return operation_name
+    agent_text = truncate_string(_agent_name(extra_kwargs), 200)
+    return f"{operation_name} {agent_text}" if agent_text else operation_name
 
 
 def _model_span_name(operation_name: str, model: Any) -> str:
@@ -937,7 +974,7 @@ def _start_session_span(
         "gen_ai.request.model": truncate_string(model, 200),
     }
     attributes.update(_provider_attributes(extra_kwargs.get("provider") or platform))
-    attributes.update(_gen_ai_attributes(session_id, "invoke_agent", extra_kwargs))
+    attributes.update(_gen_ai_attributes(tracer, session_id, "invoke_agent", extra_kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, extra_kwargs))
     attributes.update(_kanban_attributes(tracer, session_id, extra_kwargs))
     if synthesized:
@@ -1006,7 +1043,7 @@ def on_session_end(
         "gen_ai.response.model": truncate_string(model, 200),
     }
     attributes.update(_provider_attributes(kwargs.get("provider") or platform))
-    attributes.update(_gen_ai_attributes(session_id, "invoke_agent", kwargs))
+    attributes.update(_gen_ai_attributes(tracer, session_id, "invoke_agent", kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
     attributes.update(_kanban_attributes(tracer, session_id, kwargs))
 
@@ -1129,7 +1166,7 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
     # Summary roll-up (requires session_id to bucket into the right turn).
     session_id = kwargs.get("session_id")
     if session_id:
-        attributes.update(_gen_ai_attributes(session_id, "execute_tool", kwargs))
+        attributes.update(_gen_ai_attributes(tracer, session_id, "execute_tool", kwargs))
         attributes.update(_correlation_attributes(tracer, session_id, kwargs))
         attributes.update(_session_sender_attributes(tracer, session_id))
         summary = tracer.sessions.get_or_create(session_id).turn_summary
@@ -1222,7 +1259,7 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
     # Summary roll-up
     session_id = kwargs.get("session_id")
     if session_id:
-        attributes.update(_gen_ai_attributes(session_id, "execute_tool", kwargs))
+        attributes.update(_gen_ai_attributes(tracer, session_id, "execute_tool", kwargs))
         attributes.update(_correlation_attributes(tracer, session_id, kwargs))
         attributes.update(_session_sender_attributes(tracer, session_id))
         summary = tracer.sessions.get_or_create(session_id).turn_summary
@@ -1290,7 +1327,7 @@ def on_pre_llm_call(
         "gen_ai.request.model": truncate_string(model, 200),
     }
     attributes.update(_provider_attributes(platform))
-    attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
+    attributes.update(_gen_ai_attributes(tracer, session_id, "chat", kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
     attributes.update(_kanban_attributes(tracer, session_id, kwargs))
 
@@ -1402,7 +1439,7 @@ def on_post_llm_call(
     # OpenInference attributes — Phoenix Info panel
     attributes: Dict[str, Any] = {"gen_ai.response.model": truncate_string(model, 200)}
     attributes.update(_provider_attributes(platform))
-    attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
+    attributes.update(_gen_ai_attributes(tracer, session_id, "chat", kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
     attributes.update(_kanban_attributes(tracer, session_id, kwargs))
     preview = _preview(
@@ -1470,7 +1507,7 @@ def on_pre_api_request(
         "gen_ai.request.model": truncate_string(model, 200),
     }
     attributes.update(_provider_attributes(provider))
-    attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
+    attributes.update(_gen_ai_attributes(tracer, session_id, "chat", kwargs))
     attributes.update(_gen_ai_request_param_attributes(kwargs))
     attributes.update(_server_attributes(base_url))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
@@ -1546,7 +1583,7 @@ def on_api_request_error(
     if error_message:
         attributes["error.message"] = error_message
     attributes.update(_provider_attributes(provider))
-    attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
+    attributes.update(_gen_ai_attributes(tracer, session_id, "chat", kwargs))
     attributes.update(_server_attributes(base_url))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
     attributes.update(_kanban_attributes(tracer, session_id, kwargs))
@@ -1586,7 +1623,7 @@ def on_post_api_request(
 
     # Build final attributes
     attributes: Dict[str, Any] = {}
-    attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
+    attributes.update(_gen_ai_attributes(tracer, session_id, "chat", kwargs))
     attributes.update(_provider_attributes(provider))
     attributes.update(_server_attributes(base_url))
     response_model_value = response_model or model

--- a/hooks.py
+++ b/hooks.py
@@ -16,6 +16,7 @@ import os
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TypedDict
+from urllib.parse import urlparse
 
 from .debug_utils import debug_log
 from .helpers import (
@@ -118,6 +119,7 @@ _USAGE_FIELDS = (
     "total_tokens",
     "cache_read_tokens",
     "cache_write_tokens",
+    "reasoning_output_tokens",
 )
 
 
@@ -129,6 +131,8 @@ def _normalize_usage(usage: dict) -> Dict[str, int]:
     the reported value or sum(prompt, completion) when absent. Returns all
     five canonical fields, zero-filled.
     """
+    details = usage.get("output_tokens_details")
+    reasoning_from_details = details.get("reasoning_tokens") if isinstance(details, dict) else 0
     completion = _to_int(usage.get("output_tokens") or usage.get("completion_tokens", 0))
     prompt = _to_int(usage.get("prompt_tokens") or usage.get("input_tokens", 0))
     total = _to_int(usage.get("total_tokens", 0)) or (prompt + completion)
@@ -138,6 +142,11 @@ def _normalize_usage(usage: dict) -> Dict[str, int]:
         "total_tokens": total,
         "cache_read_tokens": _to_int(usage.get("cache_read_tokens")),
         "cache_write_tokens": _to_int(usage.get("cache_write_tokens")),
+        "reasoning_output_tokens": _to_int(
+            usage.get("reasoning_output_tokens")
+            or usage.get("reasoning_tokens")
+            or reasoning_from_details
+        ),
     }
 
 
@@ -175,6 +184,9 @@ def _usage_attributes(totals: Dict[str, int]) -> Dict[str, Any]:
         attrs["llm.token_count.prompt_details.cache_write"] = cache_write
         attrs["gen_ai.usage.cache_creation.input_tokens"] = cache_write
         attrs["gen_ai.usage.cache_creation_input_tokens"] = cache_write
+    reasoning_output = totals.get("reasoning_output_tokens", 0)
+    if reasoning_output:
+        attrs["gen_ai.usage.reasoning.output_tokens"] = reasoning_output
     return attrs
 
 
@@ -247,16 +259,40 @@ def _gen_ai_attributes(
     session_id: Optional[str],
     operation_name: str,
     extra_kwargs: Optional[dict] = None,
-) -> Dict[str, str]:
+) -> Dict[str, Any]:
     """Return common OpenTelemetry GenAI attributes."""
-    attrs: Dict[str, str] = {
+    attrs: Dict[str, Any] = {
         "gen_ai.agent.name": _agent_name(extra_kwargs or {}),
         "gen_ai.operation.name": operation_name,
     }
     session_text = truncate_string(session_id, 200)
     if session_text:
         attrs["gen_ai.conversation.id"] = session_text
+    compacted = _conversation_compacted_value(extra_kwargs or {})
+    if compacted is not None:
+        attrs["gen_ai.conversation.compacted"] = compacted
     return attrs
+
+
+def _conversation_compacted_value(extra_kwargs: dict) -> Optional[bool]:
+    """Return explicit conversation-compaction state when Hermes provides it.
+
+    We deliberately do not infer compaction from message counts or history
+    shape: the spec field should only be sent when the caller explicitly tells
+    us whether compaction happened.
+    """
+    for key in (
+        "gen_ai.conversation.compacted",
+        "conversation_compacted",
+        "compacted",
+        "is_compacted",
+        "was_compacted",
+        "session_compacted",
+        "compaction_occurred",
+    ):
+        if key in extra_kwargs and isinstance(extra_kwargs[key], bool):
+            return extra_kwargs[key]
+    return None
 
 
 def _agent_name(extra_kwargs: dict) -> str:
@@ -351,6 +387,101 @@ def _gen_ai_request_param_attributes(kwargs: dict) -> Dict[str, Any]:
         except (TypeError, ValueError):
             pass
     return attrs
+
+
+def _server_attributes(base_url: Any) -> Dict[str, Any]:
+    """Extract low-cardinality server.address/server.port from a provider URL."""
+    value = truncate_string(base_url, 500) if base_url is not None else ""
+    if not value:
+        return {}
+    parsed = urlparse(value if "://" in value else f"//{value}")
+    host = parsed.hostname
+    if not host:
+        return {}
+    attrs: Dict[str, Any] = {"server.address": truncate_string(host, 255)}
+    if parsed.port is not None:
+        attrs["server.port"] = parsed.port
+    return attrs
+
+
+def _response_time_to_first_chunk(kwargs: dict) -> Optional[float]:
+    """Return streaming TTFC seconds when the host provides a numeric value."""
+    for key in (
+        "time_to_first_chunk",
+        "time_to_first_chunk_seconds",
+        "response_time_to_first_chunk",
+        "gen_ai.response.time_to_first_chunk",
+    ):
+        value = _optional_number(kwargs.get(key))
+        if value is not None:
+            return value
+    ttfc_ms = _optional_number(kwargs.get("time_to_first_chunk_ms"))
+    if ttfc_ms is not None:
+        return ttfc_ms / 1000.0
+    return None
+
+
+def _error_type(value: Any = None, default: str = "error") -> str:
+    """Return a bounded, non-sensitive error.type value."""
+    if isinstance(value, BaseException):
+        return truncate_string(type(value).__name__, 120)
+    if isinstance(value, dict):
+        for key in ("error_type", "type", "code", "status_code"):
+            raw = value.get(key)
+            text = truncate_string(raw, 120) if raw is not None else ""
+            if text:
+                return text
+    return truncate_string(default, 120) or "error"
+
+
+def _tool_type(tool_name: str, args: dict, kwargs: dict) -> str:
+    """Return a best-effort GenAI tool type without exposing arguments."""
+    explicit = kwargs.get("tool_type") or (args.get("tool_type") if isinstance(args, dict) else None)
+    explicit_text = truncate_string(explicit, 120) if explicit is not None else ""
+    if explicit_text:
+        return explicit_text
+    if tool_name.startswith("mcp_"):
+        return "mcp"
+    return "function"
+
+
+def _tool_call_id(tool_name: str, task_id: str, args: dict, kwargs: dict) -> str:
+    """Resolve the stable tool-call identifier from hook metadata."""
+    for value in (
+        kwargs.get("tool_call_id"),
+        kwargs.get("call_id"),
+        kwargs.get("gen_ai.tool.call.id"),
+        args.get("tool_call_id") if isinstance(args, dict) else None,
+        args.get("call_id") if isinstance(args, dict) else None,
+        task_id,
+    ):
+        text = truncate_string(value, 200) if value is not None else ""
+        if text:
+            return text
+    return truncate_string(f"{tool_name}:{task_id}", 200)
+
+
+def _add_inference_details_event(span: Any, attributes: Dict[str, Any]) -> None:
+    """Attach the standard GenAI inference details event when supported."""
+    if span is None or not hasattr(span, "add_event"):
+        return
+    excluded = {
+        "gen_ai.input.messages",
+        "gen_ai.output.messages",
+        "gen_ai.system_instructions",
+    }
+    event_attrs = {
+        key: value
+        for key, value in attributes.items()
+        if key not in excluded
+        and (key.startswith("gen_ai.") or key in {"server.address", "server.port", "error.type"})
+    }
+    if not event_attrs:
+        return
+    try:
+        span.add_event("gen_ai.client.inference.operation.details", event_attrs)
+    except Exception:
+        pass
 
 
 def _extract_correlation_id(extra_kwargs: dict) -> str:
@@ -604,6 +735,8 @@ def on_session_end(
             attributes["hermes.turn.final_status"] = "incomplete"
 
     status = "ok" if completed or interrupted else "error"
+    if status == "error":
+        attributes["error.type"] = _error_type(kwargs, default="session_error")
 
     tracer.spans.pop_parent(session_id=session_id)
     tracer.end_span(key, attributes=attributes, status=status)
@@ -636,6 +769,8 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
     attributes: Dict[str, Any] = {
         "tool.name": tool_name,
         "gen_ai.tool.name": tool_name,
+        "gen_ai.tool.type": _tool_type(tool_name, args, kwargs),
+        "gen_ai.tool.call.id": _tool_call_id(tool_name, task_id, args, kwargs),
     }
     preview = _preview(
         json.dumps(args) if args else "{}",
@@ -724,11 +859,13 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
     # Determine outcome taxonomy
     outcome = extract_tool_result_status(result_json) or "completed"
     attributes["hermes.tool.outcome"] = outcome
+    attributes["gen_ai.tool.call.id"] = _tool_call_id(tool_name, task_id, args, kwargs)
 
     # Preserve existing error.message attribute when outcome == error
     has_error = outcome == "error"
     error_msg = ""
     if has_error and isinstance(result_json, dict):
+        attributes["error.type"] = _error_type(result_json, default="tool_error")
         err_val = result_json.get("error")
         if err_val:
             error_msg = truncate_string(err_val, 500)
@@ -985,6 +1122,7 @@ def on_pre_api_request(
     attributes.update(_provider_attributes(provider))
     attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
     attributes.update(_gen_ai_request_param_attributes(kwargs))
+    attributes.update(_server_attributes(base_url))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
     if max_tokens:
         attributes["llm.request.max_tokens"] = max_tokens
@@ -1012,10 +1150,49 @@ def on_pre_api_request(
         attributes=attributes,
         session_id=session_id,
     )
+    _add_inference_details_event(span, attributes)
 
     # Push as parent — tool spans during this API call will nest under it
     tracer.spans.push_parent(span, session_id=session_id)
     debug_log(f"  API span started: key={key}")
+
+
+def on_api_request_error(
+    task_id: str,
+    session_id: str,
+    platform: str = "",
+    model: str = "",
+    provider: str = "",
+    base_url: str = "",
+    api_mode: str = "",
+    error: Any = None,
+    **kwargs,
+):
+    """Fires when an individual LLM API request raises before post_api_request."""
+    debug_log(f"api_request_error fired: model={model}, provider={provider}, session={session_id}")
+    tracer = get_tracer()
+    if not tracer.is_enabled:
+        return
+
+    key = f"api:{task_id}"
+    error_message = truncate_string(error, 500) if error is not None else ""
+    attributes: Dict[str, Any] = {
+        "llm.model_name": model,
+        "llm.provider": provider,
+        "llm.api_mode": api_mode,
+        "gen_ai.request.model": truncate_string(model, 200),
+        "error.type": _error_type(error or kwargs, default="api_request_error"),
+    }
+    if error_message:
+        attributes["error.message"] = error_message
+    attributes.update(_provider_attributes(provider))
+    attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
+    attributes.update(_server_attributes(base_url))
+    attributes.update(_correlation_attributes(tracer, session_id, kwargs))
+
+    tracer.spans.pop_parent(session_id=session_id)
+    tracer.end_span(key, attributes=attributes, status="error", error_message=error_message)
+    debug_log(f"  API span ended: status=error, error.type={attributes['error.type']}")
 
 
 def on_post_api_request(
@@ -1050,6 +1227,7 @@ def on_post_api_request(
     attributes: Dict[str, Any] = {}
     attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
     attributes.update(_provider_attributes(provider))
+    attributes.update(_server_attributes(base_url))
     response_model_value = response_model or model
     if response_model_value:
         attributes["gen_ai.response.model"] = truncate_string(response_model_value, 200)
@@ -1092,6 +1270,9 @@ def on_post_api_request(
     if finish_reason:
         attributes["llm.response.finish_reason"] = finish_reason
         attributes["gen_ai.response.finish_reasons"] = [finish_reason]
+    ttfc = _response_time_to_first_chunk(kwargs)
+    if ttfc is not None:
+        attributes["gen_ai.response.time_to_first_chunk"] = ttfc
     if assistant_content_chars:
         attributes["llm.response.output_chars"] = assistant_content_chars
     if assistant_tool_call_count:

--- a/hooks.py
+++ b/hooks.py
@@ -151,39 +151,26 @@ def _normalize_usage(usage: dict) -> Dict[str, int]:
 
 
 def _usage_attributes(totals: Dict[str, int]) -> Dict[str, Any]:
-    """Build dual-convention OTel attributes from canonical token totals.
+    """Build canonical OTel GenAI usage attributes from token totals.
 
-    Emits both the OTel GenAI convention (``gen_ai.usage.*`` — recognised
-    by Langfuse) and the OpenInference convention (``llm.token_count.*``
-    — recognised by Phoenix). Cache attrs are included only when non-zero
-    so low-traffic spans don't get cluttered with zero fields.
+    Cache attrs are included only when non-zero so low-traffic spans don't
+    get cluttered with zero fields. Compatibility aliases are deliberately
+    not emitted: when a concept has a GenAI semantic-convention field, that
+    field is the single source of truth.
     """
     prompt = totals["prompt_tokens"]
     completion = totals["completion_tokens"]
-    total = totals["total_tokens"]
     cache_read = totals["cache_read_tokens"]
     cache_write = totals["cache_write_tokens"]
 
     attrs: Dict[str, Any] = {
-        # OpenInference (Phoenix)
-        "llm.token_count.prompt": prompt,
-        "llm.token_count.completion": completion,
-        "llm.token_count.total": total,
-        # OTel GenAI (Langfuse)
         "gen_ai.usage.input_tokens": prompt,
         "gen_ai.usage.output_tokens": completion,
-        "gen_ai.usage.total_tokens": total,
     }
     if cache_read:
-        attrs["llm.token_count.prompt_details.cache_read"] = cache_read
-        # Current OTel GenAI spelling, plus the pre-existing alias for
-        # backwards compatibility with dashboards created before this change.
         attrs["gen_ai.usage.cache_read.input_tokens"] = cache_read
-        attrs["gen_ai.usage.cache_read_input_tokens"] = cache_read
     if cache_write:
-        attrs["llm.token_count.prompt_details.cache_write"] = cache_write
         attrs["gen_ai.usage.cache_creation.input_tokens"] = cache_write
-        attrs["gen_ai.usage.cache_creation_input_tokens"] = cache_write
     reasoning_output = totals.get("reasoning_output_tokens", 0)
     if reasoning_output:
         attrs["gen_ai.usage.reasoning.output_tokens"] = reasoning_output
@@ -193,17 +180,43 @@ def _usage_attributes(totals: Dict[str, int]) -> Dict[str, Any]:
 _USAGE_METRIC_LABELS = (
     ("prompt_tokens", "input"),
     ("completion_tokens", "output"),
-    ("cache_read_tokens", "cacheRead"),
-    ("cache_write_tokens", "cacheCreation"),
 )
 
 
 def _record_usage_metrics(tracer, totals: Dict[str, int], base_attrs: Dict[str, Any]) -> None:
-    """Record one ``token_usage`` metric per non-zero canonical field."""
+    """Record one standard GenAI token-usage metric per non-zero field."""
     for key, label in _USAGE_METRIC_LABELS:
         v = totals.get(key, 0)
         if v:
-            tracer.record_metric("token_usage", v, {**base_attrs, "token_type": label})
+            tracer.record_metric(
+                "gen_ai.client.token.usage",
+                v,
+                {**base_attrs, "gen_ai.token.type": label},
+            )
+
+
+def _metric_attributes(
+    operation_name: str,
+    *,
+    session_id: Optional[str] = None,
+    provider: Any = None,
+    model: Any = None,
+    extra_kwargs: Optional[dict] = None,
+) -> Dict[str, Any]:
+    """Return low-cardinality canonical GenAI attributes for metrics.
+
+    Span-only identifiers such as ``gen_ai.conversation.id`` are intentionally
+    omitted to avoid one metric time series per Hermes turn.
+    """
+    attrs: Dict[str, Any] = {
+        "gen_ai.agent.name": _agent_name(extra_kwargs or {}),
+        "gen_ai.operation.name": operation_name,
+    }
+    attrs.update(_provider_attributes(provider))
+    model_text = truncate_string(model, 200) if model is not None else ""
+    if model_text:
+        attrs["gen_ai.request.model"] = model_text
+    return attrs
 
 
 def _detect_session_kind(platform: str, kwargs: dict) -> str:
@@ -265,7 +278,7 @@ def _gen_ai_attributes(
         "gen_ai.agent.name": _agent_name(extra_kwargs or {}),
         "gen_ai.operation.name": operation_name,
     }
-    session_text = truncate_string(session_id, 200)
+    session_text = truncate_string(session_id, 200) if session_id is not None else ""
     if session_text:
         attrs["gen_ai.conversation.id"] = session_text
     compacted = _conversation_compacted_value(extra_kwargs or {})
@@ -290,8 +303,8 @@ def _conversation_compacted_value(extra_kwargs: dict) -> Optional[bool]:
         "session_compacted",
         "compaction_occurred",
     ):
-        if key in extra_kwargs and isinstance(extra_kwargs[key], bool):
-            return extra_kwargs[key]
+        if key in extra_kwargs and extra_kwargs[key] is True:
+            return True
     return None
 
 
@@ -320,15 +333,13 @@ def _agent_name(extra_kwargs: dict) -> str:
 
 
 def _provider_attributes(provider: Any) -> Dict[str, str]:
-    """Return current and compatibility provider attributes."""
+    """Return canonical GenAI provider attributes."""
+    if provider is None:
+        return {}
     value = truncate_string(provider, 120)
     if not value:
         return {}
-    return {
-        "gen_ai.provider.name": value,
-        # Kept for older OTel drafts and existing dashboards.
-        "gen_ai.system": value,
-    }
+    return {"gen_ai.provider.name": value}
 
 
 def _optional_number(value: Any) -> Optional[float]:
@@ -629,12 +640,7 @@ def _start_session_span(
     key = f"session:{session_id}"
 
     attributes = {
-        "session.id": truncate_string(session_id, 200),
-        "session_id": truncate_string(session_id, 200),
-        "hermes.session_id": truncate_string(session_id, 120),
         "hermes.session.kind": kind,
-        "llm.model_name": truncate_string(model, 200),
-        "llm.provider": truncate_string(platform, 120),
         "gen_ai.request.model": truncate_string(model, 200),
     }
     attributes.update(_provider_attributes(extra_kwargs.get("provider") or platform))
@@ -667,7 +673,17 @@ def on_session_start(session_id: str, model: str, platform: str, **kwargs):
         return
 
     tracer.sweep_expired_turns()
-    tracer.record_metric("session_count", 1, {"session_id": session_id})
+    tracer.record_metric(
+        "session_count",
+        1,
+        _metric_attributes(
+            "invoke_agent",
+            session_id=session_id,
+            provider=kwargs.get("provider") or platform,
+            model=model,
+            extra_kwargs=kwargs,
+        ),
+    )
     _start_session_span(
         session_id,
         model,
@@ -692,8 +708,6 @@ def on_session_end(
     attributes: Dict[str, Any] = {
         "hermes.session.completed": bool(completed),
         "hermes.session.interrupted": bool(interrupted),
-        "llm.model_name": truncate_string(model, 200),
-        "llm.provider": truncate_string(platform, 120),
         "gen_ai.response.model": truncate_string(model, 200),
     }
     attributes.update(_provider_attributes(kwargs.get("provider") or platform))
@@ -733,6 +747,20 @@ def on_session_end(
             attributes["hermes.turn.final_status"] = "interrupted"
         else:
             attributes["hermes.turn.final_status"] = "incomplete"
+
+    started_at = getattr(tracer, "_turn_started_at", {}).get(session_id)
+    if isinstance(started_at, (int, float)):
+        tracer.record_metric(
+            "gen_ai.invoke_agent.duration",
+            max(time.perf_counter() - started_at, 0.0),
+            _metric_attributes(
+                "invoke_agent",
+                session_id=session_id,
+                provider=kwargs.get("provider") or platform,
+                model=model,
+                extra_kwargs=kwargs,
+            ),
+        )
 
     status = "ok" if completed or interrupted else "error"
     if status == "error":
@@ -837,11 +865,18 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
 
     start_time = tracer.sessions.pop_tool_start(key)
     if start_time:
-        duration_ms = (time.perf_counter() - start_time) * 1000
+        duration_s = time.perf_counter() - start_time
         tracer.record_metric(
-            "tool_duration",
-            duration_ms,
-            {"tool_name": tool_name, "gen_ai.tool.name": tool_name},
+            "gen_ai.execute_tool.duration",
+            duration_s,
+            {
+                **_metric_attributes(
+                    "execute_tool",
+                    session_id=kwargs.get("session_id"),
+                    extra_kwargs=kwargs,
+                ),
+                "gen_ai.tool.name": tool_name,
+            },
         )
 
     # Build final attributes — OpenInference conventions for Phoenix Info
@@ -954,10 +989,6 @@ def on_pre_llm_call(
 
     # OpenInference attributes — Phoenix Info panel
     attributes: Dict[str, Any] = {
-        "session.id": truncate_string(session_id, 200),
-        "session_id": truncate_string(session_id, 200),
-        "llm.model_name": model,
-        "llm.provider": platform,
         "gen_ai.request.model": truncate_string(model, 200),
     }
     attributes.update(_provider_attributes(platform))
@@ -1050,15 +1081,15 @@ def on_post_llm_call(
             )
 
     tracer.record_metric(
-        "message_count", 1, {"session_id": session_id, "model": model, "provider": platform}
+        "message_count",
+        1,
+        _metric_attributes(
+            "chat", session_id=session_id, provider=platform, model=model, extra_kwargs=kwargs
+        ),
     )
 
     # OpenInference attributes — Phoenix Info panel
-    attributes: Dict[str, Any] = {
-        "session.id": truncate_string(session_id, 200),
-        "session_id": truncate_string(session_id, 200),
-        "gen_ai.response.model": truncate_string(model, 200),
-    }
+    attributes: Dict[str, Any] = {"gen_ai.response.model": truncate_string(model, 200)}
     attributes.update(_provider_attributes(platform))
     attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
@@ -1110,13 +1141,9 @@ def on_pre_api_request(
 
     # OpenInference attributes — Phoenix Info panel
     attributes = {
-        "session.id": truncate_string(session_id, 200),
-        "session_id": truncate_string(session_id, 200),
-        "llm.model_name": model,
-        "llm.provider": provider,
-        "llm.api_mode": api_mode,
-        "llm.request.message_count": message_count,
-        "llm.request.approx_input_tokens": approx_input_tokens,
+        "hermes.api.mode": api_mode,
+        "hermes.request.message_count": message_count,
+        "hermes.request.approx_input_tokens": approx_input_tokens,
         "gen_ai.request.model": truncate_string(model, 200),
     }
     attributes.update(_provider_attributes(provider))
@@ -1125,7 +1152,6 @@ def on_pre_api_request(
     attributes.update(_server_attributes(base_url))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
     if max_tokens:
-        attributes["llm.request.max_tokens"] = max_tokens
         attributes["gen_ai.request.max_tokens"] = max_tokens
 
     attributes.update(_session_sender_attributes(tracer, session_id))
@@ -1135,12 +1161,10 @@ def on_pre_api_request(
         system_prompt = kwargs.get("system_prompt")
         serialized = _serialize_full(messages)
         if serialized is not None:
-            attributes["llm.input_messages"] = serialized
             attributes["gen_ai.input.messages"] = serialized
             attributes["input.value"] = serialized
             attributes["input.mime_type"] = "application/json"
         if system_prompt:
-            attributes["llm.system_prompt"] = str(system_prompt)
             attributes["gen_ai.system_instructions"] = str(system_prompt)
 
     span = tracer.start_span(
@@ -1177,9 +1201,7 @@ def on_api_request_error(
     key = f"api:{task_id}"
     error_message = truncate_string(error, 500) if error is not None else ""
     attributes: Dict[str, Any] = {
-        "llm.model_name": model,
-        "llm.provider": provider,
-        "llm.api_mode": api_mode,
+        "hermes.api.mode": api_mode,
         "gen_ai.request.model": truncate_string(model, 200),
         "error.type": _error_type(error or kwargs, default="api_request_error"),
     }
@@ -1236,8 +1258,7 @@ def on_post_api_request(
         attributes["gen_ai.response.id"] = truncate_string(response_id, 200)
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
 
-    # Token usage — dual convention (gen_ai.usage.* + llm.token_count.*).
-    # See _usage_attributes for the full attribute list.
+    # Token usage — canonical GenAI attributes only (no compatibility aliases).
     if usage:
         totals = _normalize_usage(usage)
         attributes.update(_usage_attributes(totals))
@@ -1250,9 +1271,9 @@ def on_post_api_request(
             ps.usage_updated = True
 
         # Record metrics
-        metric_attrs: Dict[str, Any] = {"model": model, "provider": provider}
-        if session_id:
-            metric_attrs["session_id"] = session_id
+        metric_attrs = _metric_attributes(
+            "chat", session_id=session_id, provider=provider, model=model, extra_kwargs=kwargs
+        )
         _record_usage_metrics(tracer, totals, metric_attrs)
 
         cost = usage.get("cost")
@@ -1262,28 +1283,32 @@ def on_post_api_request(
             except (ValueError, TypeError):
                 pass
 
-        tracer.record_metric("model_usage", 1, {"model": model, "provider": provider})
+        tracer.record_metric("model_usage", 1, metric_attrs)
 
     # Performance metrics
     if api_duration:
-        attributes["llm.response.duration_ms"] = round(api_duration * 1000, 1)
+        tracer.record_metric(
+            "gen_ai.client.operation.duration",
+            api_duration,
+            _metric_attributes(
+                "chat", session_id=session_id, provider=provider, model=model, extra_kwargs=kwargs
+            ),
+        )
     if finish_reason:
-        attributes["llm.response.finish_reason"] = finish_reason
         attributes["gen_ai.response.finish_reasons"] = [finish_reason]
     ttfc = _response_time_to_first_chunk(kwargs)
     if ttfc is not None:
         attributes["gen_ai.response.time_to_first_chunk"] = ttfc
     if assistant_content_chars:
-        attributes["llm.response.output_chars"] = assistant_content_chars
+        attributes["hermes.response.output_chars"] = assistant_content_chars
     if assistant_tool_call_count:
-        attributes["llm.response.tool_calls"] = assistant_tool_call_count
+        attributes["hermes.response.tool_calls"] = assistant_tool_call_count
 
     if tracer.config.capture_full_responses:
         response_content = kwargs.get("response_content")
         response_tool_calls = kwargs.get("response_tool_calls")
         if response_content:
             response_text = str(response_content)
-            attributes["llm.output.content"] = response_text
             attributes["gen_ai.output.messages"] = json.dumps(
                 [{"role": "assistant", "content": response_text}],
                 ensure_ascii=False,
@@ -1292,7 +1317,6 @@ def on_post_api_request(
             attributes["output.mime_type"] = "text/plain"
         tool_calls_serialized = _serialize_full(response_tool_calls)
         if tool_calls_serialized is not None:
-            attributes["llm.output.tool_calls"] = tool_calls_serialized
             if not response_content:
                 attributes["gen_ai.output.messages"] = tool_calls_serialized
                 attributes["output.value"] = tool_calls_serialized

--- a/hooks.py
+++ b/hooks.py
@@ -730,6 +730,64 @@ def _add_inference_details_event(span: Any, attributes: Dict[str, Any]) -> None:
         pass
 
 
+def _add_payload_event(
+    span: Any,
+    name: str,
+    payload: Any,
+    *,
+    mime_type: Optional[str] = None,
+    extra_attributes: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Attach a Honeycomb Agent Timeline payload event when supported.
+
+    Full prompts/responses can be large and private, so callers only reach
+    this helper after their explicit capture gates pass. The payload lives on
+    a span event (not a span attribute) so Agent Timeline can render the
+    message while regular span attributes stay compact and query-safe.
+    """
+    if span is None or not hasattr(span, "add_event"):
+        return
+    if payload is None or payload == "" or payload == [] or payload == {}:
+        return
+    attrs: Dict[str, Any] = {name: payload}
+    if mime_type:
+        attrs[f"{name}.mime_type"] = mime_type
+    if extra_attributes:
+        attrs.update(extra_attributes)
+    try:
+        span.add_event(name, attrs)
+    except Exception:
+        pass
+
+
+def _agent_span_name(operation_name: str, extra_kwargs: dict) -> str:
+    """Return the Honeycomb Agent Timeline span name for an agent operation."""
+    return operation_name
+
+
+def _model_span_name(operation_name: str, model: Any) -> str:
+    """Return the Honeycomb Agent Timeline span name for a model operation."""
+    model_text = truncate_string(model, 200)
+    return f"{operation_name} {model_text}" if model_text else operation_name
+
+
+def _tool_span_name(operation_name: str, tool_name: str) -> str:
+    """Return the Honeycomb Agent Timeline span name for a tool operation."""
+    tool_text = truncate_string(tool_name, 200)
+    return f"{operation_name} {tool_text}" if tool_text else operation_name
+
+
+def _uses_langsmith_backend(tracer: Any) -> bool:
+    """Return True when the active tracer is the LangSmith HTTP backend.
+
+    LangSmith's active spans are run dictionaries, not OTel span objects, so
+    they cannot receive OTel span events after creation. Keep canonical payload
+    fields on LangSmith inputs/outputs as a backend-compatibility fallback while
+    OTLP/Honeycomb backends receive the payloads as span events.
+    """
+    return bool(getattr(tracer, "__dict__", {}).get("_langsmith"))
+
+
 def _extract_correlation_id(extra_kwargs: dict) -> str:
     """Return an incoming correlation identifier from hook kwargs, if present.
 
@@ -871,7 +929,7 @@ def _start_session_span(
     """
     tracer = get_tracer()
     kind = _detect_session_kind(platform, extra_kwargs)
-    span_name = "agent" if kind != "cron" else "cron"
+    span_name = "cron" if kind == "cron" else _agent_span_name("invoke_agent", extra_kwargs)
     key = f"session:{session_id}"
 
     attributes = {
@@ -1082,7 +1140,7 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
     attributes.update(_kanban_attributes(tracer, session_id, kwargs))
 
     tracer.start_span(
-        name=f"tool.{tool_name}",
+        name=_tool_span_name("execute_tool", tool_name),
         key=key,
         kind="tool",
         attributes=attributes,
@@ -1247,18 +1305,23 @@ def on_pre_llm_call(
                 ps.sender_id = sender_id
                 ps.user_id = sender_attrs["user.id"]
 
-    # Opt-in: put the entire conversation the model is about to see on
-    # input.value. Falls back to just the latest user_message otherwise —
-    # that's the historical default and what small backends handle best.
+    input_payload_event: Optional[str] = None
+
+    # Opt-in: put the entire conversation the model is about to see on a
+    # GenAI payload event. Falls back to just the latest user_message preview
+    # on input.value otherwise — that's the historical default and what small
+    # backends handle best.
     if tracer.config.capture_conversation_history and tracer.config.capture_previews:
         full = _serialize_conversation_history(
             conversation_history,
             tracer.config.conversation_history_max_chars,
         )
         if full is not None:
-            attributes["input.value"] = full
-            attributes["input.mime_type"] = "application/json"
+            input_payload_event = full
             attributes["hermes.conversation.message_count"] = len(conversation_history)
+            if _uses_langsmith_backend(tracer):
+                attributes["gen_ai.input.messages"] = full
+                attributes["gen_ai.input.messages.mime_type"] = "application/json"
         else:
             preview = _preview(
                 user_message,
@@ -1275,12 +1338,19 @@ def on_pre_llm_call(
             attributes["input.value"] = preview
 
     span = tracer.start_span(
-        name=f"llm.{model}",
+        name=_model_span_name("chat", model),
         key=key,
         kind="llm",
         attributes=attributes,
         session_id=session_id,
     )
+    if input_payload_event is not None:
+        _add_payload_event(
+            span,
+            "gen_ai.input.messages",
+            input_payload_event,
+            mime_type="application/json",
+        )
 
     # Push as parent — tool spans during this LLM call will nest under it
     tracer.spans.push_parent(span, session_id=session_id)
@@ -1342,6 +1412,17 @@ def on_post_llm_call(
     if preview is not None:
         attributes["output.value"] = preview
 
+    span = tracer.spans.get_span(key)
+    if tracer.config.capture_full_responses and assistant_response:
+        payload = json.dumps(
+            [{"role": "assistant", "content": str(assistant_response)}],
+            ensure_ascii=False,
+        )
+        if _uses_langsmith_backend(tracer):
+            attributes["gen_ai.output.messages"] = payload
+            attributes["gen_ai.output.messages.mime_type"] = "application/json"
+        _add_payload_event(span, "gen_ai.output.messages", payload, mime_type="application/json")
+
     # Pop parent — tool spans after this won't nest under this LLM call
     tracer.spans.pop_parent(session_id=session_id)
 
@@ -1399,25 +1480,39 @@ def on_pre_api_request(
 
     attributes.update(_session_sender_attributes(tracer, session_id))
 
+    input_payload_event: Optional[str] = None
+    system_prompt_event: Optional[str] = None
     if tracer.config.capture_full_prompts:
         messages = kwargs.get("messages")
         system_prompt = kwargs.get("system_prompt")
         serialized = _serialize_full(messages)
         if serialized is not None:
-            attributes["gen_ai.input.messages"] = serialized
-            attributes["input.value"] = serialized
-            attributes["input.mime_type"] = "application/json"
+            input_payload_event = serialized
+            if _uses_langsmith_backend(tracer):
+                attributes["gen_ai.input.messages"] = serialized
+                attributes["gen_ai.input.messages.mime_type"] = "application/json"
         if system_prompt:
-            attributes["gen_ai.system_instructions"] = str(system_prompt)
+            system_prompt_event = str(system_prompt)
+            if _uses_langsmith_backend(tracer):
+                attributes["gen_ai.system_instructions"] = system_prompt_event
 
     span = tracer.start_span(
-        name=f"api.{model}",
+        name=_model_span_name("chat", model),
         key=key,
         kind="llm",
         attributes=attributes,
         session_id=session_id,
     )
     _add_inference_details_event(span, attributes)
+    if input_payload_event is not None:
+        _add_payload_event(
+            span,
+            "gen_ai.input.messages",
+            input_payload_event,
+            mime_type="application/json",
+        )
+    if system_prompt_event:
+        _add_payload_event(span, "gen_ai.system_instructions", system_prompt_event)
 
     # Push as parent — tool spans during this API call will nest under it
     tracer.spans.push_parent(span, session_id=session_id)
@@ -1549,23 +1644,36 @@ def on_post_api_request(
     if assistant_tool_call_count:
         attributes["hermes.response.tool_calls"] = assistant_tool_call_count
 
+    output_payload_event: Optional[str] = None
+    output_payload_mime_type: Optional[str] = None
     if tracer.config.capture_full_responses:
         response_content = kwargs.get("response_content")
         response_tool_calls = kwargs.get("response_tool_calls")
         if response_content:
             response_text = str(response_content)
-            attributes["gen_ai.output.messages"] = json.dumps(
+            output_payload_event = json.dumps(
                 [{"role": "assistant", "content": response_text}],
                 ensure_ascii=False,
             )
-            attributes["output.value"] = response_text
-            attributes["output.mime_type"] = "text/plain"
+            output_payload_mime_type = "application/json"
         tool_calls_serialized = _serialize_full(response_tool_calls)
         if tool_calls_serialized is not None:
             if not response_content:
-                attributes["gen_ai.output.messages"] = tool_calls_serialized
-                attributes["output.value"] = tool_calls_serialized
-                attributes["output.mime_type"] = "application/json"
+                output_payload_event = tool_calls_serialized
+                output_payload_mime_type = "application/json"
+
+    if output_payload_event is not None:
+        span = tracer.spans.get_span(key)
+        if _uses_langsmith_backend(tracer):
+            attributes["gen_ai.output.messages"] = output_payload_event
+            if output_payload_mime_type:
+                attributes["gen_ai.output.messages.mime_type"] = output_payload_mime_type
+        _add_payload_event(
+            span,
+            "gen_ai.output.messages",
+            output_payload_event,
+            mime_type=output_payload_mime_type,
+        )
 
     # Pop parent
     tracer.spans.pop_parent(session_id=session_id)

--- a/langsmith_backend.py
+++ b/langsmith_backend.py
@@ -202,17 +202,19 @@ class LangSmithBackend:
 
             # Map OTel-style token attributes to LangSmith's top-level fields.
             for src_key, dst_key in [
-                ("llm.token_count.prompt", "prompt_tokens"),
-                ("llm.token_count.completion", "completion_tokens"),
-                ("llm.token_count.total", "total_tokens"),
                 ("gen_ai.usage.input_tokens", "prompt_tokens"),
                 ("gen_ai.usage.output_tokens", "completion_tokens"),
-                ("gen_ai.usage.total_tokens", "total_tokens"),
             ]:
                 if src_key in outputs:
                     val = _coerce_int(outputs.get(src_key))
                     if val is not None:
                         payload[dst_key] = val
+
+            if (
+                payload.get("prompt_tokens") is not None
+                and payload.get("completion_tokens") is not None
+            ):
+                payload["total_tokens"] = payload["prompt_tokens"] + payload["completion_tokens"]
 
             # Newer LangSmith ingestion path: usage_metadata
             usage_metadata: Dict[str, Any] = {}
@@ -225,8 +227,8 @@ class LangSmithBackend:
                 if v is not None:
                     usage_metadata[k] = v
 
-            cache_read = _coerce_int(outputs.get("gen_ai.usage.cache_read_input_tokens"))
-            cache_write = _coerce_int(outputs.get("gen_ai.usage.cache_creation_input_tokens"))
+            cache_read = _coerce_int(outputs.get("gen_ai.usage.cache_read.input_tokens"))
+            cache_write = _coerce_int(outputs.get("gen_ai.usage.cache_creation.input_tokens"))
             if cache_read is not None:
                 usage_metadata["input_token_details"] = {"cache_read": cache_read}
             if cache_write is not None:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -19,3 +19,7 @@ provides_hooks:
   - post_llm_call
   - pre_api_request
   - post_api_request
+  - api_request_error
+  - kanban_task_claimed
+  - kanban_task_completed
+  - kanban_task_blocked

--- a/plugin_config.py
+++ b/plugin_config.py
@@ -25,6 +25,18 @@ Scalar = Union[str, int, float, bool]
 
 DEFAULT_CONFIG_PATH = Path.home() / ".hermes" / "plugins" / "hermes_otel" / "config.yaml"
 
+
+def _default_config_path() -> Path:
+    """Return the config path for the active Hermes profile.
+
+    Gateway/systemd runs set ``HERMES_HOME`` to the active profile directory;
+    fall back to the legacy global plugin config path for CLI/test usage.
+    """
+    hermes_home = os.getenv("HERMES_HOME", "").strip()
+    if hermes_home:
+        return Path(hermes_home) / "plugins" / "hermes_otel" / "config.yaml"
+    return DEFAULT_CONFIG_PATH
+
 _ENV_PREFIX = "HERMES_OTEL_"
 _TRUE_STRINGS = {"1", "true", "yes", "on"}
 _FALSE_STRINGS = {"0", "false", "no", "off"}
@@ -56,6 +68,12 @@ class BackendConfig:
     # SigNoz cloud credential
     ingestion_key: Optional[str] = None
     ingestion_key_env: Optional[str] = None
+    # Honeycomb credential/routing
+    api_key: Optional[str] = None
+    api_key_env: Optional[str] = None
+    region: Optional[str] = None  # us | eu, defaults to us
+    dataset: Optional[str] = None
+    dataset_env: Optional[str] = None
     # Uptrace DSN (sent as the ``uptrace-dsn`` header on every OTLP export)
     dsn: Optional[str] = None
     dsn_env: Optional[str] = None
@@ -372,7 +390,7 @@ def load_config(
         env:  Reserved for future use; env is read via os.getenv directly so
               existing monkeypatch-based tests keep working.
     """
-    yaml_path = path if path is not None else DEFAULT_CONFIG_PATH
+    yaml_path = path if path is not None else _default_config_path()
     yaml_data = _load_yaml(yaml_path)
 
     values: Dict[str, Any] = {}

--- a/session_state.py
+++ b/session_state.py
@@ -93,6 +93,7 @@ class PerSession:
     sender_id: str = ""
     user_id: str = ""
     correlation_id: str = ""
+    kanban_attrs: Dict[str, object] = field(default_factory=dict)
     io: Dict[str, str] = field(default_factory=lambda: {"input": "", "output": ""})
     io_captured: bool = False
     turn_summary: TurnSummary = field(default_factory=TurnSummary)

--- a/session_state.py
+++ b/session_state.py
@@ -71,6 +71,7 @@ def _empty_usage() -> Dict[str, int]:
         "total_tokens": 0,
         "cache_read_tokens": 0,
         "cache_write_tokens": 0,
+        "reasoning_output_tokens": 0,
     }
 
 

--- a/session_state.py
+++ b/session_state.py
@@ -93,6 +93,7 @@ class PerSession:
     sender_id: str = ""
     user_id: str = ""
     correlation_id: str = ""
+    conversation_id: str = ""
     kanban_attrs: Dict[str, object] = field(default_factory=dict)
     io: Dict[str, str] = field(default_factory=lambda: {"input": "", "output": ""})
     io_captured: bool = False

--- a/span_tracker.py
+++ b/span_tracker.py
@@ -145,6 +145,8 @@ class SpanTracker:
                 span.set_attribute(k, v)
 
         if status == "error":
+            if not (attributes and "error.type" in attributes):
+                span.set_attribute("error.type", "error")
             span.set_status(Status(status_code=StatusCode.ERROR, description=error_message or ""))
         elif status == "ok":
             # Set an explicit empty description so backends don't render "None".

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,8 @@ def _reset_otel_state(monkeypatch, tmp_path_factory):
         "OTEL_HONEYCOMB_DATASET",
         "HONEYCOMB_REGION",
         "OTEL_HONEYCOMB_ENDPOINT",
+        "HERMES_OTEL_CONVERSATION_ID",
+        "HERMES_PARENT_CONVERSATION_ID",
     ):
         monkeypatch.delenv(env_name, raising=False)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,18 @@ def _reset_otel_state(monkeypatch, tmp_path_factory):
 
     fake_path = tmp_path_factory.mktemp("isolated-config") / "nonexistent.yaml"
     monkeypatch.setattr(plugin_config_mod, "DEFAULT_CONFIG_PATH", fake_path)
+    for env_name in (
+        "HERMES_HOME",
+        "HERMES_PROFILE",
+        "HERMES_OTEL_CONFIG_PATH",
+        "HONEYCOMB_API_KEY",
+        "OTEL_HONEYCOMB_API_KEY",
+        "HONEYCOMB_DATASET",
+        "OTEL_HONEYCOMB_DATASET",
+        "HONEYCOMB_REGION",
+        "OTEL_HONEYCOMB_ENDPOINT",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
 
     def _reset():
         tracer_mod._tracer = None

--- a/tests/e2e/test_phoenix_traces.py
+++ b/tests/e2e/test_phoenix_traces.py
@@ -317,8 +317,8 @@ class TestPhoenixTraceExport:
             attrs_str = api_span["attributes"]
 
             # Token attributes should be present (as stringified JSON in Phoenix)
-            assert "llm.token_count.prompt" in attrs_str
-            assert "llm.token_count.completion" in attrs_str
+            assert "gen_ai.usage.input_tokens" in attrs_str
+            assert "gen_ai.usage.output_tokens" in attrs_str
 
         finally:
             tracer_mod._tracer = None

--- a/tests/integration/test_batch_processor.py
+++ b/tests/integration/test_batch_processor.py
@@ -213,7 +213,7 @@ class TestSessionEndFlushes:
 
         # Flush was synchronous — no sleep.
         assert any(
-            s.name == "agent" for s in exporter.exported
+            s.name == "invoke_agent" for s in exporter.exported
         ), f"agent span missing: {[s.name for s in exporter.exported]}"
 
     def test_session_end_flush_opt_out(self, batch_pipeline):
@@ -231,10 +231,10 @@ class TestSessionEndFlushes:
 
         deadline = time.time() + 2.0
         while time.time() < deadline:
-            if any(s.name == "agent" for s in exporter.exported):
+            if any(s.name == "invoke_agent" for s in exporter.exported):
                 break
             time.sleep(0.02)
-        assert any(s.name == "agent" for s in exporter.exported)
+        assert any(s.name == "invoke_agent" for s in exporter.exported)
 
 
 class TestConcurrentSessions:
@@ -327,6 +327,6 @@ class TestConcurrentSessions:
         # Each trace must be internally consistent: tool parent is api, api parent is agent.
         for trace_spans in traces.values():
             names = {s.name for s in trace_spans}
-            assert "agent" in names
-            assert any(n.startswith("api.") for n in names)
-            assert any(n.startswith("tool.") for n in names)
+            assert "invoke_agent" in names
+            assert any(n.startswith("chat ") for n in names)
+            assert any(n.startswith("execute_tool ") for n in names)

--- a/tests/integration/test_batch_processor.py
+++ b/tests/integration/test_batch_processor.py
@@ -213,7 +213,7 @@ class TestSessionEndFlushes:
 
         # Flush was synchronous — no sleep.
         assert any(
-            s.name == "invoke_agent" for s in exporter.exported
+            s.name == "invoke_agent hermes-agent" for s in exporter.exported
         ), f"agent span missing: {[s.name for s in exporter.exported]}"
 
     def test_session_end_flush_opt_out(self, batch_pipeline):
@@ -231,10 +231,10 @@ class TestSessionEndFlushes:
 
         deadline = time.time() + 2.0
         while time.time() < deadline:
-            if any(s.name == "invoke_agent" for s in exporter.exported):
+            if any(s.name == "invoke_agent hermes-agent" for s in exporter.exported):
                 break
             time.sleep(0.02)
-        assert any(s.name == "invoke_agent" for s in exporter.exported)
+        assert any(s.name == "invoke_agent hermes-agent" for s in exporter.exported)
 
 
 class TestConcurrentSessions:
@@ -327,6 +327,6 @@ class TestConcurrentSessions:
         # Each trace must be internally consistent: tool parent is api, api parent is agent.
         for trace_spans in traces.values():
             names = {s.name for s in trace_spans}
-            assert "invoke_agent" in names
+            assert "invoke_agent hermes-agent" in names
             assert any(n.startswith("chat ") for n in names)
             assert any(n.startswith("execute_tool ") for n in names)

--- a/tests/integration/test_inmemory_pipeline.py
+++ b/tests/integration/test_inmemory_pipeline.py
@@ -153,7 +153,7 @@ class TestSessionSpanExport:
         spans = exporter.get_finished_spans()
         assert len(spans) == 1
         span = spans[0]
-        assert span.name == "invoke_agent"
+        assert span.name == "invoke_agent hermes-agent"
         attrs = dict(span.attributes)
         assert attrs["openinference.span.kind"] == "AGENT"
         assert attrs["hermes.session.completed"] is True
@@ -180,3 +180,32 @@ class TestSessionSpanExport:
         span = exporter.get_finished_spans()[0]
         assert f"{span.context.trace_id:032x}" == trace_id
         assert f"{span.parent.span_id:016x}" == parent_span_id
+
+    def test_cross_process_child_can_share_parent_conversation_id(
+        self, inmemory_otel_setup, monkeypatch
+    ):
+        exporter, plugin = inmemory_otel_setup
+        trace_id = "4bf92f3577b34da6a3ce929d0e0e4736"
+        parent_span_id = "00f067aa0ba902b7"
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_child")
+        monkeypatch.setenv(
+            "HERMES_KANBAN_TRACEPARENT",
+            f"00-{trace_id}-{parent_span_id}-01",
+        )
+        monkeypatch.setenv("HERMES_OTEL_CONVERSATION_ID", "parent-session")
+
+        on_session_start(session_id="child-session", model="gpt-4", platform="api_server")
+        on_session_end(
+            session_id="child-session",
+            completed=True,
+            interrupted=False,
+            model="gpt-4",
+            platform="api_server",
+        )
+
+        span = exporter.get_finished_spans()[0]
+        attrs = dict(span.attributes)
+        assert f"{span.context.trace_id:032x}" == trace_id
+        assert f"{span.parent.span_id:016x}" == parent_span_id
+        assert attrs["gen_ai.conversation.id"] == "parent-session"
+        assert attrs["correlation.id"] == "child-session"

--- a/tests/integration/test_inmemory_pipeline.py
+++ b/tests/integration/test_inmemory_pipeline.py
@@ -157,3 +157,26 @@ class TestSessionSpanExport:
         attrs = dict(span.attributes)
         assert attrs["openinference.span.kind"] == "AGENT"
         assert attrs["hermes.session.completed"] is True
+
+    def test_kanban_session_continues_propagated_trace(self, inmemory_otel_setup, monkeypatch):
+        exporter, plugin = inmemory_otel_setup
+        trace_id = "4bf92f3577b34da6a3ce929d0e0e4736"
+        parent_span_id = "00f067aa0ba902b7"
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_child")
+        monkeypatch.setenv(
+            "HERMES_KANBAN_TRACEPARENT",
+            f"00-{trace_id}-{parent_span_id}-01",
+        )
+
+        on_session_start(session_id="s1", model="gpt-4", platform="api_server")
+        on_session_end(
+            session_id="s1",
+            completed=True,
+            interrupted=False,
+            model="gpt-4",
+            platform="api_server",
+        )
+
+        span = exporter.get_finished_spans()[0]
+        assert f"{span.context.trace_id:032x}" == trace_id
+        assert f"{span.parent.span_id:016x}" == parent_span_id

--- a/tests/integration/test_inmemory_pipeline.py
+++ b/tests/integration/test_inmemory_pipeline.py
@@ -24,7 +24,7 @@ class TestToolSpanExport:
         spans = exporter.get_finished_spans()
         assert len(spans) == 1
         span = spans[0]
-        assert span.name == "tool.bash"
+        assert span.name == "execute_tool bash"
         attrs = dict(span.attributes)
         assert attrs["tool.name"] == "bash"
         assert attrs["openinference.span.kind"] == "TOOL"
@@ -84,7 +84,7 @@ class TestLlmSpanExport:
         spans = exporter.get_finished_spans()
         assert len(spans) == 1
         span = spans[0]
-        assert span.name == "llm.gpt-4"
+        assert span.name == "chat gpt-4"
         attrs = dict(span.attributes)
         assert attrs["openinference.span.kind"] == "LLM"
         assert attrs["input.value"] == "hello"
@@ -131,7 +131,7 @@ class TestApiSpanExport:
         spans = exporter.get_finished_spans()
         assert len(spans) == 1
         span = spans[0]
-        assert span.name == "api.gpt-4"
+        assert span.name == "chat gpt-4"
         attrs = dict(span.attributes)
         assert attrs["gen_ai.usage.input_tokens"] == 100
         assert attrs["gen_ai.usage.output_tokens"] == 50
@@ -153,7 +153,7 @@ class TestSessionSpanExport:
         spans = exporter.get_finished_spans()
         assert len(spans) == 1
         span = spans[0]
-        assert span.name == "agent"
+        assert span.name == "invoke_agent"
         attrs = dict(span.attributes)
         assert attrs["openinference.span.kind"] == "AGENT"
         assert attrs["hermes.session.completed"] is True

--- a/tests/integration/test_inmemory_pipeline.py
+++ b/tests/integration/test_inmemory_pipeline.py
@@ -133,10 +133,7 @@ class TestApiSpanExport:
         span = spans[0]
         assert span.name == "api.gpt-4"
         attrs = dict(span.attributes)
-        # Dual conventions
-        assert attrs["llm.token_count.prompt"] == 100
         assert attrs["gen_ai.usage.input_tokens"] == 100
-        assert attrs["llm.token_count.completion"] == 50
         assert attrs["gen_ai.usage.output_tokens"] == 50
 
 

--- a/tests/integration/test_langsmith_integration.py
+++ b/tests/integration/test_langsmith_integration.py
@@ -30,6 +30,7 @@ from hermes_otel.hooks import (
     on_session_start,
 )
 from hermes_otel.langsmith_backend import LangSmithBackend
+from hermes_otel.plugin_config import HermesOtelConfig
 from hermes_otel.tracer import HermesOTelPlugin
 
 
@@ -168,10 +169,9 @@ class TestLangSmithPluginFlow:
         # agent (session) + llm + api + tool = 4 runs created.
         assert len(posts) == 4
         names = [p["name"] for p in posts]
-        assert "agent" in names
-        assert "llm.gpt-4" in names
-        assert "api.gpt-4" in names
-        assert "tool.bash" in names
+        assert "invoke_agent" in names
+        assert names.count("chat gpt-4") == 2
+        assert "execute_tool bash" in names
 
     def test_patches_one_per_span(self, langsmith_plugin):
         """Each end_span → one PATCH /runs/{id}; 4 spans = 4 updates."""
@@ -187,15 +187,15 @@ class TestLangSmithPluginFlow:
         recorder, _ = langsmith_plugin
         self._fire_complete_session()
         posts = recorder.posts()
-        by_name = {p["name"]: p for p in posts}
+        by_name = {p["name"]: p for p in posts if p["name"] != "chat gpt-4"}
 
-        agent_id = by_name["agent"]["id"]
-        llm = by_name["llm.gpt-4"]
-        api = by_name["api.gpt-4"]
-        tool = by_name["tool.bash"]
+        agent_id = by_name["invoke_agent"]["id"]
+        llm = next(p for p in posts if p.get("parent_run_id") == agent_id)
+        api = next(p for p in posts if p.get("parent_run_id") == llm["id"])
+        tool = by_name["execute_tool bash"]
 
         # Root span has no parent_run_id.
-        assert "parent_run_id" not in by_name["agent"]
+        assert "parent_run_id" not in by_name["invoke_agent"]
         # llm is rooted under agent.
         assert llm["parent_run_id"] == agent_id
         # api is rooted under llm.
@@ -208,13 +208,10 @@ class TestLangSmithPluginFlow:
         recorder, _ = langsmith_plugin
         self._fire_complete_session()
 
-        posts = recorder.posts()
-        api_id = next(p["id"] for p in posts if p["name"] == "api.gpt-4")
-
-        # Find the PATCH for that run_id in the request log.
+        # Find the PATCH carrying usage for the API span.
         api_patch = None
         for method, url, body in recorder.requests:
-            if method == "PATCH" and url.endswith(f"/runs/{api_id}"):
+            if method == "PATCH" and body.get("usage_metadata"):
                 api_patch = body
                 break
         assert api_patch is not None, "no PATCH for api span"
@@ -227,3 +224,58 @@ class TestLangSmithPluginFlow:
         assert api_patch["usage_metadata"]["input_tokens"] == 100
         assert api_patch["usage_metadata"]["output_tokens"] == 50
         assert api_patch["usage_metadata"]["total_tokens"] == 150
+
+    def test_full_capture_flags_preserve_payloads_for_langsmith(self, langsmith_plugin):
+        """LangSmith lacks OTel span events, so payload events remain canonical fields."""
+        recorder, plugin = langsmith_plugin
+        plugin.config = HermesOtelConfig(
+            capture_full_prompts=True,
+            capture_full_responses=True,
+        )
+
+        messages = [{"role": "user", "content": "secret prompt"}]
+        on_pre_api_request(
+            task_id="t-full",
+            session_id="s-full",
+            platform="cli",
+            model="gpt-4",
+            provider="openai",
+            base_url="",
+            api_mode="chat",
+            api_call_count=1,
+            message_count=1,
+            tool_count=0,
+            approx_input_tokens=10,
+            request_char_count=100,
+            max_tokens=128,
+            messages=messages,
+            system_prompt="system secret",
+        )
+        api_post = next(p for p in recorder.posts() if p["name"] == "chat gpt-4")
+        assert json.loads(api_post["inputs"]["gen_ai.input.messages"]) == messages
+        assert api_post["inputs"]["gen_ai.input.messages.mime_type"] == "application/json"
+        assert api_post["inputs"]["gen_ai.system_instructions"] == "system secret"
+
+        on_post_api_request(
+            task_id="t-full",
+            session_id="s-full",
+            platform="cli",
+            model="gpt-4",
+            provider="openai",
+            base_url="",
+            api_mode="chat",
+            api_call_count=1,
+            api_duration=0.1,
+            finish_reason="stop",
+            message_count=1,
+            response_model="gpt-4",
+            usage={},
+            assistant_content_chars=6,
+            assistant_tool_call_count=0,
+            response_content="answer",
+            response_tool_calls=[],
+        )
+        api_patch = recorder.patches()[-1]
+        output_messages = json.loads(api_patch["outputs"]["gen_ai.output.messages"])
+        assert output_messages == [{"role": "assistant", "content": "answer"}]
+        assert api_patch["outputs"]["gen_ai.output.messages.mime_type"] == "application/json"

--- a/tests/integration/test_langsmith_integration.py
+++ b/tests/integration/test_langsmith_integration.py
@@ -169,7 +169,7 @@ class TestLangSmithPluginFlow:
         # agent (session) + llm + api + tool = 4 runs created.
         assert len(posts) == 4
         names = [p["name"] for p in posts]
-        assert "invoke_agent" in names
+        assert "invoke_agent hermes-agent" in names
         assert names.count("chat gpt-4") == 2
         assert "execute_tool bash" in names
 
@@ -189,13 +189,13 @@ class TestLangSmithPluginFlow:
         posts = recorder.posts()
         by_name = {p["name"]: p for p in posts if p["name"] != "chat gpt-4"}
 
-        agent_id = by_name["invoke_agent"]["id"]
+        agent_id = by_name["invoke_agent hermes-agent"]["id"]
         llm = next(p for p in posts if p.get("parent_run_id") == agent_id)
         api = next(p for p in posts if p.get("parent_run_id") == llm["id"])
         tool = by_name["execute_tool bash"]
 
         # Root span has no parent_run_id.
-        assert "parent_run_id" not in by_name["invoke_agent"]
+        assert "parent_run_id" not in by_name["invoke_agent hermes-agent"]
         # llm is rooted under agent.
         assert llm["parent_run_id"] == agent_id
         # api is rooted under llm.

--- a/tests/integration/test_metrics_pipeline.py
+++ b/tests/integration/test_metrics_pipeline.py
@@ -26,10 +26,11 @@ def _get_metric_value(metric_reader, name):
     metric = _get_metric(metric_reader, name)
     if metric is None:
         return None
-    # Sum data points
+    # Sum data points. Counters expose ``value`` while histograms expose
+    # ``sum``; token usage is a GenAI histogram per OTel semantic conventions.
     total = 0
     for dp in metric.data.data_points:
-        total += dp.value
+        total += getattr(dp, "value", getattr(dp, "sum", 0))
     return total
 
 
@@ -89,7 +90,7 @@ class TestTokenUsageMetric:
             assistant_tool_call_count=0,
         )
 
-        value = _get_metric_value(metric_reader, "hermes.token.usage")
+        value = _get_metric_value(metric_reader, "gen_ai.client.token.usage")
         # 100 (input) + 50 (output) = 150
         assert value == 150
 
@@ -101,7 +102,7 @@ class TestToolDurationMetric:
         on_pre_tool_call(tool_name="bash", args={}, task_id="t1")
         on_post_tool_call(tool_name="bash", args={}, result="ok", task_id="t1")
 
-        metric = _get_metric(metric_reader, "hermes.tool.duration")
+        metric = _get_metric(metric_reader, "gen_ai.execute_tool.duration")
         assert metric is not None
         # Should have at least one data point
         assert len(metric.data.data_points) > 0

--- a/tests/integration/test_multi_backend.py
+++ b/tests/integration/test_multi_backend.py
@@ -91,9 +91,9 @@ class TestSpanFanOut:
         names_a = sorted(s.name for s in exp_a.get_finished_spans())
         names_b = sorted(s.name for s in exp_b.get_finished_spans())
         assert names_a == names_b
-        assert "agent" in names_a
-        assert any(n.startswith("api.") for n in names_a)
-        assert any(n.startswith("tool.") for n in names_a)
+        assert "invoke_agent" in names_a
+        assert any(n.startswith("chat ") for n in names_a)
+        assert any(n.startswith("execute_tool ") for n in names_a)
 
 
 class TestForceFlushFansOut:

--- a/tests/integration/test_multi_backend.py
+++ b/tests/integration/test_multi_backend.py
@@ -129,6 +129,12 @@ class TestForceFlushFansOut:
 def _clear_backend_env(monkeypatch):
     for var in [
         "OTEL_PHOENIX_ENDPOINT",
+        "OTEL_HONEYCOMB_ENDPOINT",
+        "OTEL_HONEYCOMB_API_KEY",
+        "HONEYCOMB_API_KEY",
+        "HONEYCOMB_REGION",
+        "HONEYCOMB_DATASET",
+        "OTEL_HONEYCOMB_DATASET",
         "OTEL_PROJECT_NAME",
         "LANGSMITH_TRACING",
         "LANGSMITH_API_KEY",
@@ -147,6 +153,25 @@ def _clear_backend_env(monkeypatch):
 
 
 class TestConfigBackendsRouting:
+    def test_honeycomb_backend_wires_trace_exporter(self, monkeypatch):
+        _clear_backend_env(monkeypatch)
+        cfg = HermesOtelConfig(
+            backends=(BackendConfig(type="honeycomb", api_key="test-key", region="us"),),
+        )
+        plugin = HermesOTelPlugin(config=cfg)
+        with (
+            patch("hermes_otel.tracer.OTLPSpanExporter") as mock_span_exp,
+            patch("hermes_otel.tracer.OTLPMetricExporter"),
+            patch("hermes_otel.tracer.trace.set_tracer_provider"),
+            patch("hermes_otel.tracer.metrics.set_meter_provider"),
+        ):
+            assert plugin.init() is True
+
+        assert len(plugin._span_processors) == 1
+        assert len(plugin._metric_readers) == 0
+        assert mock_span_exp.call_args.kwargs["endpoint"] == "https://api.honeycomb.io/v1/traces"
+        assert mock_span_exp.call_args.kwargs["headers"] == {"x-honeycomb-team": "test-key"}
+
     def test_two_backends_each_get_their_own_processor(self, monkeypatch):
         """One BackendConfig per entry → one BatchSpanProcessor per entry."""
         _clear_backend_env(monkeypatch)

--- a/tests/integration/test_multi_backend.py
+++ b/tests/integration/test_multi_backend.py
@@ -91,7 +91,7 @@ class TestSpanFanOut:
         names_a = sorted(s.name for s in exp_a.get_finished_spans())
         names_b = sorted(s.name for s in exp_b.get_finished_spans())
         assert names_a == names_b
-        assert "invoke_agent" in names_a
+        assert "invoke_agent hermes-agent" in names_a
         assert any(n.startswith("chat ") for n in names_a)
         assert any(n.startswith("execute_tool ") for n in names_a)
 

--- a/tests/integration/test_orphan_sweep.py
+++ b/tests/integration/test_orphan_sweep.py
@@ -81,10 +81,10 @@ class TestOrphanSweep:
         names = [s.name for s in spans]
         # Both the agent (session) span and the orphaned api span must have
         # been finalized by the sweep.
-        assert "invoke_agent" in names
+        assert "invoke_agent hermes-agent" in names
         assert "chat gpt-4" in names
         # And the session span carries the timed_out status.
-        agent = _span_by_name(spans, "invoke_agent")
+        agent = _span_by_name(spans, "invoke_agent hermes-agent")
         assert agent.attributes.get("hermes.turn.final_status") == "timed_out"
 
     def test_sweep_does_not_expire_young_sessions(self, inmemory_otel_setup):

--- a/tests/integration/test_orphan_sweep.py
+++ b/tests/integration/test_orphan_sweep.py
@@ -81,10 +81,10 @@ class TestOrphanSweep:
         names = [s.name for s in spans]
         # Both the agent (session) span and the orphaned api span must have
         # been finalized by the sweep.
-        assert "agent" in names
-        assert "api.gpt-4" in names
+        assert "invoke_agent" in names
+        assert "chat gpt-4" in names
         # And the session span carries the timed_out status.
-        agent = _span_by_name(spans, "agent")
+        agent = _span_by_name(spans, "invoke_agent")
         assert agent.attributes.get("hermes.turn.final_status") == "timed_out"
 
     def test_sweep_does_not_expire_young_sessions(self, inmemory_otel_setup):

--- a/tests/integration/test_session_lifecycle.py
+++ b/tests/integration/test_session_lifecycle.py
@@ -150,16 +150,15 @@ class TestFullSessionLifecycle:
         session_span = _span_by_name(spans, "agent")
         attrs = dict(session_span.attributes)
 
-        # Token roll-up: 200+300=500 prompt, 30+80=110 completion, 230+380=610 total
-        assert attrs["llm.token_count.prompt"] == 500
-        assert attrs["llm.token_count.completion"] == 110
-        assert attrs["llm.token_count.total"] == 610
+        # Token roll-up: 200+300=500 prompt, 30+80=110 completion.
+        # Total tokens are derived from input+output downstream rather than emitted
+        # as a duplicate compatibility attribute.
         assert attrs["gen_ai.usage.input_tokens"] == 500
         assert attrs["gen_ai.usage.output_tokens"] == 110
+        assert "gen_ai.usage.total_tokens" not in attrs
 
         # Cache roll-up: 50+100=150 cache read
-        assert attrs["llm.token_count.prompt_details.cache_read"] == 150
-        assert attrs["gen_ai.usage.cache_read_input_tokens"] == 150
+        assert attrs["gen_ai.usage.cache_read.input_tokens"] == 150
 
         # Session I/O: first input and last output
         assert attrs["input.value"] == "What files are here?"

--- a/tests/integration/test_session_lifecycle.py
+++ b/tests/integration/test_session_lifecycle.py
@@ -21,6 +21,13 @@ def _span_by_name(spans, name):
     raise ValueError(f"No span named '{name}'")
 
 
+def _span_by_attr(spans, name, attr):
+    for s in spans:
+        if s.name == name and attr in dict(s.attributes):
+            return s
+    raise ValueError(f"No span named '{name}' with attr '{attr}'")
+
+
 class TestFullSessionLifecycle:
     def test_complete_session_with_token_aggregation(self, inmemory_otel_setup):
         """Simulate a complete session: start -> llm -> api -> tool -> api end -> llm end -> end.
@@ -147,7 +154,7 @@ class TestFullSessionLifecycle:
         # Expect: 2 api spans + 1 tool span + 1 llm span + 1 session span = 5
         assert len(spans) == 5
 
-        session_span = _span_by_name(spans, "agent")
+        session_span = _span_by_name(spans, "invoke_agent")
         attrs = dict(session_span.attributes)
 
         # Token roll-up: 200+300=500 prompt, 30+80=110 completion.
@@ -227,8 +234,8 @@ class TestFullSessionLifecycle:
         )
 
         spans = exporter.get_finished_spans()
-        api_span = _span_by_name(spans, "api.gpt-4")
-        tool_span = _span_by_name(spans, "tool.execute_code")
+        api_span = _span_by_attr(spans, "chat gpt-4", "hermes.api.mode")
+        tool_span = _span_by_name(spans, "execute_tool execute_code")
         for span in [api_span, tool_span]:
             assert span.attributes["hermes.sender.id"] == "U0B074344DP"
             assert span.attributes["user.id"] == "slack:U0B074344DP"
@@ -331,8 +338,8 @@ class TestFullSessionLifecycle:
         )
 
         spans = exporter.get_finished_spans()
-        llm_span = _span_by_name(spans, "llm.gpt-4")
-        session_span = _span_by_name(spans, "agent")
+        llm_span = _span_by_attr(spans, "chat gpt-4", "input.value")
+        session_span = _span_by_name(spans, "invoke_agent")
         assert llm_span.attributes["hermes.sender.id"] == "123456789012345678"
         assert llm_span.attributes["user.id"] == "discord:123456789012345678"
         assert session_span.attributes["hermes.sender.id"] == "123456789012345678"

--- a/tests/integration/test_session_lifecycle.py
+++ b/tests/integration/test_session_lifecycle.py
@@ -154,7 +154,7 @@ class TestFullSessionLifecycle:
         # Expect: 2 api spans + 1 tool span + 1 llm span + 1 session span = 5
         assert len(spans) == 5
 
-        session_span = _span_by_name(spans, "invoke_agent")
+        session_span = _span_by_name(spans, "invoke_agent hermes-agent")
         attrs = dict(session_span.attributes)
 
         # Token roll-up: 200+300=500 prompt, 30+80=110 completion.
@@ -339,7 +339,7 @@ class TestFullSessionLifecycle:
 
         spans = exporter.get_finished_spans()
         llm_span = _span_by_attr(spans, "chat gpt-4", "input.value")
-        session_span = _span_by_name(spans, "invoke_agent")
+        session_span = _span_by_name(spans, "invoke_agent hermes-agent")
         assert llm_span.attributes["hermes.sender.id"] == "123456789012345678"
         assert llm_span.attributes["user.id"] == "discord:123456789012345678"
         assert session_span.attributes["hermes.sender.id"] == "123456789012345678"

--- a/tests/integration/test_span_hierarchy.py
+++ b/tests/integration/test_span_hierarchy.py
@@ -73,7 +73,7 @@ class TestSessionContainsLlm:
         spans = exporter.get_finished_spans()
         assert len(spans) == 2
 
-        session_span = _span_by_name(spans, "invoke_agent")
+        session_span = _span_by_name(spans, "invoke_agent hermes-agent")
         llm_span = _span_by_attr(spans, "chat gpt-4", "input.value")
 
         assert _parent_span_id(llm_span) == session_span.context.span_id
@@ -273,7 +273,7 @@ class TestFullHierarchy:
         spans = exporter.get_finished_spans()
         assert len(spans) == 4
 
-        session = _span_by_name(spans, "invoke_agent")
+        session = _span_by_name(spans, "invoke_agent hermes-agent")
         llm = _span_by_attr(spans, "chat gpt-4", "input.value")
         api = _span_by_attr(spans, "chat gpt-4", "hermes.api.mode")
         tool = _span_by_name(spans, "execute_tool bash")
@@ -541,7 +541,7 @@ class TestContinuationTurnSynthesizesAgent:
         trace_ids = {s.context.trace_id for s in spans}
         assert len(trace_ids) == 1
 
-        agent = _span_by_name(spans, "invoke_agent")
+        agent = _span_by_name(spans, "invoke_agent hermes-agent")
         llm = _span_by_attr(spans, "chat gpt-4", "input.value")
         api = _span_by_attr(spans, "chat gpt-4", "hermes.api.mode")
 
@@ -667,7 +667,7 @@ class TestCrossThreadNesting:
             len(trace_ids) == 1
         ), f"expected 1 trace, got {len(trace_ids)}: {[s.name for s in spans]}"
 
-        agent = _span_by_name(spans, "invoke_agent")
+        agent = _span_by_name(spans, "invoke_agent hermes-agent")
         llm = _span_by_attr(spans, "chat gpt-4", "input.value")
         api = _span_by_attr(spans, "chat gpt-4", "hermes.api.mode")
         tool = _span_by_name(spans, "execute_tool bash")

--- a/tests/integration/test_span_hierarchy.py
+++ b/tests/integration/test_span_hierarchy.py
@@ -23,6 +23,17 @@ def _span_by_name(spans, name):
     raise ValueError(f"No span named '{name}' in {[s.name for s in spans]}")
 
 
+def _span_by_attr(spans, name, attr):
+    """Find a span by name that carries a specific attribute."""
+    for s in spans:
+        if s.name == name and attr in dict(s.attributes):
+            return s
+    raise ValueError(
+        f"No span named '{name}' with attr '{attr}' in "
+        f"{[(s.name, sorted(dict(s.attributes))) for s in spans]}"
+    )
+
+
 def _parent_span_id(span):
     """Extract the parent span ID from a span, or None."""
     if span.parent is not None:
@@ -62,8 +73,8 @@ class TestSessionContainsLlm:
         spans = exporter.get_finished_spans()
         assert len(spans) == 2
 
-        session_span = _span_by_name(spans, "agent")
-        llm_span = _span_by_name(spans, "llm.gpt-4")
+        session_span = _span_by_name(spans, "invoke_agent")
+        llm_span = _span_by_attr(spans, "chat gpt-4", "input.value")
 
         assert _parent_span_id(llm_span) == session_span.context.span_id
 
@@ -124,8 +135,8 @@ class TestLlmContainsApi:
         spans = exporter.get_finished_spans()
         assert len(spans) == 2
 
-        llm_span = _span_by_name(spans, "llm.gpt-4")
-        api_span = _span_by_name(spans, "api.gpt-4")
+        llm_span = _span_by_attr(spans, "chat gpt-4", "input.value")
+        api_span = _span_by_attr(spans, "chat gpt-4", "hermes.api.mode")
 
         assert _parent_span_id(api_span) == llm_span.context.span_id
 
@@ -189,8 +200,8 @@ class TestApiContainsTool:
         spans = exporter.get_finished_spans()
         assert len(spans) == 3
 
-        api_span = _span_by_name(spans, "api.gpt-4")
-        tool_span = _span_by_name(spans, "tool.bash")
+        api_span = _span_by_attr(spans, "chat gpt-4", "hermes.api.mode")
+        tool_span = _span_by_name(spans, "execute_tool bash")
 
         assert _parent_span_id(tool_span) == api_span.context.span_id
 
@@ -262,10 +273,10 @@ class TestFullHierarchy:
         spans = exporter.get_finished_spans()
         assert len(spans) == 4
 
-        session = _span_by_name(spans, "agent")
-        llm = _span_by_name(spans, "llm.gpt-4")
-        api = _span_by_name(spans, "api.gpt-4")
-        tool = _span_by_name(spans, "tool.bash")
+        session = _span_by_name(spans, "invoke_agent")
+        llm = _span_by_attr(spans, "chat gpt-4", "input.value")
+        api = _span_by_attr(spans, "chat gpt-4", "hermes.api.mode")
+        tool = _span_by_name(spans, "execute_tool bash")
 
         # Verify parent chain: tool -> api -> llm -> session
         assert _parent_span_id(tool) == api.context.span_id
@@ -334,8 +345,8 @@ class TestMultipleToolsUnderApi:
         spans = exporter.get_finished_spans()
         assert len(spans) == 4
 
-        api_span = _span_by_name(spans, "api.gpt-4")
-        tool_spans = [s for s in spans if s.name.startswith("tool.")]
+        api_span = _span_by_attr(spans, "chat gpt-4", "hermes.api.mode")
+        tool_spans = [s for s in spans if s.name.startswith("execute_tool ")]
         assert len(tool_spans) == 2
 
         for tool_span in tool_spans:
@@ -388,7 +399,7 @@ class TestCaptureConversationHistory:
         ]
         self._drive_llm_call("s1", history, user_message="now do it again")
 
-        llm = _span_by_name(exporter.get_finished_spans(), "llm.gpt-4")
+        llm = _span_by_name(exporter.get_finished_spans(), "chat gpt-4")
         attrs = dict(llm.attributes)
         assert attrs.get("input.value") == "now do it again"
         assert "hermes.conversation.message_count" not in attrs
@@ -408,13 +419,18 @@ class TestCaptureConversationHistory:
         ]
         self._drive_llm_call("s2", history)
 
-        llm = _span_by_name(exporter.get_finished_spans(), "llm.gpt-4")
+        llm = _span_by_attr(
+            exporter.get_finished_spans(), "chat gpt-4", "hermes.conversation.message_count"
+        )
         attrs = dict(llm.attributes)
-        input_value = attrs.get("input.value", "")
+        assert attrs.get("hermes.conversation.message_count") == 4
+        assert "input.value" not in attrs
+        assert "input.mime_type" not in attrs
+        events = {event.name: dict(event.attributes) for event in llm.events}
+        input_value = events["gen_ai.input.messages"]["gen_ai.input.messages"]
         assert "an earlier assistant reply" in input_value
         assert "tool output from before" in input_value
-        assert attrs.get("hermes.conversation.message_count") == 4
-        assert attrs.get("input.mime_type") == "application/json"
+        assert events["gen_ai.input.messages"]["gen_ai.input.messages.mime_type"] == "application/json"
 
     def test_respects_max_chars_clip(self, inmemory_otel_setup):
         exporter, plugin = inmemory_otel_setup
@@ -428,10 +444,14 @@ class TestCaptureConversationHistory:
         history = [{"role": "user", "content": "x" * 5000}]
         self._drive_llm_call("s3", history)
 
-        llm = _span_by_name(exporter.get_finished_spans(), "llm.gpt-4")
+        llm = _span_by_attr(
+            exporter.get_finished_spans(), "chat gpt-4", "hermes.conversation.message_count"
+        )
         attrs = dict(llm.attributes)
-        assert len(attrs["input.value"]) <= 200
-        assert attrs["input.value"].endswith("...")
+        events = {event.name: dict(event.attributes) for event in llm.events}
+        input_value = events["gen_ai.input.messages"]["gen_ai.input.messages"]
+        assert len(input_value) <= 200
+        assert input_value.endswith("...")
 
     def test_empty_history_falls_back_to_user_message(self, inmemory_otel_setup):
         exporter, plugin = inmemory_otel_setup
@@ -441,7 +461,7 @@ class TestCaptureConversationHistory:
 
         self._drive_llm_call("s4", [], user_message="solo turn")
 
-        llm = _span_by_name(exporter.get_finished_spans(), "llm.gpt-4")
+        llm = _span_by_name(exporter.get_finished_spans(), "chat gpt-4")
         attrs = dict(llm.attributes)
         assert attrs.get("input.value") == "solo turn"
         assert "hermes.conversation.message_count" not in attrs
@@ -521,9 +541,9 @@ class TestContinuationTurnSynthesizesAgent:
         trace_ids = {s.context.trace_id for s in spans}
         assert len(trace_ids) == 1
 
-        agent = _span_by_name(spans, "agent")
-        llm = _span_by_name(spans, "llm.gpt-4")
-        api = _span_by_name(spans, "api.gpt-4")
+        agent = _span_by_name(spans, "invoke_agent")
+        llm = _span_by_attr(spans, "chat gpt-4", "input.value")
+        api = _span_by_attr(spans, "chat gpt-4", "hermes.api.mode")
 
         assert _parent_span_id(agent) is None
         assert _parent_span_id(llm) == agent.context.span_id
@@ -647,10 +667,10 @@ class TestCrossThreadNesting:
             len(trace_ids) == 1
         ), f"expected 1 trace, got {len(trace_ids)}: {[s.name for s in spans]}"
 
-        agent = _span_by_name(spans, "agent")
-        llm = _span_by_name(spans, "llm.gpt-4")
-        api = _span_by_name(spans, "api.gpt-4")
-        tool = _span_by_name(spans, "tool.bash")
+        agent = _span_by_name(spans, "invoke_agent")
+        llm = _span_by_attr(spans, "chat gpt-4", "input.value")
+        api = _span_by_attr(spans, "chat gpt-4", "hermes.api.mode")
+        tool = _span_by_name(spans, "execute_tool bash")
 
         assert _parent_span_id(agent) is None
         assert _parent_span_id(llm) == agent.context.span_id

--- a/tests/integration/test_tool_attributes.py
+++ b/tests/integration/test_tool_attributes.py
@@ -21,7 +21,7 @@ class TestToolTargetAttributes:
         on_post_tool_call(
             tool_name="read", args={"path": "/tmp/foo.txt"}, result="contents", task_id="t1"
         )
-        span = _span_by_name(exporter.get_finished_spans(), "tool.read")
+        span = _span_by_name(exporter.get_finished_spans(), "execute_tool read")
         assert span.attributes["hermes.tool.target"] == "/tmp/foo.txt"
 
     def test_target_attribute_from_file_path(self, inmemory_otel_setup):
@@ -30,21 +30,21 @@ class TestToolTargetAttributes:
         on_post_tool_call(
             tool_name="edit", args={"file_path": "/etc/hosts"}, result="ok", task_id="t1"
         )
-        span = _span_by_name(exporter.get_finished_spans(), "tool.edit")
+        span = _span_by_name(exporter.get_finished_spans(), "execute_tool edit")
         assert span.attributes["hermes.tool.target"] == "/etc/hosts"
 
     def test_command_attribute_from_command(self, inmemory_otel_setup):
         exporter, _ = inmemory_otel_setup
         on_pre_tool_call(tool_name="bash", args={"command": "ls -la"}, task_id="t1")
         on_post_tool_call(tool_name="bash", args={"command": "ls -la"}, result="ok", task_id="t1")
-        span = _span_by_name(exporter.get_finished_spans(), "tool.bash")
+        span = _span_by_name(exporter.get_finished_spans(), "execute_tool bash")
         assert span.attributes["hermes.tool.command"] == "ls -la"
 
     def test_no_target_or_command_when_absent(self, inmemory_otel_setup):
         exporter, _ = inmemory_otel_setup
         on_pre_tool_call(tool_name="noop", args={"foo": "bar"}, task_id="t1")
         on_post_tool_call(tool_name="noop", args={"foo": "bar"}, result="ok", task_id="t1")
-        span = _span_by_name(exporter.get_finished_spans(), "tool.noop")
+        span = _span_by_name(exporter.get_finished_spans(), "execute_tool noop")
         assert "hermes.tool.target" not in span.attributes
         assert "hermes.tool.command" not in span.attributes
 
@@ -54,21 +54,21 @@ class TestToolOutcomeAttribute:
         exporter, _ = inmemory_otel_setup
         on_pre_tool_call(tool_name="bash", args={}, task_id="t1")
         on_post_tool_call(tool_name="bash", args={}, result="ok", task_id="t1")
-        span = _span_by_name(exporter.get_finished_spans(), "tool.bash")
+        span = _span_by_name(exporter.get_finished_spans(), "execute_tool bash")
         assert span.attributes["hermes.tool.outcome"] == "completed"
 
     def test_error_on_error_result(self, inmemory_otel_setup):
         exporter, _ = inmemory_otel_setup
         on_pre_tool_call(tool_name="bash", args={}, task_id="t1")
         on_post_tool_call(tool_name="bash", args={}, result='{"error": "boom"}', task_id="t1")
-        span = _span_by_name(exporter.get_finished_spans(), "tool.bash")
+        span = _span_by_name(exporter.get_finished_spans(), "execute_tool bash")
         assert span.attributes["hermes.tool.outcome"] == "error"
 
     def test_explicit_status_overrides(self, inmemory_otel_setup):
         exporter, _ = inmemory_otel_setup
         on_pre_tool_call(tool_name="bash", args={}, task_id="t1")
         on_post_tool_call(tool_name="bash", args={}, result='{"status": "timeout"}', task_id="t1")
-        span = _span_by_name(exporter.get_finished_spans(), "tool.bash")
+        span = _span_by_name(exporter.get_finished_spans(), "execute_tool bash")
         assert span.attributes["hermes.tool.outcome"] == "timeout"
 
     def test_timeout_does_not_flip_span_status_to_error(self, inmemory_otel_setup):
@@ -78,7 +78,7 @@ class TestToolOutcomeAttribute:
         exporter, _ = inmemory_otel_setup
         on_pre_tool_call(tool_name="bash", args={}, task_id="t1")
         on_post_tool_call(tool_name="bash", args={}, result='{"status": "timeout"}', task_id="t1")
-        span = _span_by_name(exporter.get_finished_spans(), "tool.bash")
+        span = _span_by_name(exporter.get_finished_spans(), "execute_tool bash")
         assert span.status.status_code == StatusCode.OK
 
     def test_error_flips_span_status(self, inmemory_otel_setup):
@@ -87,7 +87,7 @@ class TestToolOutcomeAttribute:
         exporter, _ = inmemory_otel_setup
         on_pre_tool_call(tool_name="bash", args={}, task_id="t1")
         on_post_tool_call(tool_name="bash", args={}, result='{"error": "boom"}', task_id="t1")
-        span = _span_by_name(exporter.get_finished_spans(), "tool.bash")
+        span = _span_by_name(exporter.get_finished_spans(), "execute_tool bash")
         assert span.status.status_code == StatusCode.ERROR
 
 
@@ -97,7 +97,7 @@ class TestSkillNameInference:
         args = {"path": "/repo/skills/monitor/SKILL.md"}
         on_pre_tool_call(tool_name="read", args=args, task_id="t1")
         on_post_tool_call(tool_name="read", args=args, result="ok", task_id="t1")
-        span = _span_by_name(exporter.get_finished_spans(), "tool.read")
+        span = _span_by_name(exporter.get_finished_spans(), "execute_tool read")
         assert span.attributes["hermes.skill.name"] == "monitor"
 
     def test_no_skill_on_regular_path(self, inmemory_otel_setup):
@@ -105,7 +105,7 @@ class TestSkillNameInference:
         args = {"path": "/tmp/scratch.txt"}
         on_pre_tool_call(tool_name="read", args=args, task_id="t1")
         on_post_tool_call(tool_name="read", args=args, result="ok", task_id="t1")
-        span = _span_by_name(exporter.get_finished_spans(), "tool.read")
+        span = _span_by_name(exporter.get_finished_spans(), "execute_tool read")
         assert "hermes.skill.name" not in span.attributes
 
     def test_no_skill_on_optional_skills_references(self, inmemory_otel_setup):
@@ -114,7 +114,7 @@ class TestSkillNameInference:
         args = {"path": "/repo/optional-skills/monitor/references/api.md"}
         on_pre_tool_call(tool_name="read", args=args, task_id="t1")
         on_post_tool_call(tool_name="read", args=args, result="ok", task_id="t1")
-        span = _span_by_name(exporter.get_finished_spans(), "tool.read")
+        span = _span_by_name(exporter.get_finished_spans(), "execute_tool read")
         assert "hermes.skill.name" not in span.attributes
 
 

--- a/tests/integration/test_turn_summary.py
+++ b/tests/integration/test_turn_summary.py
@@ -101,7 +101,7 @@ class TestTurnSummaryBasic:
         )
 
         spans = exporter.get_finished_spans()
-        agent = _span_by_name(spans, "agent")
+        agent = _span_by_name(spans, "invoke_agent")
         attrs = dict(agent.attributes)
 
         assert attrs["hermes.turn.tool_count"] == 2
@@ -123,7 +123,7 @@ class TestTurnSummaryBasic:
                 ("bash", {"command": "ls"}, "ok"),  # duplicate command
             ],
         )
-        agent = _span_by_name(exporter.get_finished_spans(), "agent")
+        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent")
         attrs = dict(agent.attributes)
         assert attrs["hermes.turn.tool_count"] == 1
         assert attrs["hermes.turn.tools"] == "bash"
@@ -139,7 +139,7 @@ class TestTurnSummaryBasic:
                 ("read", {"path": "/repo/skills/deployer/index.md"}, "ok"),
             ],
         )
-        agent = _span_by_name(exporter.get_finished_spans(), "agent")
+        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent")
         attrs = dict(agent.attributes)
         assert attrs["hermes.turn.skill_count"] == 2
         assert attrs["hermes.turn.skills"] == "deployer,monitor"
@@ -153,7 +153,7 @@ class TestTurnSummaryBasic:
                 ("bash", {"command": "fail"}, '{"error": "boom"}'),
             ],
         )
-        agent = _span_by_name(exporter.get_finished_spans(), "agent")
+        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent")
         attrs = dict(agent.attributes)
         assert "completed" in attrs["hermes.turn.tool_outcomes"]
         assert "error" in attrs["hermes.turn.tool_outcomes"]
@@ -163,7 +163,7 @@ class TestTurnSummaryEdgeCases:
     def test_session_with_no_tools(self, inmemory_otel_setup):
         exporter, _ = inmemory_otel_setup
         _run_full_turn("s1", [])
-        agent = _span_by_name(exporter.get_finished_spans(), "agent")
+        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent")
         attrs = dict(agent.attributes)
         # Zero-count attributes are skipped entirely
         assert "hermes.turn.tool_count" not in attrs
@@ -178,7 +178,7 @@ class TestTurnSummaryEdgeCases:
         on_session_end(
             session_id="s1", completed=False, interrupted=True, model="gpt-4", platform="cli"
         )
-        agent = _span_by_name(exporter.get_finished_spans(), "agent")
+        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent")
         assert agent.attributes["hermes.turn.final_status"] == "interrupted"
 
     def test_incomplete_session_final_status(self, inmemory_otel_setup):
@@ -187,7 +187,7 @@ class TestTurnSummaryEdgeCases:
         on_session_end(
             session_id="s1", completed=False, interrupted=False, model="gpt-4", platform="cli"
         )
-        agent = _span_by_name(exporter.get_finished_spans(), "agent")
+        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent")
         assert agent.attributes["hermes.turn.final_status"] == "incomplete"
 
     def test_long_tool_list_clipped(self, inmemory_otel_setup):
@@ -195,7 +195,7 @@ class TestTurnSummaryEdgeCases:
         exporter, _ = inmemory_otel_setup
         many = [(f"tool_{i:04d}", {}, "ok") for i in range(200)]
         _run_full_turn("s1", many)
-        agent = _span_by_name(exporter.get_finished_spans(), "agent")
+        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent")
         tools_attr = agent.attributes["hermes.turn.tools"]
         assert len(tools_attr) == 500
         assert tools_attr.endswith("...")

--- a/tests/integration/test_turn_summary.py
+++ b/tests/integration/test_turn_summary.py
@@ -101,7 +101,7 @@ class TestTurnSummaryBasic:
         )
 
         spans = exporter.get_finished_spans()
-        agent = _span_by_name(spans, "invoke_agent")
+        agent = _span_by_name(spans, "invoke_agent hermes-agent")
         attrs = dict(agent.attributes)
 
         assert attrs["hermes.turn.tool_count"] == 2
@@ -123,7 +123,7 @@ class TestTurnSummaryBasic:
                 ("bash", {"command": "ls"}, "ok"),  # duplicate command
             ],
         )
-        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent")
+        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent hermes-agent")
         attrs = dict(agent.attributes)
         assert attrs["hermes.turn.tool_count"] == 1
         assert attrs["hermes.turn.tools"] == "bash"
@@ -139,7 +139,7 @@ class TestTurnSummaryBasic:
                 ("read", {"path": "/repo/skills/deployer/index.md"}, "ok"),
             ],
         )
-        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent")
+        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent hermes-agent")
         attrs = dict(agent.attributes)
         assert attrs["hermes.turn.skill_count"] == 2
         assert attrs["hermes.turn.skills"] == "deployer,monitor"
@@ -153,7 +153,7 @@ class TestTurnSummaryBasic:
                 ("bash", {"command": "fail"}, '{"error": "boom"}'),
             ],
         )
-        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent")
+        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent hermes-agent")
         attrs = dict(agent.attributes)
         assert "completed" in attrs["hermes.turn.tool_outcomes"]
         assert "error" in attrs["hermes.turn.tool_outcomes"]
@@ -163,7 +163,7 @@ class TestTurnSummaryEdgeCases:
     def test_session_with_no_tools(self, inmemory_otel_setup):
         exporter, _ = inmemory_otel_setup
         _run_full_turn("s1", [])
-        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent")
+        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent hermes-agent")
         attrs = dict(agent.attributes)
         # Zero-count attributes are skipped entirely
         assert "hermes.turn.tool_count" not in attrs
@@ -178,7 +178,7 @@ class TestTurnSummaryEdgeCases:
         on_session_end(
             session_id="s1", completed=False, interrupted=True, model="gpt-4", platform="cli"
         )
-        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent")
+        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent hermes-agent")
         assert agent.attributes["hermes.turn.final_status"] == "interrupted"
 
     def test_incomplete_session_final_status(self, inmemory_otel_setup):
@@ -187,7 +187,7 @@ class TestTurnSummaryEdgeCases:
         on_session_end(
             session_id="s1", completed=False, interrupted=False, model="gpt-4", platform="cli"
         )
-        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent")
+        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent hermes-agent")
         assert agent.attributes["hermes.turn.final_status"] == "incomplete"
 
     def test_long_tool_list_clipped(self, inmemory_otel_setup):
@@ -195,7 +195,7 @@ class TestTurnSummaryEdgeCases:
         exporter, _ = inmemory_otel_setup
         many = [(f"tool_{i:04d}", {}, "ok") for i in range(200)]
         _run_full_turn("s1", many)
-        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent")
+        agent = _span_by_name(exporter.get_finished_spans(), "invoke_agent hermes-agent")
         tools_attr = agent.attributes["hermes.turn.tools"]
         assert len(tools_attr) == 500
         assert tools_attr.endswith("...")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -373,6 +373,22 @@ class TestBackendsYaml:
         cfg = load_config(path=tmp_path / "missing.yaml")
         assert cfg.backends is None
 
+    def test_default_path_uses_active_hermes_home(self, tmp_path, monkeypatch):
+        if not _has_yaml():
+            pytest.skip("pyyaml not installed")
+        cfg_path = tmp_path / "plugins" / "hermes_otel" / "config.yaml"
+        cfg_path.parent.mkdir(parents=True)
+        cfg_path.write_text(
+            "backends:\n"
+            "  - type: honeycomb\n"
+            "    api_key_env: HONEYCOMB_API_KEY\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg = load_config()
+        assert cfg.backends is not None
+        assert cfg.backends[0].type == "honeycomb"
+        assert cfg.backends[0].api_key_env == "HONEYCOMB_API_KEY"
+
     def test_loads_multiple_backends(self, tmp_path):
         if not _has_yaml():
             pytest.skip("pyyaml not installed")
@@ -414,6 +430,25 @@ class TestBackendsYaml:
         assert b.public_key_env == "LANGFUSE_PUBLIC_KEY"
         assert b.secret_key_env == "LANGFUSE_SECRET_KEY"
         assert b.base_url == "https://cloud.langfuse.com"
+
+    def test_loads_honeycomb_credentials(self, tmp_path):
+        if not _has_yaml():
+            pytest.skip("pyyaml not installed")
+        path = tmp_path / "config.yaml"
+        path.write_text(
+            "backends:\n"
+            "  - type: honeycomb\n"
+            "    region: eu\n"
+            "    api_key_env: HONEYCOMB_API_KEY\n"
+            "    dataset_env: HONEYCOMB_DATASET\n"
+        )
+        cfg = load_config(path=path)
+        assert cfg.backends is not None
+        b = cfg.backends[0]
+        assert b.type == "honeycomb"
+        assert b.region == "eu"
+        assert b.api_key_env == "HONEYCOMB_API_KEY"
+        assert b.dataset_env == "HONEYCOMB_DATASET"
 
     def test_loads_per_backend_headers(self, tmp_path):
         if not _has_yaml():

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -26,6 +26,8 @@ KANBAN_ENV_KEYS = (
     "HERMES_TENANT",
     "HERMES_PROFILE",
     "HERMES_KANBAN_SOURCE_KIND",
+    "HERMES_OTEL_CONVERSATION_ID",
+    "HERMES_PARENT_CONVERSATION_ID",
 )
 
 
@@ -75,7 +77,7 @@ class TestOnSessionStart:
         on_session_start(session_id="s1", model="gpt-4", platform="api_server")
         mock_tracer.start_span.assert_called_once()
         call_kwargs = mock_tracer.start_span.call_args[1]
-        assert call_kwargs["name"] == "invoke_agent"
+        assert call_kwargs["name"] == "invoke_agent hermes-agent"
         assert call_kwargs["key"] == "session:s1"
         assert call_kwargs["kind"] == "agent"
 
@@ -114,6 +116,30 @@ class TestOnSessionStart:
         assert attrs["gen_ai.operation.name"] == "invoke_agent"
         assert attrs["gen_ai.request.model"] == "gpt-4o"
         assert attrs["gen_ai.provider.name"] == "telegram"
+
+    def test_uses_propagated_conversation_id_from_env(self, mock_tracer, monkeypatch):
+        monkeypatch.setenv("HERMES_OTEL_CONVERSATION_ID", "parent-conversation")
+
+        on_session_start(session_id="child-session", model="gpt-4o", platform="cli")
+
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert attrs["gen_ai.conversation.id"] == "parent-conversation"
+        assert "hermes.conversation.id" not in attrs
+
+    def test_explicit_canonical_conversation_id_wins_over_env(
+        self, mock_tracer, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_OTEL_CONVERSATION_ID", "env-conversation")
+
+        on_session_start(
+            session_id="child-session",
+            model="gpt-4o",
+            platform="cli",
+            **{"gen_ai.conversation.id": "kw-conversation"},
+        )
+
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert attrs["gen_ai.conversation.id"] == "kw-conversation"
 
     def test_uses_propagated_kanban_parent_context(self, mock_tracer, monkeypatch):
         traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
@@ -157,6 +183,7 @@ class TestOnSessionStart:
     def test_agent_name_uses_profile_context(self, mock_tracer, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", "/home/test/.hermes/profiles/engineer")
         on_session_start(session_id="s1", model="gpt-4", platform="cli")
+        assert mock_tracer.start_span.call_args[1]["name"] == "invoke_agent engineer"
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
         assert attrs["gen_ai.agent.name"] == "engineer"
 
@@ -164,6 +191,7 @@ class TestOnSessionStart:
         monkeypatch.delenv("HERMES_PROFILE", raising=False)
         monkeypatch.setenv("HERMES_HOME", "/home/test/.hermes")
         on_session_start(session_id="s1", model="gpt-4", platform="cli")
+        assert mock_tracer.start_span.call_args[1]["name"] == "invoke_agent default"
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
         assert attrs["gen_ai.agent.name"] == "default"
 
@@ -491,6 +519,53 @@ class TestOnPreLlmCall:
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
         assert attrs["correlation.id"] == "corr-123"
 
+    def test_reuses_session_conversation_id_on_child_span(self, mock_tracer):
+        mock_tracer.spans._active_spans["session:child-session"] = MagicMock()
+        on_session_start(
+            session_id="child-session",
+            model="gpt-4",
+            platform="cli",
+            **{"gen_ai.conversation.id": "parent-conversation"},
+        )
+        mock_tracer.start_span.reset_mock()
+
+        on_pre_llm_call(
+            session_id="child-session",
+            user_message="hello",
+            conversation_history=[],
+            is_first_turn=True,
+            model="gpt-4",
+            platform="cli",
+        )
+
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert attrs["gen_ai.conversation.id"] == "parent-conversation"
+
+    def test_session_state_uses_full_session_id_for_conversation(self, mock_tracer):
+        long_session_id = "s" * 250
+        mock_tracer.spans._active_spans[f"session:{long_session_id}"] = MagicMock()
+        on_session_start(
+            session_id=long_session_id,
+            model="gpt-4",
+            platform="cli",
+            **{"gen_ai.conversation.id": "long-parent-conversation"},
+        )
+        assert long_session_id in mock_tracer.sessions._sessions
+        assert ("s" * 200) not in mock_tracer.sessions._sessions
+        mock_tracer.start_span.reset_mock()
+
+        on_pre_llm_call(
+            session_id=long_session_id,
+            user_message="hello",
+            conversation_history=[],
+            is_first_turn=True,
+            model="gpt-4",
+            platform="cli",
+        )
+
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert attrs["gen_ai.conversation.id"] == "long-parent-conversation"
+
     def test_session_state_uses_full_session_id_for_correlation(self, mock_tracer):
         long_session_id = "s" * 250
         mock_tracer.spans._active_spans[f"session:{long_session_id}"] = MagicMock()
@@ -537,7 +612,7 @@ class TestOnPreLlmCall:
         # Two start_span calls: invoke_agent (synthesized) + chat gpt-4
         assert mock_tracer.start_span.call_count == 2
         first_kw = mock_tracer.start_span.call_args_list[0][1]
-        assert first_kw["name"] == "invoke_agent"
+        assert first_kw["name"] == "invoke_agent hermes-agent"
         assert first_kw["key"] == "session:s1"
         assert first_kw["attributes"].get("hermes.session.synthesized") is True
 

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from hermes_otel.hooks import (
+    _kanban_context_from_kwargs_env,
     on_api_request_error,
+    on_kanban_task_blocked,
+    on_kanban_task_claimed,
+    on_kanban_task_completed,
     on_post_api_request,
     on_post_llm_call,
     on_post_tool_call,
@@ -14,6 +18,21 @@ from hermes_otel.hooks import (
     on_session_end,
     on_session_start,
 )
+
+KANBAN_ENV_KEYS = (
+    "HERMES_KANBAN_TASK",
+    "HERMES_KANBAN_RUN_ID",
+    "HERMES_KANBAN_BOARD",
+    "HERMES_TENANT",
+    "HERMES_PROFILE",
+    "HERMES_KANBAN_SOURCE_KIND",
+)
+
+
+@pytest.fixture()
+def clean_kanban_env(monkeypatch):
+    for key in KANBAN_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
 
 
 @pytest.fixture()
@@ -128,6 +147,97 @@ class TestOnSessionStart:
     def test_noop_when_disabled(self, disabled_tracer):
         on_session_start(session_id="s1", model="gpt-4", platform="cli")
         disabled_tracer.start_span.assert_not_called()
+
+
+class TestKanbanContextResolver:
+    def test_env_only_context(self, clean_kanban_env, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_123")
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+        monkeypatch.setenv("HERMES_TENANT", "hermes-otel")
+        monkeypatch.setenv("HERMES_PROFILE", "engineer")
+
+        attrs = _kanban_context_from_kwargs_env({})
+
+        assert attrs == {
+            "hermes.kanban.flow.kind": "worker",
+            "hermes.kanban.task.id": "t_123",
+            "hermes.kanban.run.id": "42",
+            "hermes.kanban.board": "default",
+            "hermes.kanban.tenant": "hermes-otel",
+            "hermes.kanban.assignee": "engineer",
+        }
+
+    def test_kwargs_win_over_env(self, clean_kanban_env, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "env-task")
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "env-run")
+        monkeypatch.setenv("HERMES_PROFILE", "env-profile")
+
+        attrs = _kanban_context_from_kwargs_env(
+            {
+                "kanban_task_id": "kw-task",
+                "kanban_run_id": "kw-run",
+                "kanban_board": "board-a",
+                "kanban_assignee": "researcher",
+                "kanban_flow_kind": "recovery",
+                "kanban_source_kind": "telegram",
+            }
+        )
+
+        assert attrs["hermes.kanban.task.id"] == "kw-task"
+        assert attrs["hermes.kanban.run.id"] == "kw-run"
+        assert attrs["hermes.kanban.board"] == "board-a"
+        assert attrs["hermes.kanban.assignee"] == "researcher"
+        assert attrs["hermes.kanban.flow.kind"] == "recovery"
+        assert attrs["hermes.kanban.source.kind"] == "telegram"
+
+    def test_generic_hook_kwargs_do_not_imply_kanban_context(self, clean_kanban_env):
+        attrs = _kanban_context_from_kwargs_env(
+            {"task_id": "api-call-1", "run_id": "generic-run", "tenant": "project"}
+        )
+        assert attrs == {}
+
+    def test_non_kanban_session_omits_context(self, clean_kanban_env, monkeypatch):
+        monkeypatch.setenv("HERMES_PROFILE", "engineer")
+        assert _kanban_context_from_kwargs_env({}) == {}
+
+    def test_tenant_alone_does_not_imply_kanban_context(self, clean_kanban_env, monkeypatch):
+        monkeypatch.setenv("HERMES_TENANT", "hermes-otel")
+        monkeypatch.setenv("HERMES_PROFILE", "engineer")
+        assert _kanban_context_from_kwargs_env({}) == {}
+
+    def test_malformed_values_are_omitted(self, clean_kanban_env, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "")
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "   ")
+        assert _kanban_context_from_kwargs_env({"kanban_task_id": None}) == {}
+
+    def test_long_whitespace_values_are_omitted(self, clean_kanban_env, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", " " * 500)
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "\t" * 500)
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "\n" * 500)
+        assert _kanban_context_from_kwargs_env({}) == {}
+
+    def test_uses_only_canonical_dotted_keys(self, clean_kanban_env, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_123")
+        attrs = _kanban_context_from_kwargs_env({})
+        assert all(key.startswith("hermes.kanban.") for key in attrs)
+        assert "kanban_task_id" not in attrs
+        assert "hermes_kanban_task_id" not in attrs
+
+    def test_canonical_concepts_are_not_dual_emitted(self, clean_kanban_env, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_123")
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "43")
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+        attrs = _kanban_context_from_kwargs_env({})
+        forbidden_aliases = {
+            "kanban_task_id",
+            "hermes_kanban_task_id",
+            "kanban_run_id",
+            "hermes_kanban_run_id",
+            "kanban_board",
+            "hermes_kanban_board",
+        }
+        assert forbidden_aliases.isdisjoint(attrs)
 
 
 class TestOnSessionEnd:
@@ -1167,3 +1277,191 @@ class TestFullCaptureFlags:
         on_post_api_request(**self._post_kwargs(response_content="hi", response_tool_calls=[]))
         attrs = mock_tracer.end_span.call_args[1]["attributes"]
         assert "gen_ai.output.messages" not in attrs
+
+
+class TestKanbanSpanAttributes:
+    def _set_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_123")
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "43")
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+        monkeypatch.setenv("HERMES_TENANT", "hermes-otel")
+        monkeypatch.setenv("HERMES_PROFILE", "engineer")
+
+    def _assert_kanban_attrs(self, attrs):
+        assert attrs["hermes.kanban.flow.kind"] == "worker"
+        assert attrs["hermes.kanban.task.id"] == "t_123"
+        assert attrs["hermes.kanban.run.id"] == "43"
+        assert attrs["hermes.kanban.board"] == "default"
+        assert attrs["hermes.kanban.tenant"] == "hermes-otel"
+        assert attrs["hermes.kanban.assignee"] == "engineer"
+
+    def test_session_llm_api_tool_and_error_spans_include_kanban_context(
+        self, mock_tracer, clean_kanban_env, monkeypatch
+    ):
+        self._set_env(monkeypatch)
+
+        on_session_start(session_id="s1", model="gpt-4", platform="cli")
+        self._assert_kanban_attrs(mock_tracer.start_span.call_args[1]["attributes"])
+        mock_tracer.reset_mock()
+
+        on_pre_llm_call(
+            session_id="s1",
+            user_message="hello",
+            conversation_history=[],
+            is_first_turn=True,
+            model="gpt-4",
+            platform="cli",
+        )
+        self._assert_kanban_attrs(mock_tracer.start_span.call_args[1]["attributes"])
+        mock_tracer.reset_mock()
+
+        on_post_llm_call(
+            session_id="s1",
+            user_message="hello",
+            assistant_response="hi",
+            conversation_history=[],
+            model="gpt-4",
+            platform="cli",
+        )
+        self._assert_kanban_attrs(mock_tracer.end_span.call_args[1]["attributes"])
+        mock_tracer.reset_mock()
+
+        on_pre_api_request(
+            task_id="api1",
+            session_id="s1",
+            platform="cli",
+            model="gpt-4",
+            provider="openai",
+            base_url="",
+            api_mode="chat",
+            api_call_count=1,
+            message_count=1,
+            tool_count=0,
+            approx_input_tokens=1,
+            request_char_count=5,
+            max_tokens=0,
+        )
+        self._assert_kanban_attrs(mock_tracer.start_span.call_args[1]["attributes"])
+        mock_tracer.reset_mock()
+
+        on_api_request_error(
+            task_id="api1",
+            session_id="s1",
+            platform="cli",
+            model="gpt-4",
+            provider="openai",
+            base_url="",
+            api_mode="chat",
+            error=RuntimeError("boom"),
+        )
+        self._assert_kanban_attrs(mock_tracer.end_span.call_args[1]["attributes"])
+        mock_tracer.reset_mock()
+
+        on_post_api_request(
+            task_id="api2",
+            session_id="s1",
+            platform="cli",
+            model="gpt-4",
+            provider="openai",
+            base_url="",
+            api_mode="chat",
+            api_call_count=1,
+            api_duration=0.1,
+            finish_reason="stop",
+            message_count=1,
+            response_model="gpt-4",
+            usage={},
+            assistant_content_chars=0,
+            assistant_tool_call_count=0,
+        )
+        self._assert_kanban_attrs(mock_tracer.end_span.call_args[1]["attributes"])
+        mock_tracer.reset_mock()
+
+        on_pre_tool_call(tool_name="bash", args={}, task_id="tool1", session_id="s1")
+        self._assert_kanban_attrs(mock_tracer.start_span.call_args[1]["attributes"])
+        mock_tracer.reset_mock()
+
+        on_post_tool_call(
+            tool_name="bash",
+            args={},
+            result="ok",
+            task_id="tool1",
+            session_id="s1",
+        )
+        self._assert_kanban_attrs(mock_tracer.end_span.call_args[1]["attributes"])
+        mock_tracer.reset_mock()
+
+        on_session_end(
+            session_id="s1", completed=True, interrupted=False, model="gpt-4", platform="cli"
+        )
+        self._assert_kanban_attrs(mock_tracer.end_span.call_args[1]["attributes"])
+
+    def test_session_reuses_saved_kanban_context_when_env_changes(
+        self, mock_tracer, clean_kanban_env, monkeypatch
+    ):
+        self._set_env(monkeypatch)
+        on_session_start(session_id="s1", model="gpt-4", platform="cli")
+
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_999")
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "99")
+        mock_tracer.reset_mock()
+
+        on_pre_tool_call(tool_name="bash", args={}, task_id="tool1", session_id="s1")
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert attrs["hermes.kanban.task.id"] == "t_123"
+        assert attrs["hermes.kanban.run.id"] == "43"
+
+    def test_non_kanban_spans_omit_kanban_context(self, mock_tracer, clean_kanban_env):
+        on_session_start(session_id="s1", model="gpt-4", platform="cli")
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert not any(key.startswith("hermes.kanban.") for key in attrs)
+
+    def test_non_kanban_tool_and_api_spans_omit_kanban_context(
+        self, mock_tracer, clean_kanban_env
+    ):
+        on_pre_tool_call(tool_name="bash", args={}, task_id="tool1", session_id="s1")
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert not any(key.startswith("hermes.kanban.") for key in attrs)
+        mock_tracer.reset_mock()
+
+        on_pre_api_request(
+            task_id="api1",
+            session_id="s1",
+            platform="cli",
+            model="gpt-4",
+            provider="openai",
+            base_url="",
+            api_mode="chat",
+            api_call_count=1,
+            message_count=1,
+            tool_count=0,
+            approx_input_tokens=1,
+            request_char_count=5,
+            max_tokens=0,
+        )
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert not any(key.startswith("hermes.kanban.") for key in attrs)
+
+    @pytest.mark.parametrize(
+        ("callback", "event"),
+        [
+            (on_kanban_task_claimed, "claimed"),
+            (on_kanban_task_completed, "completed"),
+            (on_kanban_task_blocked, "blocked"),
+        ],
+    )
+    def test_lifecycle_hooks_emit_short_spans(self, mock_tracer, clean_kanban_env, callback, event):
+        callback(
+            kanban_task_id="t_123",
+            kanban_run_id="43",
+            kanban_board="default",
+            kanban_tenant="hermes-otel",
+            kanban_assignee="engineer",
+        )
+        start_kwargs = mock_tracer.start_span.call_args[1]
+        end_kwargs = mock_tracer.end_span.call_args[1]
+        assert start_kwargs["name"] == f"kanban.task.{event}"
+        assert start_kwargs["kind"] == "general"
+        assert start_kwargs["attributes"]["hermes.kanban.lifecycle.event"] == event
+        assert end_kwargs["attributes"]["hermes.kanban.lifecycle.event"] == event
+        assert end_kwargs["status"] == "ok"

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from hermes_otel.hooks import (
+    on_api_request_error,
     on_post_api_request,
     on_post_llm_call,
     on_post_tool_call,
@@ -213,6 +214,8 @@ class TestOnPreToolCall:
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
         assert attrs["tool.name"] == "bash"
         assert attrs["gen_ai.tool.name"] == "bash"
+        assert attrs["gen_ai.tool.type"] == "function"
+        assert attrs["gen_ai.tool.call.id"] == "t1"
         assert '"cmd"' in attrs["input.value"]
 
     def test_full_mcp_args_follow_preview_privacy_gate(self, mock_tracer):
@@ -283,6 +286,18 @@ class TestOnPostToolCall:
         kw = mock_tracer.end_span.call_args[1]
         assert kw["status"] == "error"
         assert "boom" in (kw.get("error_message") or "")
+        assert kw["attributes"]["error.type"] == "tool_error"
+
+    def test_uses_explicit_error_type_when_present(self, mock_tracer):
+        mock_tracer.sessions.record_tool_start("bash:t1", 1000.0)
+        on_post_tool_call(
+            tool_name="bash",
+            args={},
+            result='{"error": "boom", "error_type": "RateLimitError"}',
+            task_id="t1",
+        )
+        attrs = mock_tracer.end_span.call_args[1]["attributes"]
+        assert attrs["error.type"] == "RateLimitError"
 
     def test_records_tool_duration_metric(self, mock_tracer):
         mock_tracer.sessions.record_tool_start("bash:t1", 1000.0)
@@ -686,6 +701,80 @@ class TestOnPreApiRequest:
         assert attrs["gen_ai.provider.name"] == "openai"
         assert attrs["gen_ai.system"] == "openai"
 
+    def test_includes_server_attributes_from_base_url(self, mock_tracer):
+        on_pre_api_request(
+            task_id="t1",
+            session_id="s1",
+            platform="cli",
+            model="gpt-4",
+            provider="openai",
+            base_url="https://api.openai.com:8443/v1",
+            api_mode="chat",
+            api_call_count=1,
+            message_count=10,
+            tool_count=0,
+            approx_input_tokens=500,
+            request_char_count=2000,
+            max_tokens=2048,
+        )
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert attrs["server.address"] == "api.openai.com"
+        assert attrs["server.port"] == 8443
+
+    def test_emits_inference_details_event_without_prompt_payload(self, mock_tracer):
+        span = MagicMock()
+        mock_tracer.start_span.return_value = span
+        on_pre_api_request(
+            task_id="t1",
+            session_id="s1",
+            platform="cli",
+            model="gpt-4",
+            provider="openai",
+            base_url="https://api.openai.com/v1",
+            api_mode="chat",
+            api_call_count=1,
+            message_count=10,
+            tool_count=0,
+            approx_input_tokens=500,
+            request_char_count=2000,
+            max_tokens=2048,
+            messages=[{"role": "user", "content": "secret"}],
+        )
+        event_name, event_attrs = span.add_event.call_args[0]
+        assert event_name == "gen_ai.client.inference.operation.details"
+        assert event_attrs["gen_ai.operation.name"] == "chat"
+        assert event_attrs["gen_ai.request.model"] == "gpt-4"
+        assert "gen_ai.input.messages" not in event_attrs
+
+    def test_inference_details_event_excludes_full_prompt_payload_when_enabled(
+        self, mock_tracer
+    ):
+        from hermes_otel.plugin_config import HermesOtelConfig
+
+        span = MagicMock()
+        mock_tracer.start_span.return_value = span
+        mock_tracer.config = HermesOtelConfig(capture_full_prompts=True)
+        on_pre_api_request(
+            task_id="t1",
+            session_id="s1",
+            platform="cli",
+            model="gpt-4",
+            provider="openai",
+            base_url="https://api.openai.com/v1",
+            api_mode="chat",
+            api_call_count=1,
+            message_count=10,
+            tool_count=0,
+            approx_input_tokens=500,
+            request_char_count=2000,
+            max_tokens=2048,
+            messages=[{"role": "user", "content": "secret"}],
+            system_prompt="private system prompt",
+        )
+        event_attrs = span.add_event.call_args[0][1]
+        assert "gen_ai.input.messages" not in event_attrs
+        assert "gen_ai.system_instructions" not in event_attrs
+
     def test_includes_standard_request_params(self, mock_tracer):
         on_pre_api_request(
             task_id="t1",
@@ -755,6 +844,29 @@ class TestOnPreApiRequest:
         disabled_tracer.start_span.assert_not_called()
 
 
+class TestOnApiRequestError:
+    def test_ends_api_span_with_error_type(self, mock_tracer):
+        error = TimeoutError("request timed out")
+        on_api_request_error(
+            task_id="t1",
+            session_id="s1",
+            platform="cli",
+            model="gpt-4",
+            provider="openai",
+            base_url="https://api.openai.com/v1",
+            api_mode="chat",
+            error=error,
+        )
+        mock_tracer.spans.pop_parent.assert_called_once_with(session_id="s1")
+        kw = mock_tracer.end_span.call_args[1]
+        attrs = kw["attributes"]
+        assert kw["status"] == "error"
+        assert kw["error_message"] == "request timed out"
+        assert attrs["error.type"] == "TimeoutError"
+        assert attrs["server.address"] == "api.openai.com"
+        assert attrs["gen_ai.operation.name"] == "chat"
+
+
 class TestOnPostApiRequest:
     def _call_post_api(self, mock_tracer, usage=None, **overrides):
         defaults = dict(
@@ -804,6 +916,33 @@ class TestOnPostApiRequest:
         assert attrs["gen_ai.response.model"] == "gpt-4"
         assert attrs["gen_ai.provider.name"] == "openai"
         assert attrs["gen_ai.system"] == "openai"
+
+    def test_reasoning_token_attribute(self, mock_tracer):
+        usage = {
+            "prompt_tokens": 100,
+            "output_tokens": 50,
+            "total_tokens": 170,
+            "output_tokens_details": {"reasoning_tokens": 20},
+        }
+        self._call_post_api(mock_tracer, usage=usage)
+        attrs = mock_tracer.end_span.call_args[1]["attributes"]
+        assert attrs["gen_ai.usage.reasoning.output_tokens"] == 20
+        assert mock_tracer.sessions.peek("s1").usage["reasoning_output_tokens"] == 20
+
+    def test_compaction_attr_only_when_explicit(self, mock_tracer):
+        self._call_post_api(mock_tracer, conversation_compacted=True)
+        attrs = mock_tracer.end_span.call_args[1]["attributes"]
+        assert attrs["gen_ai.conversation.compacted"] is True
+
+    def test_no_compaction_attr_when_unknown(self, mock_tracer):
+        self._call_post_api(mock_tracer)
+        attrs = mock_tracer.end_span.call_args[1]["attributes"]
+        assert "gen_ai.conversation.compacted" not in attrs
+
+    def test_time_to_first_chunk_attribute(self, mock_tracer):
+        self._call_post_api(mock_tracer, time_to_first_chunk_ms=125)
+        attrs = mock_tracer.end_span.call_args[1]["attributes"]
+        assert attrs["gen_ai.response.time_to_first_chunk"] == 0.125
 
     def test_cache_token_attributes(self, mock_tracer):
         usage = {

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -75,7 +75,7 @@ class TestOnSessionStart:
         on_session_start(session_id="s1", model="gpt-4", platform="api_server")
         mock_tracer.start_span.assert_called_once()
         call_kwargs = mock_tracer.start_span.call_args[1]
-        assert call_kwargs["name"] == "agent"
+        assert call_kwargs["name"] == "invoke_agent"
         assert call_kwargs["key"] == "session:s1"
         assert call_kwargs["kind"] == "agent"
 
@@ -340,7 +340,7 @@ class TestOnPreToolCall:
         on_pre_tool_call(tool_name="bash", args={"cmd": "ls"}, task_id="t1")
         mock_tracer.start_span.assert_called_once()
         kw = mock_tracer.start_span.call_args[1]
-        assert kw["name"] == "tool.bash"
+        assert kw["name"] == "execute_tool bash"
         assert kw["key"] == "bash:t1"
         assert kw["kind"] == "tool"
 
@@ -471,7 +471,7 @@ class TestOnPreLlmCall:
         )
         mock_tracer.start_span.assert_called_once()
         kw = mock_tracer.start_span.call_args[1]
-        assert kw["name"] == "llm.gpt-4"
+        assert kw["name"] == "chat gpt-4"
         assert kw["key"] == "llm:s1"
         assert kw["kind"] == "llm"
         assert kw["attributes"]["correlation.id"] == "s1"
@@ -534,10 +534,10 @@ class TestOnPreLlmCall:
             model="gpt-4",
             platform="cli",
         )
-        # Two start_span calls: agent (synthesized) + llm.gpt-4
+        # Two start_span calls: invoke_agent (synthesized) + chat gpt-4
         assert mock_tracer.start_span.call_count == 2
         first_kw = mock_tracer.start_span.call_args_list[0][1]
-        assert first_kw["name"] == "agent"
+        assert first_kw["name"] == "invoke_agent"
         assert first_kw["key"] == "session:s1"
         assert first_kw["attributes"].get("hermes.session.synthesized") is True
 
@@ -794,7 +794,7 @@ class TestOnPreApiRequest:
         )
         mock_tracer.start_span.assert_called_once()
         kw = mock_tracer.start_span.call_args[1]
-        assert kw["name"] == "api.gpt-4"
+        assert kw["name"] == "chat gpt-4"
         assert kw["key"] == "api:t1"
         assert kw["kind"] == "llm"
 
@@ -916,7 +916,13 @@ class TestOnPreApiRequest:
             messages=[{"role": "user", "content": "secret"}],
             system_prompt="private system prompt",
         )
-        event_attrs = span.add_event.call_args[0][1]
+        inference_events = [
+            call.args[1]
+            for call in span.add_event.call_args_list
+            if call.args[0] == "gen_ai.client.inference.operation.details"
+        ]
+        assert len(inference_events) == 1
+        event_attrs = inference_events[0]
         assert "gen_ai.input.messages" not in event_attrs
         assert "gen_ai.system_instructions" not in event_attrs
 
@@ -1220,6 +1226,8 @@ class TestFullCaptureFlags:
     def test_pre_writes_full_prompt_when_flag_on(self, mock_tracer):
         from hermes_otel.plugin_config import HermesOtelConfig
 
+        span = MagicMock()
+        mock_tracer.start_span.return_value = span
         mock_tracer.config = HermesOtelConfig(capture_full_prompts=True)
         huge = "x" * 5000  # well past preview_max_chars (1200)
         messages = [
@@ -1228,15 +1236,25 @@ class TestFullCaptureFlags:
         ]
         on_pre_api_request(**self._pre_kwargs(messages=messages, system_prompt="the-system-prompt"))
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
-        assert attrs["gen_ai.system_instructions"] == "the-system-prompt"
-        assert attrs["input.mime_type"] == "application/json"
-        # Full, untruncated payload round-trips
+        assert "gen_ai.input.messages" not in attrs
+        assert "gen_ai.system_instructions" not in attrs
+        assert "input.value" not in attrs
+        assert "input.mime_type" not in attrs
+
+        calls = span.add_event.call_args_list
+        payload_events = {call.args[0]: call.args[1] for call in calls}
+        assert payload_events["gen_ai.system_instructions"]["gen_ai.system_instructions"] == (
+            "the-system-prompt"
+        )
+        assert payload_events["gen_ai.input.messages"]["gen_ai.input.messages.mime_type"] == (
+            "application/json"
+        )
+        # Full, untruncated event payload round-trips
         import json as _json
 
-        parsed = _json.loads(attrs["gen_ai.input.messages"])
+        parsed = _json.loads(payload_events["gen_ai.input.messages"]["gen_ai.input.messages"])
         assert parsed == messages
-        assert _json.loads(attrs["gen_ai.input.messages"]) == messages
-        assert len(attrs["input.value"]) > 5000
+        assert len(payload_events["gen_ai.input.messages"]["gen_ai.input.messages"]) > 5000
 
     def test_pre_handles_empty_messages(self, mock_tracer):
         from hermes_otel.plugin_config import HermesOtelConfig
@@ -1261,15 +1279,20 @@ class TestFullCaptureFlags:
     def test_post_writes_full_response_when_flag_on(self, mock_tracer):
         from hermes_otel.plugin_config import HermesOtelConfig
 
+        span = MagicMock()
+        mock_tracer.spans.get_span.return_value = span
         mock_tracer.config = HermesOtelConfig(capture_full_responses=True)
         big_response = "answer " * 500  # > preview_max_chars
         on_post_api_request(
             **self._post_kwargs(response_content=big_response, response_tool_calls=[])
         )
         attrs = mock_tracer.end_span.call_args[1]["attributes"]
-        assert "gen_ai.output.messages" in attrs
-        assert attrs["output.value"] == big_response
-        assert attrs["output.mime_type"] == "text/plain"
+        assert "gen_ai.output.messages" not in attrs
+        assert "output.value" not in attrs
+        event_name, event_attrs = span.add_event.call_args.args
+        assert event_name == "gen_ai.output.messages"
+        assert event_attrs["gen_ai.output.messages.mime_type"] == "application/json"
+        assert big_response in event_attrs["gen_ai.output.messages"]
 
     def test_post_serializes_simplenamespace_tool_calls(self, mock_tracer):
         from types import SimpleNamespace
@@ -1286,11 +1309,13 @@ class TestFullCaptureFlags:
         attrs = mock_tracer.end_span.call_args[1]["attributes"]
         import json as _json
 
-        parsed = _json.loads(attrs["gen_ai.output.messages"])
+        event_name, event_attrs = mock_tracer.spans.get_span.return_value.add_event.call_args.args
+        assert event_name == "gen_ai.output.messages"
+        parsed = _json.loads(event_attrs["gen_ai.output.messages"])
         assert parsed[0]["id"] == "call_1"
         assert parsed[0]["function"]["name"] == "web_search"
-        # With no text content, the tool-call JSON stands in as output.value
-        assert attrs["output.mime_type"] == "application/json"
+        assert "gen_ai.output.messages" not in attrs
+        assert "output.mime_type" not in attrs
 
     def test_flags_independent(self, mock_tracer):
         """Enabling one flag must not imply the other."""

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -74,7 +74,9 @@ class TestOnSessionStart:
         on_session_start(session_id="s1", model="gpt-4", platform="cli")
         mock_tracer.record_metric.assert_called_once_with("session_count", 1, {"session_id": "s1"})
 
-    def test_includes_session_attributes(self, mock_tracer):
+    def test_includes_session_attributes(self, mock_tracer, monkeypatch):
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
         on_session_start(session_id="s1", model="gpt-4o", platform="telegram")
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
         assert attrs["session_id"] == "s1"
@@ -82,6 +84,7 @@ class TestOnSessionStart:
         assert attrs["llm.model_name"] == "gpt-4o"
         assert attrs["llm.provider"] == "telegram"
         assert attrs["gen_ai.conversation.id"] == "s1"
+        assert attrs["gen_ai.agent.name"] == "hermes-agent"
         assert attrs["gen_ai.operation.name"] == "invoke_agent"
         assert attrs["gen_ai.request.model"] == "gpt-4o"
         assert attrs["gen_ai.provider.name"] == "telegram"
@@ -102,6 +105,19 @@ class TestOnSessionStart:
         on_session_start(session_id="s1", model="gpt-4", platform="cli", job_id="j123")
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
         assert attrs["hermes.cron.job_id"] == "j123"
+
+    def test_agent_name_uses_profile_context(self, mock_tracer, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", "/home/test/.hermes/profiles/engineer")
+        on_session_start(session_id="s1", model="gpt-4", platform="cli")
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert attrs["gen_ai.agent.name"] == "engineer"
+
+    def test_agent_name_uses_default_profile_for_root_home(self, mock_tracer, monkeypatch):
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+        monkeypatch.setenv("HERMES_HOME", "/home/test/.hermes")
+        on_session_start(session_id="s1", model="gpt-4", platform="cli")
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert attrs["gen_ai.agent.name"] == "default"
 
     def test_noop_when_disabled(self, disabled_tracer):
         on_session_start(session_id="s1", model="gpt-4", platform="cli")

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -115,6 +115,29 @@ class TestOnSessionStart:
         assert attrs["gen_ai.request.model"] == "gpt-4o"
         assert attrs["gen_ai.provider.name"] == "telegram"
 
+    def test_uses_propagated_kanban_parent_context(self, mock_tracer, monkeypatch):
+        traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_child")
+        monkeypatch.setenv("HERMES_KANBAN_TRACEPARENT", traceparent)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-sho...leak")
+
+        on_session_start(session_id="s1", model="gpt-4o", platform="cli")
+
+        call_kwargs = mock_tracer.start_span.call_args[1]
+        assert call_kwargs["parent_context"] is not None
+        attrs = call_kwargs["attributes"]
+        assert attrs["hermes.kanban.traceparent"] == traceparent
+        assert "OPENAI_API_KEY" not in attrs
+
+    def test_falls_back_without_propagated_kanban_context(self, mock_tracer, monkeypatch):
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.delenv("HERMES_KANBAN_TRACEPARENT", raising=False)
+
+        on_session_start(session_id="s1", model="gpt-4o", platform="cli")
+
+        call_kwargs = mock_tracer.start_span.call_args[1]
+        assert call_kwargs["parent_context"] is None
+
     def test_incoming_correlation_id_wins(self, mock_tracer):
         on_session_start(
             session_id="s1",
@@ -1451,17 +1474,21 @@ class TestKanbanSpanAttributes:
         ],
     )
     def test_lifecycle_hooks_emit_short_spans(self, mock_tracer, clean_kanban_env, callback, event):
+        traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
         callback(
             kanban_task_id="t_123",
             kanban_run_id="43",
             kanban_board="default",
             kanban_tenant="hermes-otel",
             kanban_assignee="engineer",
+            traceparent=traceparent,
         )
         start_kwargs = mock_tracer.start_span.call_args[1]
         end_kwargs = mock_tracer.end_span.call_args[1]
         assert start_kwargs["name"] == f"kanban.task.{event}"
         assert start_kwargs["kind"] == "general"
+        assert start_kwargs["parent_context"] is not None
+        assert start_kwargs["attributes"]["hermes.kanban.traceparent"] == traceparent
         assert start_kwargs["attributes"]["hermes.kanban.lifecycle.event"] == event
         assert end_kwargs["attributes"]["hermes.kanban.lifecycle.event"] == event
         assert end_kwargs["status"] == "ok"

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -73,23 +73,28 @@ class TestOnSessionStart:
 
     def test_records_session_count_metric(self, mock_tracer):
         on_session_start(session_id="s1", model="gpt-4", platform="cli")
-        mock_tracer.record_metric.assert_called_once_with("session_count", 1, {"session_id": "s1"})
+        mock_tracer.record_metric.assert_called_once_with(
+            "session_count",
+            1,
+            {
+                "gen_ai.agent.name": "hermes-agent",
+                "gen_ai.operation.name": "invoke_agent",
+                "gen_ai.provider.name": "cli",
+                "gen_ai.request.model": "gpt-4",
+            },
+        )
 
     def test_includes_session_attributes(self, mock_tracer, monkeypatch):
         monkeypatch.delenv("HERMES_PROFILE", raising=False)
         monkeypatch.delenv("HERMES_HOME", raising=False)
         on_session_start(session_id="s1", model="gpt-4o", platform="telegram")
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
-        assert attrs["session_id"] == "s1"
         assert attrs["correlation.id"] == "s1"
-        assert attrs["llm.model_name"] == "gpt-4o"
-        assert attrs["llm.provider"] == "telegram"
         assert attrs["gen_ai.conversation.id"] == "s1"
         assert attrs["gen_ai.agent.name"] == "hermes-agent"
         assert attrs["gen_ai.operation.name"] == "invoke_agent"
         assert attrs["gen_ai.request.model"] == "gpt-4o"
         assert attrs["gen_ai.provider.name"] == "telegram"
-        assert attrs["gen_ai.system"] == "telegram"
 
     def test_incoming_correlation_id_wins(self, mock_tracer):
         on_session_start(
@@ -172,12 +177,9 @@ class TestOnSessionEnd:
             session_id="s1", completed=True, interrupted=False, model="gpt-4", platform="cli"
         )
         attrs = mock_tracer.end_span.call_args[1]["attributes"]
-        assert attrs["llm.token_count.prompt"] == 100
-        assert attrs["llm.token_count.completion"] == 50
         assert attrs["gen_ai.usage.input_tokens"] == 100
         assert attrs["gen_ai.usage.output_tokens"] == 50
-        assert attrs["llm.token_count.prompt_details.cache_read"] == 20
-        assert attrs["gen_ai.usage.cache_creation_input_tokens"] == 10
+        assert attrs["gen_ai.usage.cache_creation.input_tokens"] == 10
         # Verify cleanup — PerSession popped from registry.
         assert mock_tracer.sessions.peek("s1") is None
 
@@ -304,9 +306,11 @@ class TestOnPostToolCall:
         on_post_tool_call(tool_name="bash", args={}, result="ok", task_id="t1")
         mock_tracer.record_metric.assert_called_once()
         name, _value, attrs = mock_tracer.record_metric.call_args[0]
-        assert name == "tool_duration"
-        assert attrs["tool_name"] == "bash"
+        assert name == "gen_ai.execute_tool.duration"
+        assert attrs["gen_ai.operation.name"] == "execute_tool"
         assert attrs["gen_ai.tool.name"] == "bash"
+        assert "gen_ai.conversation.id" not in attrs
+        assert "gen_ai.provider.name" not in attrs
 
     def test_cleans_up_start_time(self, mock_tracer):
         mock_tracer.sessions.record_tool_start("bash:t1", 1000.0)
@@ -543,7 +547,14 @@ class TestOnPostLlmCall:
             platform="cli",
         )
         mock_tracer.record_metric.assert_called_once_with(
-            "message_count", 1, {"session_id": "s1", "model": "gpt-4", "provider": "cli"}
+            "message_count",
+            1,
+            {
+                "gen_ai.agent.name": "hermes-agent",
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": "cli",
+                "gen_ai.request.model": "gpt-4",
+            },
         )
 
     def test_noop_when_disabled(self, disabled_tracer):
@@ -691,15 +702,16 @@ class TestOnPreApiRequest:
             max_tokens=2048,
         )
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
-        assert attrs["llm.model_name"] == "gpt-4"
-        assert attrs["llm.provider"] == "openai"
-        assert attrs["llm.request.message_count"] == 10
-        assert attrs["llm.request.max_tokens"] == 2048
+        # Hermes-specific request-shape metadata stays under hermes.* because
+        # there is no equivalent GenAI semantic-convention field.
+        assert attrs["hermes.api.mode"] == "chat"
+        assert attrs["hermes.request.message_count"] == 10
+        assert attrs["hermes.request.approx_input_tokens"] == 500
+        assert attrs["gen_ai.request.max_tokens"] == 2048
         assert attrs["gen_ai.conversation.id"] == "s1"
         assert attrs["gen_ai.operation.name"] == "chat"
         assert attrs["gen_ai.request.model"] == "gpt-4"
         assert attrs["gen_ai.provider.name"] == "openai"
-        assert attrs["gen_ai.system"] == "openai"
 
     def test_includes_server_attributes_from_base_url(self, mock_tracer):
         on_pre_api_request(
@@ -895,7 +907,7 @@ class TestOnPostApiRequest:
         mock_tracer.end_span.assert_called_once()
         assert mock_tracer.end_span.call_args[0][0] == "api:t1"
 
-    def test_dual_convention_token_attributes(self, mock_tracer):
+    def test_canonical_gen_ai_token_attributes(self, mock_tracer):
         usage = {
             "prompt_tokens": 100,
             "output_tokens": 50,
@@ -903,19 +915,13 @@ class TestOnPostApiRequest:
         }
         self._call_post_api(mock_tracer, usage=usage)
         attrs = mock_tracer.end_span.call_args[1]["attributes"]
-        # OpenInference (Phoenix)
-        assert attrs["llm.token_count.prompt"] == 100
-        assert attrs["llm.token_count.completion"] == 50
-        assert attrs["llm.token_count.total"] == 150
-        # OTel GenAI (Langfuse)
         assert attrs["gen_ai.usage.input_tokens"] == 100
         assert attrs["gen_ai.usage.output_tokens"] == 50
-        assert attrs["gen_ai.usage.total_tokens"] == 150
+        assert "gen_ai.usage.total_tokens" not in attrs
         assert attrs["gen_ai.conversation.id"] == "s1"
         assert attrs["gen_ai.operation.name"] == "chat"
         assert attrs["gen_ai.response.model"] == "gpt-4"
         assert attrs["gen_ai.provider.name"] == "openai"
-        assert attrs["gen_ai.system"] == "openai"
 
     def test_reasoning_token_attribute(self, mock_tracer):
         usage = {
@@ -939,6 +945,11 @@ class TestOnPostApiRequest:
         attrs = mock_tracer.end_span.call_args[1]["attributes"]
         assert "gen_ai.conversation.compacted" not in attrs
 
+    def test_no_compaction_attr_when_explicit_false(self, mock_tracer):
+        self._call_post_api(mock_tracer, conversation_compacted=False)
+        attrs = mock_tracer.end_span.call_args[1]["attributes"]
+        assert "gen_ai.conversation.compacted" not in attrs
+
     def test_time_to_first_chunk_attribute(self, mock_tracer):
         self._call_post_api(mock_tracer, time_to_first_chunk_ms=125)
         attrs = mock_tracer.end_span.call_args[1]["attributes"]
@@ -954,12 +965,8 @@ class TestOnPostApiRequest:
         }
         self._call_post_api(mock_tracer, usage=usage)
         attrs = mock_tracer.end_span.call_args[1]["attributes"]
-        assert attrs["llm.token_count.prompt_details.cache_read"] == 30
         assert attrs["gen_ai.usage.cache_read.input_tokens"] == 30
-        assert attrs["gen_ai.usage.cache_read_input_tokens"] == 30
-        assert attrs["llm.token_count.prompt_details.cache_write"] == 15
         assert attrs["gen_ai.usage.cache_creation.input_tokens"] == 15
-        assert attrs["gen_ai.usage.cache_creation_input_tokens"] == 15
 
     def test_session_usage_rollup(self, mock_tracer):
         usage = {"prompt_tokens": 100, "output_tokens": 50, "total_tokens": 150}
@@ -978,16 +985,28 @@ class TestOnPostApiRequest:
 
     def test_records_duration_attribute(self, mock_tracer):
         self._call_post_api(mock_tracer, api_duration=1.234)
-        attrs = mock_tracer.end_span.call_args[1]["attributes"]
-        assert attrs["llm.response.duration_ms"] == 1234.0
+        metric_names = [c[0][0] for c in mock_tracer.record_metric.call_args_list]
+        assert "gen_ai.client.operation.duration" in metric_names
 
-    def test_records_token_metrics(self, mock_tracer):
-        usage = {"prompt_tokens": 100, "output_tokens": 50, "total_tokens": 150}
+    def test_records_canonical_gen_ai_token_metrics(self, mock_tracer):
+        usage = {
+            "prompt_tokens": 100,
+            "output_tokens": 50,
+            "total_tokens": 150,
+            "cache_read_tokens": 30,
+            "cache_write_tokens": 15,
+        }
         self._call_post_api(mock_tracer, usage=usage)
         metric_calls = [c for c in mock_tracer.record_metric.call_args_list]
         metric_names = [c[0][0] for c in metric_calls]
-        assert "token_usage" in metric_names
+        assert "gen_ai.client.token.usage" in metric_names
         assert "model_usage" in metric_names
+        token_calls = [c for c in metric_calls if c[0][0] == "gen_ai.client.token.usage"]
+        assert {c[0][2]["gen_ai.token.type"] for c in token_calls} == {"input", "output"}
+        token_call = token_calls[0]
+        assert token_call[0][2]["gen_ai.token.type"] == "input"
+        assert token_call[0][2]["gen_ai.operation.name"] == "chat"
+        assert token_call[0][2]["gen_ai.provider.name"] == "openai"
 
     def test_noop_when_disabled(self, disabled_tracer):
         on_post_api_request(
@@ -1061,8 +1080,8 @@ class TestFullCaptureFlags:
             )
         )
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
-        assert "llm.input_messages" not in attrs
-        assert "llm.system_prompt" not in attrs
+        assert "gen_ai.input.messages" not in attrs
+        assert "gen_ai.system_instructions" not in attrs
         assert "input.value" not in attrs
 
     def test_pre_writes_full_prompt_when_flag_on(self, mock_tracer):
@@ -1076,13 +1095,12 @@ class TestFullCaptureFlags:
         ]
         on_pre_api_request(**self._pre_kwargs(messages=messages, system_prompt="the-system-prompt"))
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
-        assert attrs["llm.system_prompt"] == "the-system-prompt"
         assert attrs["gen_ai.system_instructions"] == "the-system-prompt"
         assert attrs["input.mime_type"] == "application/json"
         # Full, untruncated payload round-trips
         import json as _json
 
-        parsed = _json.loads(attrs["llm.input_messages"])
+        parsed = _json.loads(attrs["gen_ai.input.messages"])
         assert parsed == messages
         assert _json.loads(attrs["gen_ai.input.messages"]) == messages
         assert len(attrs["input.value"]) > 5000
@@ -1093,8 +1111,8 @@ class TestFullCaptureFlags:
         mock_tracer.config = HermesOtelConfig(capture_full_prompts=True)
         on_pre_api_request(**self._pre_kwargs(messages=[], system_prompt=""))
         attrs = mock_tracer.start_span.call_args[1]["attributes"]
-        assert "llm.input_messages" not in attrs
-        assert "llm.system_prompt" not in attrs
+        assert "gen_ai.input.messages" not in attrs
+        assert "gen_ai.system_instructions" not in attrs
 
     def test_post_skips_response_attrs_when_flag_off(self, mock_tracer):
         on_post_api_request(
@@ -1104,7 +1122,7 @@ class TestFullCaptureFlags:
             )
         )
         attrs = mock_tracer.end_span.call_args[1]["attributes"]
-        assert "llm.output.content" not in attrs
+        assert "gen_ai.output.messages" not in attrs
         assert "output.value" not in attrs
 
     def test_post_writes_full_response_when_flag_on(self, mock_tracer):
@@ -1116,7 +1134,6 @@ class TestFullCaptureFlags:
             **self._post_kwargs(response_content=big_response, response_tool_calls=[])
         )
         attrs = mock_tracer.end_span.call_args[1]["attributes"]
-        assert attrs["llm.output.content"] == big_response
         assert "gen_ai.output.messages" in attrs
         assert attrs["output.value"] == big_response
         assert attrs["output.mime_type"] == "text/plain"
@@ -1136,7 +1153,7 @@ class TestFullCaptureFlags:
         attrs = mock_tracer.end_span.call_args[1]["attributes"]
         import json as _json
 
-        parsed = _json.loads(attrs["llm.output.tool_calls"])
+        parsed = _json.loads(attrs["gen_ai.output.messages"])
         assert parsed[0]["id"] == "call_1"
         assert parsed[0]["function"]["name"] == "web_search"
         # With no text content, the tool-call JSON stands in as output.value
@@ -1149,4 +1166,4 @@ class TestFullCaptureFlags:
         mock_tracer.config = HermesOtelConfig(capture_full_prompts=True)
         on_post_api_request(**self._post_kwargs(response_content="hi", response_tool_calls=[]))
         attrs = mock_tracer.end_span.call_args[1]["attributes"]
-        assert "llm.output.content" not in attrs
+        assert "gen_ai.output.messages" not in attrs

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -1492,3 +1492,41 @@ class TestKanbanSpanAttributes:
         assert start_kwargs["attributes"]["hermes.kanban.lifecycle.event"] == event
         assert end_kwargs["attributes"]["hermes.kanban.lifecycle.event"] == event
         assert end_kwargs["status"] == "ok"
+
+    def test_lifecycle_hook_includes_safe_task_title(self, mock_tracer, clean_kanban_env):
+        on_kanban_task_claimed(
+            task_id="t_123",
+            run_id="43",
+            board="default",
+            title="Fix production smoke",
+        )
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        assert attrs["hermes.kanban.task.id"] == "t_123"
+        assert attrs["hermes.kanban.task.title"] == "Fix production smoke"
+
+    def test_lifecycle_title_summary_and_reason_are_redacted_and_truncated(
+        self, mock_tracer, clean_kanban_env
+    ):
+        secret = "sk-" + "a" * 48
+        bearer = "eyJ" + "b" * 48
+        basic = "dXNlcjpwYXNz"
+        on_kanban_task_blocked(
+            task_id="t_secret",
+            title=(
+                f"deploy Authorization: Basic {basic} Bearer {bearer} "
+                f"Basic {basic} token={secret} "
+            ) + "x" * 260,
+            summary=f"summary api_key={secret}",
+            reason=f"reason password={secret}",
+        )
+        attrs = mock_tracer.start_span.call_args[1]["attributes"]
+        for key in (
+            "hermes.kanban.task.title",
+            "hermes.kanban.summary",
+            "hermes.kanban.reason",
+        ):
+            assert "[REDACTED]" in attrs[key]
+            assert secret not in attrs[key]
+            assert bearer not in attrs[key]
+            assert basic not in attrs[key]
+            assert len(attrs[key]) <= 200

--- a/tests/unit/test_langsmith_backend.py
+++ b/tests/unit/test_langsmith_backend.py
@@ -284,29 +284,12 @@ class TestEndSpan:
         payload = _captured_payload(mock)
         assert "error" not in payload
 
-    def test_token_mapping_from_openinference(self):
-        backend = self._backend()
-        run = {"id": "abc", "run_type": "llm"}
-        attrs = {
-            "llm.token_count.prompt": 100,
-            "llm.token_count.completion": 50,
-            "llm.token_count.total": 150,
-        }
-        with _mock_urlopen_success() as mock:
-            backend.end_span(run, attributes=attrs)
-
-        payload = _captured_payload(mock)
-        assert payload["prompt_tokens"] == 100
-        assert payload["completion_tokens"] == 50
-        assert payload["total_tokens"] == 150
-
     def test_token_mapping_from_gen_ai(self):
         backend = self._backend()
         run = {"id": "abc", "run_type": "llm"}
         attrs = {
             "gen_ai.usage.input_tokens": 200,
             "gen_ai.usage.output_tokens": 80,
-            "gen_ai.usage.total_tokens": 280,
         }
         with _mock_urlopen_success() as mock:
             backend.end_span(run, attributes=attrs)
@@ -322,7 +305,6 @@ class TestEndSpan:
         attrs = {
             "gen_ai.usage.input_tokens": 100,
             "gen_ai.usage.output_tokens": 50,
-            "gen_ai.usage.total_tokens": 150,
         }
         with _mock_urlopen_success() as mock:
             backend.end_span(run, attributes=attrs)
@@ -339,9 +321,8 @@ class TestEndSpan:
         attrs = {
             "gen_ai.usage.input_tokens": 100,
             "gen_ai.usage.output_tokens": 50,
-            "gen_ai.usage.total_tokens": 150,
-            "gen_ai.usage.cache_read_input_tokens": 30,
-            "gen_ai.usage.cache_creation_input_tokens": 10,
+            "gen_ai.usage.cache_read.input_tokens": 30,
+            "gen_ai.usage.cache_creation.input_tokens": 10,
         }
         with _mock_urlopen_success() as mock:
             backend.end_span(run, attributes=attrs)

--- a/tests/unit/test_tracer_span_tracker.py
+++ b/tests/unit/test_tracer_span_tracker.py
@@ -1,6 +1,6 @@
 """Tests for the SpanTracker class in tracer.py."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 from hermes_otel.tracer import SpanTracker
 from opentelemetry.trace import Status, StatusCode
@@ -64,6 +64,15 @@ class TestSpanTrackerAttributes:
         status_arg = span.set_status.call_args[0][0]
         assert status_arg.status_code == StatusCode.ERROR
         assert status_arg.description == "something broke"
+        span.set_attribute.assert_any_call("error.type", "error")
+
+    def test_end_span_status_error_preserves_explicit_error_type(self):
+        tracker = SpanTracker()
+        span = MagicMock()
+        tracker.start_span("k1", span)
+        tracker.end_span("k1", attributes={"error.type": "TimeoutError"}, status="error")
+        span.set_attribute.assert_any_call("error.type", "TimeoutError")
+        assert call("error.type", "error") not in span.set_attribute.call_args_list
 
     def test_end_span_no_status_skips_set_status(self):
         tracker = SpanTracker()

--- a/tracer.py
+++ b/tracer.py
@@ -100,7 +100,9 @@ class HermesOTelPlugin:
         self._session_count = None
         self._token_usage = None
         self._cost_usage = None
-        self._tool_duration = None
+        self._client_operation_duration = None
+        self._invoke_agent_duration = None
+        self._execute_tool_duration = None
         self._message_count = None
         self._model_usage = None
         self._skill_inferred_counter = None
@@ -375,18 +377,29 @@ class HermesOTelPlugin:
             "hermes.session.count",
             description="Sessions created",
         )
-        self._token_usage = self._meter.create_counter(
-            "hermes.token.usage",
-            description="Tokens consumed by type",
+        self._token_usage = self._meter.create_histogram(
+            "gen_ai.client.token.usage",
+            unit="{token}",
+            description="GenAI client tokens consumed by token type",
         )
         self._cost_usage = self._meter.create_counter(
             "hermes.cost.usage",
             description="USD cost per message",
         )
-        self._tool_duration = self._meter.create_histogram(
-            "hermes.tool.duration",
-            unit="ms",
-            description="Tool execution time",
+        self._client_operation_duration = self._meter.create_histogram(
+            "gen_ai.client.operation.duration",
+            unit="s",
+            description="GenAI client operation duration",
+        )
+        self._invoke_agent_duration = self._meter.create_histogram(
+            "gen_ai.invoke_agent.duration",
+            unit="s",
+            description="GenAI invoke-agent operation duration",
+        )
+        self._execute_tool_duration = self._meter.create_histogram(
+            "gen_ai.execute_tool.duration",
+            unit="s",
+            description="GenAI execute-tool operation duration",
         )
         self._message_count = self._meter.create_counter(
             "hermes.message.count",
@@ -456,12 +469,20 @@ class HermesOTelPlugin:
 
         if name == "session_count":
             self._session_count.add(1, attrs)
-        elif name == "token_usage":
-            self._token_usage.add(int(value), attrs)
+        elif name == "gen_ai.client.token.usage":
+            if self._token_usage is not None:
+                self._token_usage.record(int(value), attrs)
         elif name == "cost_usage":
             self._cost_usage.add(value, attrs)
-        elif name == "tool_duration":
-            self._tool_duration.record(value, attrs)
+        elif name == "gen_ai.client.operation.duration":
+            if self._client_operation_duration is not None:
+                self._client_operation_duration.record(value, attrs)
+        elif name == "gen_ai.invoke_agent.duration":
+            if self._invoke_agent_duration is not None:
+                self._invoke_agent_duration.record(value, attrs)
+        elif name == "gen_ai.execute_tool.duration":
+            if self._execute_tool_duration is not None:
+                self._execute_tool_duration.record(value, attrs)
         elif name == "message_count":
             self._message_count.add(1, attrs)
         elif name == "model_usage":

--- a/tracer.py
+++ b/tracer.py
@@ -498,6 +498,7 @@ class HermesOTelPlugin:
         kind: str = "general",
         attributes: dict = None,
         session_id: Optional[str] = None,
+        parent_context: Any = None,
     ):
         """Create and track a new span.
 
@@ -542,7 +543,7 @@ class HermesOTelPlugin:
             # Check for active parent — prefers the session-keyed stack so
             # nesting survives hermes' cross-thread hook dispatch.
             parent = self.spans.get_current_parent(session_id)
-            span_ctx = None
+            span_ctx = parent_context
             if parent is not None and hasattr(parent, "get_span_context"):
                 span_ctx = set_span_in_context(parent)
 

--- a/website/docs/architecture/attributes.md
+++ b/website/docs/architecture/attributes.md
@@ -1,47 +1,49 @@
 ---
 sidebar_position: 3
 title: "Attribute conventions"
-description: "Dual-convention emitted on every span — gen_ai.* (Langfuse, SigNoz) and OpenInference llm.* (Phoenix)."
+description: "Canonical OpenTelemetry GenAI attributes plus Hermes extensions."
 ---
 
 # Attribute conventions
 
-The observability ecosystem hasn't agreed on attribute names for LLM telemetry yet. Langfuse and SigNoz use the (pre-standard) `gen_ai.*` convention from [OTel's GenAI SIG](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/gen-ai); Phoenix uses [Arize's OpenInference](https://arize.com/docs/phoenix/reference/openinference) with `llm.token_count.*` and `input.value` / `output.value`.
-
-hermes-otel emits **both** conventions on the same span so whichever backend reads from it picks up the data it's expecting. No vendor-specific adapter code per backend.
+hermes-otel emits the OpenTelemetry GenAI convention for LLM telemetry (`gen_ai.*`) and uses `hermes.*` for Hermes-specific extensions. Generic `input.value` / `output.value` are still used for preview-safe input and output rendering.
 
 ## Token counts (on `api.*` spans)
 
-| Metric | Langfuse / gen_ai | Phoenix / OpenInference |
-|---|---|---|
-| Prompt tokens | `gen_ai.usage.input_tokens` | `llm.token_count.prompt` |
-| Completion tokens | `gen_ai.usage.output_tokens` | `llm.token_count.completion` |
-| Total tokens | — | `llm.token_count.total` |
-| Cache read | `gen_ai.usage.cache_read_input_tokens` | `llm.token_count.cache_read` |
-| Cache write | `gen_ai.usage.cache_creation_input_tokens` | `llm.token_count.cache_write` |
+| Metric | GenAI attribute |
+|---|---|
+| Prompt tokens | `gen_ai.usage.input_tokens` |
+| Completion tokens | `gen_ai.usage.output_tokens` |
+| Cache read | `gen_ai.usage.cache_read.input_tokens` |
+| Cache write | `gen_ai.usage.cache_creation.input_tokens` |
 
-Phoenix adds a `total` variant that's the sum; gen_ai doesn't. Cache read/write are only populated when the provider reports them (Anthropic's prompt caching, OpenAI's — both surface them in their API responses).
+Cache read/write are only populated when the provider reports them (Anthropic's prompt caching, OpenAI's — both surface them in their API responses).
+Total tokens are derived downstream from input + output tokens rather than emitted as a duplicate span attribute.
 
 ## Message content (on `llm.*` spans)
 
-| | Langfuse / gen_ai | Phoenix / OpenInference |
-|---|---|---|
-| User message | `gen_ai.content.prompt` | `input.value` |
-| Assistant response | `gen_ai.content.completion` | `output.value` |
-| Content type | *(not set)* | `input.mime_type`, `output.mime_type` |
+| Attribute | Meaning |
+|---|---|
+| `input.value` | Preview-safe user message or full conversation JSON |
+| `input.mime_type` | `text/plain` or `application/json` |
+| `output.value` | Preview-safe assistant response |
+| `output.mime_type` | `text/plain` |
+| `gen_ai.input.messages` | Full input messages when explicitly enabled |
+| `gen_ai.output.messages` | Full output messages when explicitly enabled |
+| `gen_ai.system_instructions` | System prompt when explicitly enabled |
 
 When [conversation capture](/configuration/conversation-capture) is on, `input.value` becomes JSON of the full message list, `input.mime_type` becomes `application/json`, and `hermes.conversation.message_count` records how many messages were passed.
 
 ## Model / request metadata
 
-| | Langfuse / gen_ai | Phoenix / OpenInference |
-|---|---|---|
-| Model name | `gen_ai.request.model` | `llm.model_name` |
-| Provider | `gen_ai.system` | `llm.provider` |
-| Invocation params | — | `llm.invocation_parameters` (JSON) |
-| Finish reason | `gen_ai.response.finish_reason` | *(same)* |
-
-`llm.invocation_parameters` is a JSON blob with the request params (temperature, max_tokens, tool schemas, etc.) that Phoenix pretty-prints in the UI.
+| Attribute | Meaning |
+|---|---|
+| `gen_ai.request.model` | Requested model name |
+| `gen_ai.response.model` | Provider-returned model name |
+| `gen_ai.provider.name` | Provider (anthropic, openai, ...) |
+| `gen_ai.operation.name` | `chat`, `invoke_agent`, `execute_tool`, etc. |
+| `gen_ai.request.temperature`, `gen_ai.request.max_tokens`, ... | Request params when available |
+| `gen_ai.response.finish_reasons` | Finish reasons such as `stop`, `tool_use`, `length` |
 
 ## Tool spans
 
@@ -61,14 +63,14 @@ See [Tool identity](/architecture/tool-identity).
 
 ## Session / turn metadata (on `session.*`)
 
-All plugin-specific:
-
 | Attribute | Meaning |
 |---|---|
 | `openinference.project.name` | Project name from `OTEL_PROJECT_NAME` |
-| `hermes.session.kind` | `cli` / `telegram` / `discord` / `cron` / ... |
-| `hermes.session.id` | Hermes session ID |
-| `session.id` | Standard OTel alias of the above |
+| `gen_ai.conversation.id` | Hermes session/conversation ID |
+| `gen_ai.conversation.compacted` | `true` when Hermes explicitly reports compaction; otherwise unset |
+| `gen_ai.agent.name` | Active Hermes profile / agent name |
+| `gen_ai.operation.name` | `invoke_agent` for session spans |
+| `hermes.session.kind` | `cli` / `telegram` / `discord` / `cron` / ... (plugin-specific) |
 | `user.id` | Hermes user ID |
 | `hermes.turn.*` | Turn summary (see [Turn summary](/architecture/turn-summary)) |
 
@@ -84,12 +86,12 @@ Set on the OTel `Resource` and therefore stamped on **every** span:
 | `openinference.project.name` | Same as `service.name` |
 | *plus* any `resource_attributes:` / `global_tags:` from `config.yaml` |
 
-## Why dual-convention rather than pick one?
+## Compatibility note
 
-Every backend supports a different set. Emitting both is cheap (same span, a few extra key-value pairs) and saves every user from writing their own mapping adapter. When the GenAI spec stabilises and Phoenix/Langfuse converge, this will simplify.
+Older hermes-otel releases emitted OpenInference `llm.*` aliases alongside GenAI fields. Current releases prefer the GenAI names only for model/provider/token metadata; update backend queries and collector dimensions to use the `gen_ai.*` keys above.
 
 ## Roadmap
 
 - [OpenInference Tool span kind is now stable](https://arize.com/docs/phoenix/reference/openinference) — already emitted.
 - `gen_ai.tool.*` convention is evolving; we'll add it once the spec is stable.
-- `session.id` is the standard OTel name; the plugin emits both `hermes.session.id` (for compatibility with older backends that key on it) and `session.id`. The former may be dropped in a future major version — watch the changelog.
+- Session identity uses `gen_ai.conversation.id`; older `session.id` / `hermes.session.id` aliases are intentionally not dual-emitted.

--- a/website/docs/architecture/overview.md
+++ b/website/docs/architecture/overview.md
@@ -111,7 +111,7 @@ This is the standard OTel trade-off and matches every production tracing stack �
 ## Next
 
 - **[Span hierarchy](/architecture/span-hierarchy)** — what each span carries
-- **[Attribute conventions](/architecture/attributes)** — the dual-convention mapping
+- **[Attribute conventions](/architecture/attributes)** — GenAI and Hermes attribute conventions
 - **[Turn summary](/architecture/turn-summary)** — the rolled-up attributes on the session root
 - **[Tool identity](/architecture/tool-identity)** — how `hermes.tool.command` / `target` / `outcome` / `skill` get inferred
 - **[Orphan-span sweep](/architecture/orphan-sweep)** — how crashed sessions get cleaned up

--- a/website/docs/architecture/span-hierarchy.md
+++ b/website/docs/architecture/span-hierarchy.md
@@ -36,8 +36,7 @@ Key attributes, set at start:
 |---|---|
 | `openinference.project.name` | `OTEL_PROJECT_NAME` / `HERMES_OTEL_PROJECT_NAME` |
 | `hermes.session.kind` | From Hermes (`cli`, `telegram`, `cron`, etc.) |
-| `hermes.session.id` | Hermes session ID |
-| `session.id` | Same as above, standard OTel naming |
+| `gen_ai.conversation.id` | Hermes session/conversation ID |
 | `user.id` | Hermes user ID (when available) |
 
 Key attributes, set at end (the **turn summary**):
@@ -60,19 +59,19 @@ See [Turn summary](/architecture/turn-summary) for why these exist.
 
 One per logical model turn. Name is `llm.{model}` (e.g. `llm.claude-sonnet-4-6`).
 
-**Span kind:** `LLM` (OpenInference).
+**Span kind:** LLM-like model turn.
 
 | Attribute | Convention | Meaning |
 |---|---|---|
-| `llm.model_name` | OpenInference | Model name |
-| `llm.provider` | OpenInference | Provider (anthropic, openai, etc.) |
-| `input.value` | OpenInference | User message *or* full conversation history (see below) |
-| `input.mime_type` | OpenInference | `text/plain` or `application/json` |
-| `output.value` | OpenInference | Final assistant response |
-| `output.mime_type` | OpenInference | `text/plain` |
-| `gen_ai.request.model` | gen_ai | Model name (for Langfuse / SigNoz) |
-| `gen_ai.content.prompt` | gen_ai | User message (same content as `input.value` when both are strings) |
-| `gen_ai.content.completion` | gen_ai | Assistant response |
+| `gen_ai.request.model` | gen_ai | Model name |
+| `gen_ai.provider.name` | gen_ai | Provider (anthropic, openai, etc.) |
+| `gen_ai.operation.name` | gen_ai | Operation name such as `chat` |
+| `input.value` | generic | User message *or* full conversation history (see below) |
+| `input.mime_type` | generic | `text/plain` or `application/json` |
+| `output.value` | generic | Final assistant response |
+| `output.mime_type` | generic | `text/plain` |
+| `gen_ai.input.messages` | gen_ai | Full input messages when explicitly enabled |
+| `gen_ai.output.messages` | gen_ai | Full output messages when explicitly enabled |
 | `hermes.conversation.message_count` | hermes-specific | When `capture_conversation_history: true` |
 
 By default `input.value` is the latest user turn only. To see the full message list the model saw, enable [conversation capture](/configuration/conversation-capture).
@@ -81,24 +80,18 @@ By default `input.value` is the latest user turn only. To see the full message l
 
 One per HTTP round-trip to the provider. Name is `api.{model}`.
 
-**Span kind:** `LLM` (OpenInference).
+**Span kind:** LLM-like provider request.
 
 | Attribute | Convention | Meaning |
 |---|---|---|
-| `llm.token_count.prompt` | OpenInference | Prompt tokens |
-| `llm.token_count.completion` | OpenInference | Completion tokens |
-| `llm.token_count.total` | OpenInference | Sum of the above |
-| `llm.token_count.cache_read` | OpenInference | Prompt tokens read from cache (if provider reports) |
-| `llm.token_count.cache_write` | OpenInference | Prompt tokens written to cache (if provider reports) |
-| `gen_ai.usage.input_tokens` | gen_ai | Prompt tokens (for Langfuse) |
-| `gen_ai.usage.output_tokens` | gen_ai | Completion tokens (for Langfuse) |
-| `gen_ai.usage.cache_read_input_tokens` | gen_ai | Cache read (if provider reports) |
-| `gen_ai.usage.cache_creation_input_tokens` | gen_ai | Cache write (if provider reports) |
-| `llm.invocation_parameters` | OpenInference | JSON of temperature, max_tokens, etc. |
-| `gen_ai.response.finish_reason` | gen_ai | `stop`, `tool_use`, `length`, etc. |
-| `http.duration_ms` | hermes-specific | Wall-clock duration of the HTTP call |
+| `gen_ai.usage.input_tokens` | gen_ai | Prompt tokens |
+| `gen_ai.usage.output_tokens` | gen_ai | Completion tokens |
+| `gen_ai.usage.cache_read.input_tokens` | gen_ai | Prompt tokens read from cache (if provider reports) |
+| `gen_ai.usage.cache_creation.input_tokens` | gen_ai | Prompt tokens written to cache (if provider reports) |
+| `gen_ai.request.*` | gen_ai | Request params such as temperature and max tokens |
+| `gen_ai.response.finish_reasons` | gen_ai | `stop`, `tool_use`, `length`, etc. |
 
-The `api.*` span is the right place to look for token counts — not the parent `llm.*` (which doesn't carry per-call counts, because a turn can have multiple `api.*` calls).
+The `api.*` span is the right place to look for token counts — not the parent `llm.*` (which doesn't carry per-call counts, because a turn can have multiple `api.*` calls). Total tokens are derived downstream from input + output tokens rather than emitted as a duplicate span attribute; API duration is emitted as the `gen_ai.client.operation.duration` metric.
 
 ## `tool.*`
 
@@ -126,4 +119,4 @@ The tree mirrors the agent's execution structure:
 - **`llm.*` as a logical parent of all `api.*`** because the conversation-with-the-model is one coherent thing even when it takes multiple HTTP calls.
 - **`tool.*` under `api.*`** because tools run *between* rounds of model inference, within a specific HTTP response's tool_calls. The `api.*` parent makes that explicit.
 
-See [Attribute conventions](/architecture/attributes) for the dual-convention mapping side-by-side.
+See [Attribute conventions](/architecture/attributes) for the GenAI attribute mapping.

--- a/website/docs/backends/jaeger.md
+++ b/website/docs/backends/jaeger.md
@@ -42,8 +42,8 @@ Jaeger shows the plugin's spans as a standard trace tree — the service-map vie
 
 Jaeger is not LLM-specific, so:
 
-- Message content appears as the raw `input.value` / `gen_ai.content.prompt` tag rather than pretty-printed.
-- Token counts are tags, not first-class fields — look for `gen_ai.usage.input_tokens` / `llm.token_count.prompt`.
+- Message content appears as the raw `input.value` / `output.value` tags rather than pretty-printed.
+- Token counts are tags, not first-class fields — look for `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens`.
 - Tool args / results are JSON in the `input.value` / `output.value` tags.
 
 For LLM-native UI, pair Jaeger with a fan-out to Phoenix or Langfuse — see [Multi-backend](/backends/multi-backend).

--- a/website/docs/backends/lgtm.md
+++ b/website/docs/backends/lgtm.md
@@ -66,9 +66,9 @@ The bundled collector config at `docker-compose/lgtm/otelcol-config.yaml` enable
 
 Dimensions are picked from attributes the plugin actually emits:
 
-- `llm.provider` — split RED by model provider
-- `llm.model_name` — split by specific model
-- `openinference.span.kind` — split by LLM / TOOL / AGENT
+- `gen_ai.provider.name` — split RED by model provider
+- `gen_ai.request.model` — split by specific model
+- `gen_ai.operation.name` — split by chat / invoke_agent / execute_tool
 - `hermes.session.kind` — split by session vs cron
 - `hermes.tool.outcome` — error-rate panels
 
@@ -77,10 +77,10 @@ Add more in the YAML under `connectors.spanmetrics.dimensions` if you want to sl
 ## What you'll see in Grafana
 
 **Traces (Tempo):**
-Explore → Tempo. Search by `service.name=hermes-agent` or span name (`agent`, `tool.*`, `api.*`). Every span carries the OpenInference + GenAI attribute set and the plugin's `hermes.*` extensions.
+Explore → Tempo. Search by `service.name=hermes-agent` or span name (`agent`, `tool.*`, `api.*`). Every span carries the OTel GenAI attribute set and the plugin's `hermes.*` extensions.
 
 **Metrics (Prometheus):**
-Explore → Prometheus. Query any `hermes_*` metric (`hermes_session_count_total`, `hermes_token_usage_total`, `hermes_tool_duration_bucket`, ...) or any `traces_spanmetrics_*` derived metric.
+Explore → Prometheus. Query emitted metric series such as `hermes_session_count_total`, `gen_ai_client_token_usage_total`, and `gen_ai_execute_tool_duration_bucket`, or any `traces_spanmetrics_*` derived metric.
 
 **Logs (Loki):**
 Explore → Loki. Query `{service_name="hermes-agent"}`. Every `logger.info(...)` call from hermes or the plugin lands here with the active span's `trace_id` / `span_id` automatically attached — clicking a `trace_id` in a log line jumps straight into the Tempo trace. See [OTel logs](/configuration/logs) for the full story.

--- a/website/docs/backends/phoenix.md
+++ b/website/docs/backends/phoenix.md
@@ -52,14 +52,12 @@ Phoenix is built around LLM-specific spans, so the UI understands the plugin's s
 
 - **`session.*` / `cron`** spans appear as top-level traces with the turn summary on them (tool count, skills, final status).
 - **`llm.*`** spans show the user message in the Input panel and the assistant response in the Output panel (pretty-printed JSON when [conversation capture](/configuration/conversation-capture) is on).
-- **`api.*`** spans carry the token counts (`llm.token_count.prompt`, `llm.token_count.completion`, `llm.token_count.total`), the `finish_reason`, and the HTTP duration.
+- **`api.*`** spans carry token counts (`gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`), finish reasons, and related duration metrics. Total tokens are derived downstream from input + output tokens.
 - **`tool.*`** spans show the arguments (Input) and the result (Output). Errors map to `StatusCode.ERROR` so the Phoenix error filter works.
 
 ## Attribute convention
 
-Phoenix uses [OpenInference](https://arize.com/docs/phoenix/reference/openinference). hermes-otel emits that convention on every span (`llm.token_count.*`, `input.value`, `output.value`) alongside the `gen_ai.*` convention for other backends.
-
-See [Attribute conventions](/architecture/attributes) for the full dual-convention table.
+hermes-otel emits OpenTelemetry GenAI model/provider/token attributes and preview-safe `input.value` / `output.value` fields for generic span rendering. See [Attribute conventions](/architecture/attributes) for the full table.
 
 ## Metrics
 
@@ -79,4 +77,4 @@ Phoenix accepts OTLP metrics in addition to traces. The plugin's token/tool/cost
 
 **"Tokens show as zero"**
 
-- Phoenix keys off `llm.token_count.*` — the plugin emits these on `api.*` spans (not `llm.*`). Check the child `api.*` span, not the parent.
+- Token attributes are emitted on `api.*` spans (not `llm.*`) as `gen_ai.usage.*`. Check the child `api.*` span, not the parent.

--- a/website/docs/backends/signoz.md
+++ b/website/docs/backends/signoz.md
@@ -59,16 +59,17 @@ SigNoz treats the plugin's spans as standard OTel traces. The service-map view l
 
 Metrics flow to the SigNoz metrics UI automatically:
 
-- `hermes.tokens.prompt` / `hermes.tokens.completion` (counters)
-- `hermes.tool.calls` (counter)
-- `hermes.tool.duration` (histogram)
-- `hermes.api.duration` (histogram)
+- `gen_ai.client.token.usage` (histogram, tokens)
+- `gen_ai.client.operation.duration` (histogram, seconds)
+- `gen_ai.invoke_agent.duration` (histogram, seconds)
+- `gen_ai.execute_tool.duration` (histogram, seconds)
+- `hermes.session.count`, `hermes.message.count`, and `hermes.model.usage` (Hermes-specific counters)
 
 See [Span attributes reference](/reference/span-attributes) for the full list.
 
 ## Attribute convention
 
-SigNoz reads `gen_ai.*` attributes for LLM-specific views, which the plugin emits alongside the OpenInference `llm.*` convention. Both sets land on the same spans — SigNoz uses whichever it recognises.
+SigNoz reads `gen_ai.*` attributes for LLM-specific views. The plugin emits canonical GenAI model/provider/token fields and keeps `hermes.*` only for Hermes-specific extensions.
 
 ## Troubleshooting
 

--- a/website/docs/backends/uptrace.md
+++ b/website/docs/backends/uptrace.md
@@ -74,14 +74,14 @@ Port 14318 was picked specifically to avoid the standard 4318 used by LGTM / Jae
 ## What you'll see in the UI
 
 **Traces:**
-Navigation → Traces. Every attribute the plugin emits is searchable (OpenInference + GenAI + `hermes.*`). Group by `llm.model_name`, `openinference.span.kind`, `hermes.session.kind`, etc. Click a trace to see the full waterfall with the same attributes Phoenix and Grafana show.
+Navigation → Traces. Every attribute the plugin emits is searchable (GenAI + `hermes.*`). Group by `gen_ai.request.model`, `gen_ai.operation.name`, `hermes.session.kind`, etc. Click a trace to see the full waterfall with the same attributes Phoenix and Grafana show.
 
 **Metrics:**
-Navigation → Metrics. Query with PromQL over any `hermes_*` metric the plugin emits:
+Navigation → Metrics. Query with PromQL over the metrics the plugin emits:
 
 - `hermes_session_count_total` — sessions started
-- `hermes_token_usage_total` — prompt / completion tokens by provider / model
-- `hermes_tool_duration_bucket` — tool execution histogram
+- `gen_ai_client_token_usage_total` — prompt / completion tokens by provider / model
+- `gen_ai_execute_tool_duration_bucket` — tool execution histogram
 
 **Logs:**
 Navigation → Logs. When `capture_logs: true` is on, every `logger.info(...)` from hermes or the plugin lands here with the active span's `trace_id` and `span_id` attached — click a log record's `trace_id` to jump into the corresponding trace. See [OTel logs](/configuration/logs) for the full story.

--- a/website/docs/configuration/privacy.md
+++ b/website/docs/configuration/privacy.md
@@ -43,7 +43,7 @@ Everything that isn't user-originated content:
 - Span tree (parent/child relationships)
 - Span timings (start / end / duration)
 - Tool names, commands, targets, outcomes (`tool.name`, `hermes.tool.command`, `hermes.tool.target`, `hermes.tool.outcome`)
-- Token counts (`gen_ai.usage.*`, `llm.token_count.*`)
+- Token counts (`gen_ai.usage.*`)
 - Model name, provider, finish reason
 - Per-turn summary (tool count, skill count, API call count, final status)
 - Metrics (all of them — counters and histograms)
@@ -72,6 +72,6 @@ If even command and target are too sensitive for your deployment, file an issue 
 
 ## Verifying
 
-A quick way to verify privacy mode is working: run a Hermes turn that uses a tool, then inspect the trace. Every `input.value` / `output.value` / `gen_ai.content.*` attribute should be **absent** (not empty — absent). Token counts and tool names should still be present.
+A quick way to verify privacy mode is working: run a Hermes turn that uses a tool, then inspect the trace. Every `input.value`, `output.value`, `gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.system_instructions` attribute should be **absent** (not empty — absent). Token counts and tool names should still be present.
 
 In Langfuse, you'll see observations with empty input/output panels. In Phoenix, the Input/Output panels won't render at all for those spans.

--- a/website/docs/getting-started/concepts.md
+++ b/website/docs/getting-started/concepts.md
@@ -43,9 +43,9 @@ Because a single user turn usually involves **multiple HTTP round-trips**. The t
 
 That's two `api.*` calls but one logical `llm.*` turn. The parent `llm.*` span carries the user message (input) and the final assistant response (output), so at a glance you see what the user asked and what they got back.
 
-## Dual-convention attributes
+## GenAI semantic attributes
 
-Different observability vendors standardised on different attribute names for the same LLM concepts. hermes-otel emits **both** the [Langfuse / `gen_ai.*`](https://langfuse.com/docs) convention and the [Phoenix / OpenInference `llm.*`](https://arize.com/docs/phoenix/reference/openinference) convention on the same span, so whichever backend you point at sees the data it's expecting.
+hermes-otel emits canonical OpenTelemetry GenAI attributes (`gen_ai.*`) for model, provider, token, request, and response metadata, plus `hermes.*` extensions for agent-specific turn and tool details.
 
 See [Attribute conventions](/architecture/attributes) for the full mapping.
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -33,8 +33,8 @@ hermes-otel turns every Hermes lifecycle hook into a properly-nested **OpenTelem
 
 <div className="feature-grid">
   <div className="feature-card">
-    <h3>Dual-convention attributes</h3>
-    <p>Emits both <code>{'gen_ai.*'}</code> (Langfuse / SigNoz) and <code>{'llm.token_count.*'}</code> (Phoenix / OpenInference) so the UI in your chosen backend just <em>works</em>.</p>
+    <h3>GenAI semantic attributes</h3>
+    <p>Emits canonical <code>{'gen_ai.*'}</code> model, provider, token, and response fields plus Hermes-specific extensions for turn and tool details.</p>
   </div>
   <div className="feature-card">
     <h3>Multi-backend fan-out</h3>
@@ -105,7 +105,7 @@ session.{platform} / cron                 [root, GENERAL]
     └── api.{model}                       [LLM — second round-trip, final response]
 ```
 
-Each span carries the attributes both Langfuse (`gen_ai.usage.input_tokens`, `gen_ai.content.prompt`) and Phoenix (`llm.token_count.prompt`, `input.value`) expect — see [Attribute conventions](/architecture/attributes).
+Each span carries GenAI attributes such as `gen_ai.usage.input_tokens`, `gen_ai.provider.name`, and `gen_ai.request.model`, plus preview-safe `input.value` / `output.value` — see [Attribute conventions](/architecture/attributes).
 
 ## Where to go next
 

--- a/website/docs/reference/hooks.md
+++ b/website/docs/reference/hooks.md
@@ -25,15 +25,15 @@ Fires when the tool returns (success, error, or timeout).
 - **Span op:** closes the `tool.*` span
 - **Attributes set on end:** `output.value` (result), `hermes.tool.outcome`
 - **Span status:** `ERROR` if outcome is `error`, else `OK`
-- **Metrics:** `hermes.tool.calls{tool_name, outcome}` counter, `hermes.tool.duration{tool_name, outcome}` histogram
+- **Metrics:** `gen_ai.execute_tool.duration{gen_ai.tool.name}` histogram (seconds)
 
 ### `pre_llm_call`
 
 Fires before the logical LLM turn starts (before any HTTP round-trips).
 
 - **Span op:** `tracker.start("llm.{model}", parent=session_root)`
-- **Attributes set on start:** `llm.model_name`, `llm.provider`, `gen_ai.request.model`, and (when `capture_conversation_history: true`) `input.value` JSON + `input.mime_type=application/json` + `hermes.conversation.message_count`
-- **Side effects:** stores the current `llm.*` as the parent for subsequent `api.*` and `tool.*`
+- **Attributes set on start:** `gen_ai.request.model`, `gen_ai.provider.name`, `gen_ai.operation.name`, and (when `capture_conversation_history: true`) `input.value` JSON + `input.mime_type=application/json` + `hermes.conversation.message_count`
+- **Side effects:** stores the current `llm.*` span as the parent for subsequent `api.*` and `tool.*`
 
 ### `post_llm_call`
 
@@ -47,7 +47,7 @@ Fires after the logical LLM turn finishes (all round-trips done, final response 
 Fires before each HTTP request to the LLM provider. Can fire multiple times per `llm.*` turn.
 
 - **Span op:** `tracker.start("api.{model}", parent=current_llm)`
-- **Attributes set on start:** `llm.model_name`, `llm.provider`, `llm.invocation_parameters`
+- **Attributes set on start:** `gen_ai.request.model`, `gen_ai.provider.name`, `gen_ai.operation.name`, and request parameters such as `gen_ai.request.temperature`
 - **Side effects:** increments `hermes.turn.api_call_count`
 
 ### `post_api_request`
@@ -55,8 +55,8 @@ Fires before each HTTP request to the LLM provider. Can fire multiple times per 
 Fires when the HTTP response is parsed.
 
 - **Span op:** closes the `api.*` span
-- **Attributes set on end:** token counts (both conventions), `gen_ai.response.finish_reason`, `http.duration_ms`
-- **Metrics:** `hermes.tokens.*` counters, `hermes.api.duration` histogram
+- **Attributes set on end:** `gen_ai.usage.*` token counts and `gen_ai.response.finish_reasons`
+- **Metrics:** `gen_ai.client.token.usage` counter, `gen_ai.client.operation.duration` histogram
 
 ## Newer (session hooks)
 
@@ -67,7 +67,7 @@ Registered inside a `try:/except:` because older Hermes versions don't expose th
 Fires at the start of a user turn (CLI input, inbound message, cron wake-up).
 
 - **Span op:** `tracker.start("session.{kind}", parent=None)` — this becomes the root of the trace
-- **Attributes set on start:** `hermes.session.kind`, `hermes.session.id`, `session.id`, `user.id`, `openinference.project.name`
+- **Attributes set on start:** `hermes.session.kind`, `gen_ai.conversation.id`, `gen_ai.conversation.compacted=true` when compaction is explicitly reported, `gen_ai.agent.name`, `gen_ai.operation.name=invoke_agent`, `user.id` when sender capture is enabled, `openinference.project.name`
 - **Fallback if not available:** the `llm.*` span becomes the root; turn summary is attached there instead of on a dedicated session root
 
 ### `on_session_end`
@@ -76,7 +76,7 @@ Fires when the turn is fully complete (assistant has returned its final response
 
 - **Span op:** closes the `session.*` span
 - **Attributes set on end:** the full [turn summary](/architecture/turn-summary) — `hermes.turn.tool_count`, `hermes.turn.tools`, `hermes.turn.tool_targets`, `hermes.turn.tool_commands`, `hermes.turn.tool_outcomes`, `hermes.turn.skill_count`, `hermes.turn.skills`, `hermes.turn.api_call_count`, `hermes.turn.final_status`
-- **Metrics:** `hermes.sessions{kind, final_status}` counter
+- **Metrics:** `hermes.session.count` counter and `gen_ai.invoke_agent.duration` histogram (seconds)
 - **Side effects:** if `force_flush_on_session_end: true` (default), synchronously force-flushes every `BatchSpanProcessor` so the trace appears in the backend UI immediately
 
 ## Hook → span mapping

--- a/website/docs/reference/span-attributes.md
+++ b/website/docs/reference/span-attributes.md
@@ -6,7 +6,7 @@ description: "Every attribute the plugin sets, by span type."
 
 # Span attribute reference
 
-Every attribute the plugin may set, grouped by span type. See [Attribute conventions](/architecture/attributes) for the narrative version of the dual-convention mapping.
+Every attribute the plugin may set, grouped by span type. See [Attribute conventions](/architecture/attributes) for the narrative version of the GenAI mapping.
 
 Attributes marked **optional** are only set when the underlying data is available.
 
@@ -29,8 +29,7 @@ Set at **start**:
 | Attribute | Type | Meaning |
 |---|---|---|
 | `hermes.session.kind` | string | `cli` · `telegram` · `discord` · `cron` · ... |
-| `hermes.session.id` | string | Hermes session ID |
-| `session.id` | string | Standard OTel alias |
+| `gen_ai.conversation.id` | string | Hermes session/conversation ID |
 | `user.id` | string | Hermes user ID (optional) |
 
 Set at **end** (turn summary):
@@ -55,16 +54,15 @@ Span kind: `LLM` (OpenInference).
 
 | Attribute | Convention | Type | Meaning |
 |---|---|---|---|
-| `llm.model_name` | OpenInference | string | Model name |
-| `llm.provider` | OpenInference | string | Provider (anthropic, openai, ...) |
-| `gen_ai.request.model` | gen_ai | string | Model name (Langfuse) |
-| `gen_ai.system` | gen_ai | string | Provider (Langfuse) |
-| `input.value` | OpenInference | string | User message OR full conversation JSON |
-| `input.mime_type` | OpenInference | string | `text/plain` OR `application/json` |
-| `output.value` | OpenInference | string | Final assistant response |
-| `output.mime_type` | OpenInference | string | `text/plain` |
-| `gen_ai.content.prompt` | gen_ai | string | User message |
-| `gen_ai.content.completion` | gen_ai | string | Assistant response |
+| `gen_ai.request.model` | gen_ai | string | Model name |
+| `gen_ai.provider.name` | gen_ai | string | Provider (anthropic, openai, ...) |
+| `gen_ai.operation.name` | gen_ai | string | Operation name |
+| `input.value` | generic | string | User message OR full conversation JSON |
+| `input.mime_type` | generic | string | `text/plain` OR `application/json` |
+| `output.value` | generic | string | Final assistant response |
+| `output.mime_type` | generic | string | `text/plain` |
+| `gen_ai.input.messages` | gen_ai | array/string | Full input messages when explicitly enabled |
+| `gen_ai.output.messages` | gen_ai | array/string | Full output messages when explicitly enabled |
 | `hermes.conversation.message_count` | hermes | int | When conversation capture is on (optional) |
 
 ## `api.*`
@@ -74,20 +72,14 @@ Span kind: `LLM` (OpenInference).
 | Attribute | Convention | Type | Meaning |
 |---|---|---|---|
 | `gen_ai.request.model` | gen_ai | string | Model name |
-| `llm.model_name` | OpenInference | string | Model name |
-| `llm.provider` | OpenInference | string | Provider |
-| `llm.token_count.prompt` | OpenInference | int | Prompt tokens |
-| `llm.token_count.completion` | OpenInference | int | Completion tokens |
-| `llm.token_count.total` | OpenInference | int | Sum |
-| `llm.token_count.cache_read` | OpenInference | int | Cache read (optional) |
-| `llm.token_count.cache_write` | OpenInference | int | Cache write (optional) |
 | `gen_ai.usage.input_tokens` | gen_ai | int | Prompt tokens |
 | `gen_ai.usage.output_tokens` | gen_ai | int | Completion tokens |
-| `gen_ai.usage.cache_read_input_tokens` | gen_ai | int | Cache read (optional) |
-| `gen_ai.usage.cache_creation_input_tokens` | gen_ai | int | Cache write (optional) |
-| `llm.invocation_parameters` | OpenInference | string (JSON) | Request params |
-| `gen_ai.response.finish_reason` | gen_ai | string | `stop`, `tool_use`, `length`, etc. |
-| `http.duration_ms` | hermes | int | Wall-clock HTTP duration |
+| `gen_ai.usage.cache_read.input_tokens` | gen_ai | int | Cache read (optional) |
+| `gen_ai.usage.cache_creation.input_tokens` | gen_ai | int | Cache write (optional) |
+| `gen_ai.request.*` | gen_ai | mixed | Request params |
+| `gen_ai.response.finish_reasons` | gen_ai | string/list | `stop`, `tool_use`, `length`, etc. |
+
+Total tokens are derived downstream from input + output tokens rather than emitted as a duplicate span attribute.
 
 ## `tool.*`
 
@@ -109,15 +101,14 @@ Emitted via `PeriodicExportingMetricReader` on backends that support OTLP metric
 
 | Metric | Type | Unit | Labels |
 |---|---|---|---|
-| `hermes.tokens.prompt` | Counter | tokens | `model`, `provider` |
-| `hermes.tokens.completion` | Counter | tokens | `model`, `provider` |
-| `hermes.tokens.total` | Counter | tokens | `model`, `provider` |
-| `hermes.tokens.cache_read` | Counter | tokens | `model`, `provider` |
-| `hermes.tokens.cache_write` | Counter | tokens | `model`, `provider` |
-| `hermes.tool.calls` | Counter | count | `tool_name`, `outcome` |
-| `hermes.tool.duration` | Histogram | ms | `tool_name`, `outcome` |
-| `hermes.api.duration` | Histogram | ms | `model`, `provider`, `finish_reason` |
+| `gen_ai.client.token.usage` | Histogram | `{token}` | `gen_ai.token.type`, `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model` |
+| `gen_ai.client.operation.duration` | Histogram | s | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model` |
+| `gen_ai.invoke_agent.duration` | Histogram | s | `gen_ai.operation.name`, `gen_ai.agent.name`, `gen_ai.provider.name`, `gen_ai.request.model` |
+| `gen_ai.execute_tool.duration` | Histogram | s | `gen_ai.operation.name`, `gen_ai.agent.name`, `gen_ai.tool.name` |
+| `hermes.session.count` | Counter | count | `gen_ai.agent.name`, `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model` |
+| `hermes.cost.usage` | Counter | USD | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model` |
+| `hermes.message.count` | Counter | count | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model` |
+| `hermes.model.usage` | Counter | count | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model` |
 | `hermes.skill.inferred` | Counter | count | `skill_name`, `source` |
-| `hermes.sessions` | Counter | count | `kind`, `final_status` |
 
-Label cardinality is bounded by normalised values (outcomes, finish reasons) and small dimension sets (model, tool name). No user IDs or other high-cardinality labels.
+Label cardinality is bounded by normalised values (token type, operation name) and small dimension sets (model, provider, tool name). No prompt/message/tool payloads are emitted as metric labels.


### PR DESCRIPTION
## Summary
- propagate explicit GenAI conversation IDs from kwargs/env into per-session state
- reuse persisted conversation IDs on LLM/API/tool child spans so child processes keep the parent conversation id
- add focused unit/integration coverage for env, kwargs, long session IDs, and cross-process child propagation

## Verification
- python -m pytest tests/unit/test_hooks_callbacks.py::TestOnPreLlmCall::test_session_state_uses_full_session_id_for_conversation tests/unit/test_hooks_callbacks.py::TestOnPreLlmCall::test_reuses_session_conversation_id_on_child_span tests/integration/test_inmemory_pipeline.py::TestSessionSpanExport::test_cross_process_child_can_share_parent_conversation_id
- python -m pytest tests/unit/test_hooks_callbacks.py tests/integration/test_inmemory_pipeline.py tests/integration/test_span_hierarchy.py
- python -m pytest
- autoreview --mode local --parallel-tests "python -m pytest tests/unit/test_hooks_callbacks.py tests/integration/test_inmemory_pipeline.py tests/integration/test_span_hierarchy.py"