### PR TITLE
feat(hooks): W3C traceparent propagation to MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,17 @@ LLM and API spans also expose standard GenAI request/response metadata where Her
 
 Phoenix uses `input.value` and `output.value` for previews. When full prompt/response capture is explicitly enabled, the plugin also writes the corresponding GenAI content attributes (`gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.system_instructions`).
 
+## Trace propagation to MCP servers
+
+The plugin forwards the active span's W3C `traceparent` on outbound MCP HTTP requests so an OTel-instrumented MCP server's spans join the **same trace** as the agent. It registers an `mcp_request_headers` hook (only when the host Hermes advertises it — a silent no-op otherwise) and exposes a public helper:
+
+```python
+from hermes_plugins.hermes_otel.hooks import get_current_traceparent
+traceparent = get_current_traceparent(session_id)   # "00-<trace>-<span>-01" or None
+```
+
+See [docs: MCP trace propagation](website/docs/configuration/mcp-trace-propagation.md).
+
 ## File structure
 
 | File | Role |

--- a/__init__.py
+++ b/__init__.py
@@ -47,4 +47,23 @@ def register(ctx):
         except Exception:
             debug_log(f"{hook_name} hook unavailable")
 
-    logger.info(f"[hermes-otel] Registered {6 + session_hooks} hooks")
+    # Trace-context propagation to MCP servers. Registered only when the host
+    # Hermes advertises the `mcp_request_headers` hook, so older Hermes builds
+    # don't get an "unknown hook" warning. The hook injects a W3C `traceparent`
+    # onto outbound MCP HTTP requests so MCP-server spans link into the agent's
+    # trace. No-op (returns {}) when no span is active. See get_current_traceparent.
+    mcp_hooks = 0
+    try:
+        from hermes_cli.plugins import VALID_HOOKS as _valid_hooks
+    except Exception:
+        _valid_hooks = None
+    if _valid_hooks is None or "mcp_request_headers" in _valid_hooks:
+        try:
+            ctx.register_hook("mcp_request_headers", hooks.on_mcp_request_headers)
+            mcp_hooks = 1
+        except Exception:
+            debug_log("mcp_request_headers hook unavailable")
+    else:
+        debug_log("mcp_request_headers hook not supported by this Hermes; skipping")
+
+    logger.info(f"[hermes-otel] Registered {6 + session_hooks + mcp_hooks} hooks")

--- a/hooks.py
+++ b/hooks.py
@@ -1096,3 +1096,71 @@ def on_post_api_request(
     # Mark as OK
     tracer.end_span(key, attributes=attributes, status="ok")
     debug_log(f"  API span ended: status=ok, tokens={usage.get('total_tokens', 0) if usage else 0}")
+
+
+# ── Distributed trace-context propagation (W3C traceparent) ──────────────────
+#
+# Downstream services (notably MCP servers reached over HTTP) can be linked
+# into the agent's trace by forwarding the active span's context as a W3C
+# ``traceparent`` header. The span registry (``tracer.spans``) is a
+# process-global dict keyed by ``session_id`` holding real OTel spans, so these
+# helpers are safe to call from any thread or event loop — including the MCP
+# background loop, which does not inherit the agent task's OTel context var.
+
+
+def get_current_traceparent(session_id: Optional[str] = None) -> Optional[str]:
+    """Return the W3C ``traceparent`` for the active span, or ``None``.
+
+    Format: ``00-<32-hex trace id>-<16-hex span id>-<2-hex flags>`` (the
+    ``traceparent`` header defined by https://www.w3.org/TR/trace-context/).
+
+    Pass ``session_id`` when you know it — the lookup is session-keyed and
+    survives thread/event-loop boundaries. With no ``session_id`` (or an
+    unknown one) it falls back to the current context-var parent and, as a
+    last resort, the innermost span of any single active session. Returns
+    ``None`` when tracing is disabled or no valid span is active.
+    """
+    tracer = get_tracer()
+    spans = getattr(tracer, "spans", None)
+    if spans is None:
+        return None
+
+    parent = spans.get_current_parent(session_id)
+    if parent is None:
+        # Last resort: any active session's innermost span. Helps callers on a
+        # background loop (e.g. an outbound MCP request) that can't supply a
+        # session_id when exactly one session is in flight.
+        stacks = getattr(spans, "_session_parent_stacks", {})
+        for stack in reversed(list(stacks.values())):
+            if stack:
+                parent = stack[-1]
+                break
+    if parent is None:
+        return None
+
+    get_ctx = getattr(parent, "get_span_context", None)
+    if get_ctx is None:
+        return None
+    ctx = get_ctx()
+    if ctx is None or not getattr(ctx, "is_valid", False):
+        return None
+
+    flags = "01" if (ctx.trace_flags & 1) else "00"
+    return f"00-{ctx.trace_id:032x}-{ctx.span_id:016x}-{flags}"
+
+
+def on_mcp_request_headers(
+    server_name: Optional[str] = None,
+    tool_name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    **kwargs: Any,
+) -> Dict[str, str]:
+    """``mcp_request_headers`` hook — inject ``traceparent`` on outbound MCP calls.
+
+    Returns a header dict merged onto the outbound MCP HTTP request by
+    hermes-agent. Empty dict when no trace is active (never raises, never
+    blocks the call). ``session_id`` may also arrive nested in ``kwargs``.
+    """
+    sid = session_id or kwargs.get("session_id")
+    traceparent = get_current_traceparent(sid)
+    return {"traceparent": traceparent} if traceparent else {}

--- a/tests/unit/test_traceparent.py
+++ b/tests/unit/test_traceparent.py
@@ -1,0 +1,89 @@
+"""Unit tests for W3C traceparent propagation helpers.
+
+Exercises ``get_current_traceparent`` and the ``on_mcp_request_headers`` hook
+against a real OTel span pushed onto the tracer's session-keyed parent stack.
+No network.
+"""
+
+import re
+
+import pytest
+from hermes_otel import hooks
+from hermes_otel.tracer import get_tracer
+from opentelemetry import trace as _trace
+from opentelemetry.sdk.trace import TracerProvider
+
+_TRACEPARENT_RE = re.compile(r"^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$")
+
+
+@pytest.fixture
+def real_span():
+    """Yield a real, recording OTel span (not attached to the OTel context)."""
+    provider = TracerProvider()
+    tracer = provider.get_tracer("test")
+    span = tracer.start_span("unit-parent")
+    try:
+        yield span
+    finally:
+        span.end()
+
+
+@pytest.fixture(autouse=True)
+def fresh_tracer():
+    """Reset the singleton so each test starts with an empty span registry."""
+    import hermes_otel.tracer as tracer_mod
+
+    tracer_mod._tracer = None
+    yield
+    tracer_mod._tracer = None
+
+
+class TestGetCurrentTraceparent:
+    def test_none_when_no_active_span(self):
+        assert hooks.get_current_traceparent("s1") is None
+        assert hooks.get_current_traceparent() is None
+
+    def test_returns_well_formed_traceparent_for_session(self, real_span):
+        get_tracer().spans.push_parent(real_span, session_id="s1")
+        tp = hooks.get_current_traceparent("s1")
+        assert tp is not None
+        assert _TRACEPARENT_RE.match(tp), tp
+
+    def test_traceparent_carries_span_context(self, real_span):
+        get_tracer().spans.push_parent(real_span, session_id="s1")
+        tp = hooks.get_current_traceparent("s1")
+        ctx = real_span.get_span_context()
+        assert tp == f"00-{ctx.trace_id:032x}-{ctx.span_id:016x}-01"
+
+    def test_unknown_session_falls_back_to_any_active_stack(self, real_span):
+        # Span registered under s1, but the caller doesn't know the session id.
+        get_tracer().spans.push_parent(real_span, session_id="s1")
+        tp_known = hooks.get_current_traceparent("s1")
+        tp_unknown = hooks.get_current_traceparent("does-not-exist")
+        assert tp_unknown == tp_known
+
+    def test_none_after_parent_popped(self, real_span):
+        spans = get_tracer().spans
+        spans.push_parent(real_span, session_id="s1")
+        spans.pop_parent(session_id="s1")
+        assert hooks.get_current_traceparent("s1") is None
+
+
+class TestMcpRequestHeadersHook:
+    def test_empty_dict_when_no_span(self):
+        assert hooks.on_mcp_request_headers(server_name="srv", tool_name="t") == {}
+
+    def test_injects_traceparent(self, real_span):
+        get_tracer().spans.push_parent(real_span, session_id="s1")
+        headers = hooks.on_mcp_request_headers(server_name="srv", tool_name="t", session_id="s1")
+        assert set(headers) == {"traceparent"}
+        assert headers["traceparent"] == hooks.get_current_traceparent("s1")
+
+    def test_session_id_via_kwargs(self, real_span):
+        get_tracer().spans.push_parent(real_span, session_id="s1")
+        headers = hooks.on_mcp_request_headers(session_id="s1")
+        assert "traceparent" in headers
+
+    def test_never_raises_on_missing_args(self):
+        # Defensive: a host that calls with no kwargs must not blow up.
+        assert hooks.on_mcp_request_headers() == {}

--- a/website/docs/configuration/mcp-trace-propagation.md
+++ b/website/docs/configuration/mcp-trace-propagation.md
@@ -1,0 +1,88 @@
+---
+sidebar_position: 9
+title: "MCP trace propagation"
+description: "Link MCP-server spans into the agent's trace by forwarding a W3C traceparent on outbound MCP requests."
+---
+
+# MCP trace propagation
+
+When the agent calls a tool on a remote [MCP](https://modelcontextprotocol.io/)
+server, that server's spans normally land in a **separate, unlinked trace** —
+so debugging a slow or failing MCP call means correlating timestamps by hand.
+
+This plugin can forward the active span's context as a W3C
+[`traceparent`](https://www.w3.org/TR/trace-context/) header on every outbound
+MCP HTTP request, so the MCP server's spans join the **same trace** as the
+agent. One query in your backend then shows the whole lifecycle: user message →
+LLM call → tool dispatch → MCP transport → the MCP server's own work.
+
+## How it works
+
+Two pieces cooperate:
+
+1. **hermes-otel** exposes the active trace context and registers an
+   `mcp_request_headers` hook that returns `{"traceparent": "..."}`.
+2. **hermes-agent** invokes that hook on the MCP transport's HTTP client and
+   merges the returned headers onto each outbound request.
+
+The span registry is process-global and keyed by `session_id` (not bound to a
+context var), so the lookup works even though MCP requests run on a separate
+background event loop from the agent task.
+
+:::note Requires hermes-agent support
+The header injection needs the `mcp_request_headers` hook in hermes-agent.
+hermes-otel registers the hook **only when the host advertises it**, so on
+older builds this feature is a silent no-op — nothing to configure, nothing to
+break. Trace context is propagated over **HTTP/StreamableHTTP** MCP transports
+(stdio servers have no request headers).
+:::
+
+## Enabling it
+
+Nothing to configure. When both sides support it, the hook is registered
+automatically and you'll see one extra hook in the startup banner:
+
+```
+[hermes-otel] Registered 9 hooks
+```
+
+Then point the agent at an MCP server over HTTP (`~/.hermes/config.yaml`):
+
+```yaml
+mcp_servers:
+  my-server:
+    url: "https://my-mcp-server.example.com/mcp"
+```
+
+For the MCP-server spans to actually appear linked, the **MCP server must be
+OpenTelemetry-instrumented** (extract the incoming `traceparent` and emit spans
+to a backend). Most OTel ASGI/HTTP middlewares do this out of the box.
+
+## Public API
+
+If you're building your own integration, call the public helper directly
+instead of reaching into span internals:
+
+```python
+from hermes_plugins.hermes_otel.hooks import get_current_traceparent
+
+tp = get_current_traceparent(session_id)   # "00-<trace>-<span>-01" or None
+```
+
+It returns the W3C `traceparent` for the active span of the given session
+(falling back to the current context-var parent, then to any single active
+session), or `None` when tracing is disabled or no span is active. Safe to call
+from any thread or event loop.
+
+## Verifying
+
+With an OTel-instrumented MCP server, after a tool call your backend should show
+a single trace whose spans span both services — the agent's `agent` / `tool.*`
+spans **and** the MCP server's request/handler spans — all sharing one
+`trace_id`. If the MCP server logs request headers, you'll also see the
+`traceparent` arrive on the `tools/call` request.
+
+## See also
+
+- [Span hierarchy](/architecture/span-hierarchy) — how the agent's spans nest.
+- [Backends overview](/backends/overview) — where these traces land.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -46,6 +46,7 @@ const sidebars: SidebarsConfig = {
         'configuration/conversation-capture',
         'configuration/batch-export',
         'configuration/logs',
+        'configuration/mcp-trace-propagation',
       ],
     },
     {


### PR DESCRIPTION
Closes #25.

## What

Implements W3C `traceparent` propagation so MCP-server spans link into the agent's trace instead of forming separate, unlinked traces.

This is the **hermes-otel** half. It needs a companion `mcp_request_headers` hook in **hermes-agent** (that hook does not exist upstream yet — see "Dependency" below). hermes-otel registers conditionally, so this PR is safe to merge now and activates automatically once the host supports the hook.

## Changes

- **`get_current_traceparent(session_id=None)`** (`hooks.py`) — public API returning the W3C `traceparent` for the active span. Session-keyed lookup with context-var and any-active-session fallbacks; returns `None` when tracing is off or no span is active. Replaces the fragile `_session_parent_stacks` duck-typing from the issue's workaround. Safe to call from any thread/event loop (the span registry is a process-global dict keyed by `session_id`, not a context var — which is exactly why cross-loop MCP calls can read it).
- **`on_mcp_request_headers(...)`** (`hooks.py`) — the hook callback; returns `{"traceparent": ...}` or `{}`. Never raises.
- **Conditional registration** (`__init__.py`) — registers `mcp_request_headers` only when the host's `VALID_HOOKS` advertises it, so older Hermes builds get **no warning** and the feature is a silent no-op. Startup banner shows `Registered 9 hooks` when active.
- **Tests** — `tests/unit/test_traceparent.py`, 9 cases against a real OTel span, no network.
- **Docs** — new site page (`configuration/mcp-trace-propagation`) + README section.

## Dependency (companion hermes-agent change)

The header injection requires hermes-agent to (a) add `mcp_request_headers` to `VALID_HOOKS` and (b) invoke it on the MCP transport's httpx client. A clean patch for that is prepared as a separate upstream PR for NousResearch/hermes-agent. Until it lands, this PR is inert (no-op) on stock Hermes.

## Verification — validated end-to-end against a real MCP server

Stood up an OpenTelemetry-instrumented StreamableHTTP MCP server, patched a local hermes-agent with the companion hook, and drove the real connect + tool-dispatch path:

- The MCP server received `traceparent: 00-390bdfe8…c9cd99-ef6bcfc3d3108ea7-01` on the `tools/call` POSTs — exactly the agent's active traceparent.
- The MCP server's spans adopted the same `trace_id`.
- **Phoenix showed one unified trace** (`390bdfe8…`, 31 spans) containing both the agent's `agent` span and the MCP server's `POST /mcp` + `mcp.tool.ping` spans.
- Requests outside an active tool call correctly carried **no** traceparent (no-op path).

`uv run --extra dev pytest` → **450 passed**; `ruff` / `black` clean; docs site builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
