### PR TITLE
feat(spans): capture API errors & retries (api_request_error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,11 +467,13 @@ Turn 1:
 |------|------|----------|
 | `agent` / `cron` | AGENT | Session metadata, completion/interruption status, turn summary |
 | `llm.{model}` | LLM | Model name, provider, user message (input), assistant response (output) |
-| `api.{model}` | LLM | Token counts (prompt + completion), duration, finish reason, cache tokens |
+| `api.{model}` | LLM | Token counts (prompt + completion), duration, finish reason, cache tokens. On failure: `ERROR` status + recorded exception + retry metadata |
 | `tool.{name}` | TOOL | Tool name, arguments (input), result (output), error status |
 | `subagent.{role}` | AGENT | Delegated child agent — role, goal, status, duration, summary; the child's own run nests beneath it so a multi-agent run is **one connected trace** |
 
 **Sub-agent delegation:** when the agent calls `delegate_task`, the plugin opens a `subagent.{role}` span in the parent trace (via the `subagent_start` / `subagent_stop` hooks) and rejoins the delegated child's own root span underneath it. Without this, child agents export as dozens of disconnected traces. See [Span hierarchy → `subagent.*`](website/docs/architecture/span-hierarchy.md) and the `hermes.subagent.count` / `hermes.subagent.duration` metrics.
+
+**API errors & retries:** failed provider requests (rate limits, timeouts, 5xx, network errors) close the `api.{model}` span as `ERROR` with an `exception` event and retry metadata (`error.type`, status code, `hermes.retry.count`, `hermes.retryable`), via the `api_request_error` hook — previously these ended `OK` and were invisible. Emits `hermes.api.error.count{error_type,status_class,retryable}` and `hermes.retry.count`.
 
 ### Attribute conventions
 

--- a/__init__.py
+++ b/__init__.py
@@ -44,6 +44,7 @@ def register(ctx):
         ("on_session_end", hooks.on_session_end),
         ("subagent_start", hooks.on_subagent_start),
         ("subagent_stop", hooks.on_subagent_stop),
+        ("api_request_error", hooks.on_api_request_error),
     ]:
         try:
             ctx.register_hook(hook_name, callback)

--- a/docs/PRD_metrics.md
+++ b/docs/PRD_metrics.md
@@ -33,7 +33,7 @@ This document describes adding first-class OpenTelemetry Metrics support to the 
 | `hermes.session.token.total` | Histogram | Total tokens per session on idle |
 | `hermes.session.cost.total` | Histogram | Total USD cost per session on idle |
 | `hermes.model.usage` | Counter | Messages per model + provider |
-| `hermes.retry.count` | Counter | API retries via session.status events |
+| `hermes.retry.count` | Counter | API retries — **implemented** via the `api_request_error` hook (incremented once per retryable failure), not `on_session_status`. See issue #28. |
 
 ### Attribute Dimensions
 
@@ -117,7 +117,7 @@ Phoenix stores OTLP metrics in Aurora (ADGM). Langfuse stores usage data indepen
 | session.token.total | `on_session_idle` (aggregated from _SESSION_USAGE) |
 | session.cost.total | `on_session_idle` (aggregated costs) |
 | model.usage | `on_post_api_request` (per model + provider) |
-| retry.count | New hook: `on_session_status` (status=retry) |
+| retry.count | **Implemented** via `api_request_error` (per retryable failure) — superseded the originally-planned `on_session_status` approach (#28) |
 
 ### New Hook Requirements
 

--- a/helpers.py
+++ b/helpers.py
@@ -209,3 +209,71 @@ def subagent_status_to_span_status(child_status: Any) -> str:
     if text in _SUBAGENT_ERROR_STATUSES:
         return "error"
     return "ok"
+
+
+# ── API errors / retries ─────────────────────────────────────────────────────
+
+_TRUE_STRINGS = frozenset({"1", "true", "t", "yes", "y", "on"})
+_FALSE_STRINGS = frozenset({"0", "false", "f", "no", "n", "off", ""})
+
+
+def to_optional_int(value: Any) -> Optional[int]:
+    """Best-effort int conversion that returns None (not 0) when unparseable.
+
+    Distinct from the hooks-module ``_to_int`` (which zero-fills) because for
+    error telemetry we must tell "status 0" apart from "no status reported".
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return int(float(text))
+        except ValueError:
+            return None
+    return None
+
+
+def coerce_bool(value: Any) -> Optional[bool]:
+    """Parse a loosely-typed truthy/falsey value, or None when undecidable.
+
+    Accepts real bools, ints, and the usual string spellings. Returns None for
+    ``None`` so callers can distinguish "not reported" from "reported false".
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in _TRUE_STRINGS:
+            return True
+        if text in _FALSE_STRINGS:
+            return False
+        return None
+    return None
+
+
+def http_status_class(status_code: Any) -> str:
+    """Bucket an HTTP status code into a low-cardinality metric label.
+
+    Returns ``"2xx"``/``"3xx"``/``"4xx"``/``"5xx"`` for a valid HTTP code,
+    ``"network"`` when there is no code (None / 0 / unparseable — i.e. the
+    request never got an HTTP response: timeout, connection error), and
+    ``"other"`` for an out-of-range number. Keeps error-metric cardinality
+    bounded regardless of provider quirks.
+    """
+    code = to_optional_int(status_code)
+    if code is None or code <= 0:
+        return "network"
+    if 100 <= code < 600:
+        return f"{code // 100}xx"
+    return "other"

--- a/hooks.py
+++ b/hooks.py
@@ -18,11 +18,14 @@ from typing import Any, Dict, List, Optional, TypedDict
 from .debug_utils import debug_log
 from .helpers import (
     clip_preview,
+    coerce_bool,
     extract_tool_result_status,
+    http_status_class,
     infer_skill_name,
     resolve_tool_identity,
     subagent_span_key,
     subagent_status_to_span_status,
+    to_optional_int,
     truncate_string,
 )
 from .session_state import TurnSummary
@@ -586,6 +589,10 @@ def on_session_end(
     if ps is not None and ps.usage_updated:
         attributes.update(_usage_attributes(ps.usage))
 
+    # Surface the last API error's type on the root so a failed turn shows why.
+    if ps is not None and ps.last_error_type:
+        attributes["error.type"] = ps.last_error_type
+
     attributes.update(_per_session_sender_attributes(ps))
 
     # Per-turn summary roll-up
@@ -1127,6 +1134,145 @@ def on_post_api_request(
     # Mark as OK
     tracer.end_span(key, attributes=attributes, status="ok")
     debug_log(f"  API span ended: status=ok, tokens={usage.get('total_tokens', 0) if usage else 0}")
+
+
+def on_api_request_error(
+    task_id: str = None,
+    session_id: str = None,
+    platform: str = None,
+    model: str = None,
+    provider: str = None,
+    api_duration: float = None,
+    status_code: Any = None,
+    retry_count: Any = None,
+    max_retries: Any = None,
+    retryable: Any = None,
+    reason: str = None,
+    error: dict = None,
+    **kwargs,
+):
+    """Fires when a provider API request fails (rate limit, timeout, 5xx, ...).
+
+    Without this hook the ``api.{model}`` span opened by ``on_pre_api_request``
+    is never closed on failure — it ends ``OK`` via the orphan sweep, hiding the
+    error. Here we close it as ``ERROR`` with a recorded exception and retry
+    metadata, and record error/retry metrics. Fails open.
+    """
+    debug_log(
+        f"api_request_error fired: model={model}, status_code={status_code}, "
+        f"retry_count={retry_count}, retryable={retryable}"
+    )
+    tracer = get_tracer()
+    if not tracer.is_enabled:
+        return
+
+    tracer.sweep_expired_turns()
+
+    error = error or {}
+    error_type = truncate_string(error.get("type"), 200) if error.get("type") else ""
+    error_message = truncate_string(error.get("message") or reason, 500)
+    status_class = http_status_class(status_code)
+    is_retryable = coerce_bool(retryable)
+
+    # Build the error attributes that go on whichever span we close.
+    attributes: Dict[str, Any] = {}
+    if error_type:
+        attributes["error.type"] = error_type
+    sc = to_optional_int(status_code)
+    if sc is not None:
+        attributes["http.response.status_code"] = sc
+        attributes["gen_ai.response.status_code"] = sc
+    rc = to_optional_int(retry_count)
+    if rc is not None:
+        attributes["hermes.retry.count"] = rc
+    mr = to_optional_int(max_retries)
+    if mr is not None:
+        attributes["hermes.max_retries"] = mr
+    if is_retryable is not None:
+        attributes["hermes.retryable"] = is_retryable
+    if api_duration:
+        attributes["llm.response.duration_ms"] = round(api_duration * 1000, 1)
+    attributes.update(_gen_ai_attributes(session_id, "chat", kwargs))
+    attributes.update(_provider_attributes(provider or platform))
+    attributes.update(_correlation_attributes(tracer, session_id, kwargs))
+
+    # Remember why this turn failed so on_session_end can surface it on the root.
+    if session_id and error_type:
+        tracer.sessions.get_or_create(session_id).last_error_type = error_type
+
+    key = f"api:{task_id}" if task_id else None
+    span = tracer.spans.get_span(key) if key else None
+    created_fallback = False
+
+    if span is None:
+        # No in-flight api span (error before pre_api_request, or already swept).
+        # Create a short-lived span so the failure is still visible. Fail-open.
+        fallback_key = key or f"api.error:{kwargs.get('api_request_id') or session_id or 'unknown'}"
+        identity: Dict[str, Any] = {
+            "session.id": truncate_string(session_id, 200),
+            "session_id": truncate_string(session_id, 200),
+        }
+        if model:
+            identity["llm.model_name"] = model
+            identity["gen_ai.request.model"] = truncate_string(model, 200)
+        if provider:
+            identity["llm.provider"] = provider
+        span = tracer.start_span(
+            name=f"api.{model}" if model else "api.error",
+            key=fallback_key,
+            kind="llm",
+            attributes=identity,
+            session_id=session_id,
+        )
+        key = fallback_key
+        created_fallback = True
+
+    # Record an OTel exception event (semconv: an event named "exception").
+    if span is not None and hasattr(span, "add_event"):
+        event_attrs: Dict[str, Any] = {
+            "exception.type": error_type or "error",
+            "exception.escaped": True,
+        }
+        if error_message:
+            event_attrs["exception.message"] = error_message
+        try:
+            span.add_event("exception", event_attrs)
+        except Exception:  # pragma: no cover — never let telemetry raise
+            pass
+
+    # The in-flight api span was pushed as the parent in on_pre_api_request;
+    # balance the stack (the fallback span was never pushed).
+    if not created_fallback:
+        tracer.spans.pop_parent(session_id=session_id)
+
+    tracer.end_span(
+        key,
+        attributes=attributes,
+        status="error",
+        error_message=error_message or reason or error_type or "api request failed",
+    )
+
+    # Metrics. Keep labels low-cardinality.
+    metric_attrs: Dict[str, Any] = {
+        "error_type": error_type or "unknown",
+        "status_class": status_class,
+        "retryable": str(bool(is_retryable)).lower(),
+    }
+    if model:
+        metric_attrs["model"] = model
+    if provider:
+        metric_attrs["provider"] = provider
+    tracer.record_metric("api_error_count", 1, metric_attrs)
+    # Count a retry attempt only when the failure was actually retryable.
+    if is_retryable:
+        retry_attrs: Dict[str, Any] = {}
+        if model:
+            retry_attrs["model"] = model
+        if provider:
+            retry_attrs["provider"] = provider
+        tracer.record_metric("retry_count", 1, retry_attrs)
+
+    debug_log(f"  API error span ended: key={key}, error.type={error_type}, class={status_class}")
 
 
 def on_subagent_start(

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -19,5 +19,6 @@ provides_hooks:
   - post_llm_call
   - pre_api_request
   - post_api_request
+  - api_request_error
   - subagent_start
   - subagent_stop

--- a/session_state.py
+++ b/session_state.py
@@ -95,6 +95,9 @@ class PerSession:
     io: Dict[str, str] = field(default_factory=lambda: {"input": "", "output": ""})
     io_captured: bool = False
     turn_summary: TurnSummary = field(default_factory=TurnSummary)
+    # The most recent API error's ``error.type`` for this session, surfaced on
+    # the root span at on_session_end so a failed turn shows *why* it failed.
+    last_error_type: str = ""
 
 
 class SessionState:

--- a/tests/integration/test_api_errors.py
+++ b/tests/integration/test_api_errors.py
@@ -1,0 +1,359 @@
+"""Integration tests for API error / retry telemetry (issue #28).
+
+A failed provider API request must close the in-flight ``api.{model}`` span as
+ERROR (with a recorded exception event + retry metadata) instead of leaving it
+to end OK via the orphan sweep.
+"""
+
+import pytest
+from hermes_otel.hooks import (
+    on_api_request_error,
+    on_post_api_request,
+    on_post_llm_call,
+    on_pre_api_request,
+    on_pre_llm_call,
+    on_session_end,
+    on_session_start,
+)
+from opentelemetry.trace import StatusCode
+
+
+def _spans_by_name(spans, name):
+    return [s for s in spans if s.name == name]
+
+
+def _span_by_name(spans, name):
+    matches = _spans_by_name(spans, name)
+    if not matches:
+        raise ValueError(f"No span named '{name}' in {[s.name for s in spans]}")
+    return matches[0]
+
+
+def _has_exception_event(span):
+    return any(e.name == "exception" for e in span.events)
+
+
+def _exception_event(span):
+    for e in span.events:
+        if e.name == "exception":
+            return e
+    raise AssertionError("no exception event on span")
+
+
+def _pre_api(task_id="a1", session_id="s1", model="gpt-4"):
+    on_pre_api_request(
+        task_id=task_id,
+        session_id=session_id,
+        platform="cli",
+        model=model,
+        provider="openai",
+        base_url="",
+        api_mode="chat",
+        api_call_count=1,
+        message_count=3,
+        tool_count=0,
+        approx_input_tokens=100,
+        request_char_count=400,
+        max_tokens=1024,
+    )
+
+
+def _post_api_ok(task_id="a1", session_id="s1", model="gpt-4"):
+    on_post_api_request(
+        task_id=task_id,
+        session_id=session_id,
+        platform="cli",
+        model=model,
+        provider="openai",
+        base_url="",
+        api_mode="chat",
+        api_call_count=1,
+        api_duration=0.4,
+        finish_reason="stop",
+        message_count=3,
+        response_model=model,
+        usage={"prompt_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        assistant_content_chars=20,
+        assistant_tool_call_count=0,
+    )
+
+
+class TestInFlightSpanEndsError:
+    def test_api_span_closed_as_error_with_metadata(self, inmemory_otel_setup):
+        exporter, _ = inmemory_otel_setup
+
+        on_session_start(session_id="s1", model="gpt-4", platform="cli")
+        on_pre_llm_call(
+            session_id="s1",
+            user_message="hi",
+            conversation_history=[],
+            is_first_turn=True,
+            model="gpt-4",
+            platform="cli",
+        )
+        _pre_api()
+        on_api_request_error(
+            task_id="a1",
+            session_id="s1",
+            platform="cli",
+            model="gpt-4",
+            provider="openai",
+            api_duration=1.25,
+            status_code=429,
+            retry_count=2,
+            max_retries=5,
+            retryable=True,
+            reason="rate limited",
+            error={"type": "RateLimitError", "message": "429 Too Many Requests"},
+        )
+        on_post_llm_call(
+            session_id="s1",
+            user_message="hi",
+            assistant_response="",
+            conversation_history=[],
+            model="gpt-4",
+            platform="cli",
+        )
+        on_session_end(
+            session_id="s1", completed=True, interrupted=False, model="gpt-4", platform="cli"
+        )
+
+        spans = exporter.get_finished_spans()
+        api_spans = _spans_by_name(spans, "api.gpt-4")
+        # Exactly one api span — closed by the error handler, NOT duplicated by
+        # the orphan sweep.
+        assert len(api_spans) == 1
+        api = api_spans[0]
+
+        assert api.status.status_code == StatusCode.ERROR
+        attrs = dict(api.attributes)
+        assert attrs["error.type"] == "RateLimitError"
+        assert attrs["http.response.status_code"] == 429
+        assert attrs["gen_ai.response.status_code"] == 429
+        assert attrs["hermes.retry.count"] == 2
+        assert attrs["hermes.max_retries"] == 5
+        assert attrs["hermes.retryable"] is True
+        assert attrs["llm.response.duration_ms"] == 1250.0
+
+        # Exception recorded as an OTel "exception" event.
+        assert _has_exception_event(api)
+        ev = dict(_exception_event(api).attributes)
+        assert ev["exception.type"] == "RateLimitError"
+        assert "429" in ev["exception.message"]
+
+
+class TestRetryThenSuccess:
+    def test_errored_attempt_and_successful_attempt_under_one_turn(self, inmemory_otel_setup):
+        exporter, _ = inmemory_otel_setup
+
+        on_session_start(session_id="s1", model="gpt-4", platform="cli")
+        on_pre_llm_call(
+            session_id="s1",
+            user_message="hi",
+            conversation_history=[],
+            is_first_turn=True,
+            model="gpt-4",
+            platform="cli",
+        )
+        # Attempt 1 → retryable error.
+        _pre_api(task_id="a1")
+        on_api_request_error(
+            task_id="a1",
+            session_id="s1",
+            model="gpt-4",
+            provider="openai",
+            status_code=503,
+            retry_count=1,
+            max_retries=5,
+            retryable=True,
+            error={"type": "ServiceUnavailable", "message": "503"},
+        )
+        # Attempt 2 → success (same task id, reused key).
+        _pre_api(task_id="a1")
+        _post_api_ok(task_id="a1")
+        on_post_llm_call(
+            session_id="s1",
+            user_message="hi",
+            assistant_response="ok",
+            conversation_history=[],
+            model="gpt-4",
+            platform="cli",
+        )
+        on_session_end(
+            session_id="s1", completed=True, interrupted=False, model="gpt-4", platform="cli"
+        )
+
+        api_spans = _spans_by_name(exporter.get_finished_spans(), "api.gpt-4")
+        assert len(api_spans) == 2
+        statuses = {s.status.status_code for s in api_spans}
+        assert StatusCode.ERROR in statuses
+        assert StatusCode.OK in statuses
+        # Same turn → both attempts share the LLM parent (one trace).
+        assert len({s.context.trace_id for s in api_spans}) == 1
+
+
+class TestFatalErrorPropagatesToRoot:
+    def test_root_agent_span_carries_error_type(self, inmemory_otel_setup):
+        exporter, _ = inmemory_otel_setup
+
+        on_session_start(session_id="s1", model="gpt-4", platform="cli")
+        on_pre_llm_call(
+            session_id="s1",
+            user_message="hi",
+            conversation_history=[],
+            is_first_turn=True,
+            model="gpt-4",
+            platform="cli",
+        )
+        _pre_api()
+        on_api_request_error(
+            task_id="a1",
+            session_id="s1",
+            model="gpt-4",
+            provider="openai",
+            status_code=401,
+            retryable=False,
+            error={"type": "AuthenticationError", "message": "invalid api key"},
+        )
+        # Fatal: the turn ends incomplete.
+        on_session_end(
+            session_id="s1", completed=False, interrupted=False, model="gpt-4", platform="cli"
+        )
+
+        agent = _span_by_name(exporter.get_finished_spans(), "agent")
+        attrs = dict(agent.attributes)
+        assert attrs["error.type"] == "AuthenticationError"
+        # Incomplete turn → root is ERROR (pre-existing behavior, now annotated).
+        assert agent.status.status_code == StatusCode.ERROR
+
+
+class TestFallbackSpanWhenNoInFlight:
+    def test_creates_visible_error_span(self, inmemory_otel_setup):
+        exporter, _ = inmemory_otel_setup
+
+        on_session_start(session_id="s1", model="gpt-4", platform="cli")
+        # No pre_api_request for this task → no in-flight span to close.
+        on_api_request_error(
+            task_id="ghost",
+            session_id="s1",
+            model="gpt-4",
+            provider="openai",
+            status_code=500,
+            retryable=False,
+            error={"type": "InternalServerError", "message": "boom"},
+        )
+        on_session_end(
+            session_id="s1", completed=True, interrupted=False, model="gpt-4", platform="cli"
+        )
+
+        spans = exporter.get_finished_spans()
+        api = _span_by_name(spans, "api.gpt-4")
+        assert api.status.status_code == StatusCode.ERROR
+        assert dict(api.attributes)["error.type"] == "InternalServerError"
+        assert _has_exception_event(api)
+
+    def test_fallback_without_model_or_task(self, inmemory_otel_setup):
+        exporter, _ = inmemory_otel_setup
+        # Truly minimal payload must not raise and should still surface a span.
+        on_api_request_error(error={"type": "Timeout", "message": "no response"})
+        api = _span_by_name(exporter.get_finished_spans(), "api.error")
+        assert api.status.status_code == StatusCode.ERROR
+
+
+class TestFanOut:
+    def test_errored_span_reaches_all_backends(self, two_exporter_pipeline):
+        exporter_a, exporter_b, _ = two_exporter_pipeline
+        on_session_start(session_id="s1", model="gpt-4", platform="cli")
+        on_pre_llm_call(
+            session_id="s1",
+            user_message="hi",
+            conversation_history=[],
+            is_first_turn=True,
+            model="gpt-4",
+            platform="cli",
+        )
+        _pre_api()
+        on_api_request_error(
+            task_id="a1",
+            session_id="s1",
+            model="gpt-4",
+            provider="openai",
+            status_code=500,
+            retryable=True,
+            error={"type": "ServerError", "message": "500"},
+        )
+        for exp in (exporter_a, exporter_b):
+            api = _span_by_name(exp.get_finished_spans(), "api.gpt-4")
+            assert api.status.status_code == StatusCode.ERROR
+
+
+class TestMetrics:
+    def _metrics(self, metric_reader):
+        data = metric_reader.get_metrics_data()
+        return {
+            m.name: m for rm in data.resource_metrics for sm in rm.scope_metrics for m in sm.metrics
+        }
+
+    def test_error_and_retry_metrics(self, inmemory_otel_with_metrics):
+        _, metric_reader, _ = inmemory_otel_with_metrics
+
+        on_api_request_error(
+            task_id="a1",
+            session_id="s1",
+            model="gpt-4",
+            provider="openai",
+            status_code=429,
+            retry_count=1,
+            retryable=True,
+            error={"type": "RateLimitError", "message": "429"},
+        )
+
+        metrics = self._metrics(metric_reader)
+        assert "hermes.api.error.count" in metrics
+        dp = list(metrics["hermes.api.error.count"].data.data_points)[0]
+        assert dp.value == 1
+        assert dp.attributes["error_type"] == "RateLimitError"
+        assert dp.attributes["status_class"] == "4xx"
+        assert dp.attributes["retryable"] == "true"
+
+        assert "hermes.retry.count" in metrics
+        rdp = list(metrics["hermes.retry.count"].data.data_points)[0]
+        assert rdp.value == 1
+
+    def test_non_retryable_does_not_count_retry(self, inmemory_otel_with_metrics):
+        _, metric_reader, _ = inmemory_otel_with_metrics
+
+        on_api_request_error(
+            task_id="a1",
+            session_id="s1",
+            model="gpt-4",
+            provider="openai",
+            status_code=400,
+            retryable=False,
+            error={"type": "BadRequest", "message": "400"},
+        )
+
+        metrics = self._metrics(metric_reader)
+        assert "hermes.api.error.count" in metrics
+        # No retry attempt was made → retry counter not emitted.
+        assert "hermes.retry.count" not in metrics
+
+
+class TestNetworkErrorNoStatusCode:
+    def test_status_class_network(self, inmemory_otel_with_metrics):
+        _, metric_reader, _ = inmemory_otel_with_metrics
+        on_api_request_error(
+            task_id="a1",
+            session_id="s1",
+            model="gpt-4",
+            provider="openai",
+            status_code=None,
+            retryable=True,
+            error={"type": "ConnectionError", "message": "connection refused"},
+        )
+        data = metric_reader.get_metrics_data()
+        metrics = {
+            m.name: m for rm in data.resource_metrics for sm in rm.scope_metrics for m in sm.metrics
+        }
+        dp = list(metrics["hermes.api.error.count"].data.data_points)[0]
+        assert dp.attributes["status_class"] == "network"

--- a/tests/unit/test_api_error_helpers.py
+++ b/tests/unit/test_api_error_helpers.py
@@ -1,0 +1,92 @@
+"""Unit tests for API-error/retry pure helpers and fail-open handler paths."""
+
+import pytest
+from hermes_otel.helpers import coerce_bool, http_status_class, to_optional_int
+
+
+class TestToOptionalInt:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (429, 429),
+            (500.0, 500),
+            ("503", 503),
+            ("  408 ", 408),
+            (None, None),
+            ("", None),
+            ("   ", None),
+            ("nope", None),
+            (True, None),  # bools are not status codes
+            (False, None),
+        ],
+    )
+    def test_parsing(self, value, expected):
+        assert to_optional_int(value) == expected
+
+
+class TestCoerceBool:
+    @pytest.mark.parametrize("value", [True, 1, "true", "True", "1", "yes", "on"])
+    def test_truthy(self, value):
+        assert coerce_bool(value) is True
+
+    @pytest.mark.parametrize("value", [False, 0, "false", "0", "no", "off"])
+    def test_falsey(self, value):
+        assert coerce_bool(value) is False
+
+    @pytest.mark.parametrize("value", [None, "maybe", "x"])
+    def test_undecidable_is_none(self, value):
+        assert coerce_bool(value) is None
+
+
+class TestHttpStatusClass:
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            (200, "2xx"),
+            (301, "3xx"),
+            (404, "4xx"),
+            (429, "4xx"),
+            (500, "5xx"),
+            (503, "5xx"),
+            (None, "network"),
+            (0, "network"),
+            ("", "network"),
+            ("not-a-code", "network"),
+            (999, "other"),
+            (42, "other"),
+        ],
+    )
+    def test_classes(self, code, expected):
+        assert http_status_class(code) == expected
+
+
+class TestHandlerFailOpen:
+    def test_noop_when_disabled(self):
+        from hermes_otel.hooks import on_api_request_error
+
+        # Tracer uninitialized (reset fixture) → is_enabled False → silent no-op.
+        on_api_request_error(
+            task_id="t1",
+            session_id="s1",
+            model="gpt-4",
+            error={"type": "RateLimitError", "message": "429"},
+            status_code=429,
+        )
+
+    def test_accepts_unknown_kwargs(self, inmemory_otel_setup):
+        from hermes_otel.hooks import on_api_request_error
+
+        # Forward-compat: additive payload fields must not break the handler.
+        on_api_request_error(
+            task_id="t1",
+            session_id="s1",
+            model="gpt-4",
+            provider="openai",
+            error={"type": "Timeout", "message": "deadline exceeded"},
+            status_code=None,
+            retry_count=2,
+            max_retries=5,
+            retryable=True,
+            future_field="ignored",
+            telemetry_schema_version="hermes.observer.v1",
+        )

--- a/tracer.py
+++ b/tracer.py
@@ -106,6 +106,8 @@ class HermesOTelPlugin:
         self._skill_inferred_counter = None
         self._subagent_count = None
         self._subagent_duration = None
+        self._api_error_count = None
+        self._retry_count = None
         # Sub-agent delegation registry. Maps a delegated child's session_id to
         # a record about the delegation span opened in the parent on
         # ``subagent_start`` — ``{"span", "context", "role", "parent_session_id"}``
@@ -419,6 +421,14 @@ class HermesOTelPlugin:
             unit="ms",
             description="Delegated sub-agent wall-clock duration",
         )
+        self._api_error_count = self._meter.create_counter(
+            "hermes.api.error.count",
+            description="Failed provider API requests by error type / status class",
+        )
+        self._retry_count = self._meter.create_counter(
+            "hermes.retry.count",
+            description="Provider API retry attempts",
+        )
 
     def _init_logs_pipeline(self, resource: "Resource", backends: List[_ResolvedBackend]) -> None:
         """Wire a :class:`LoggerProvider` + handler when ``capture_logs`` is on.
@@ -494,6 +504,12 @@ class HermesOTelPlugin:
         elif name == "subagent_duration":
             if self._subagent_duration is not None:
                 self._subagent_duration.record(value, attrs)
+        elif name == "api_error_count":
+            if self._api_error_count is not None:
+                self._api_error_count.add(1, attrs)
+        elif name == "retry_count":
+            if self._retry_count is not None:
+                self._retry_count.add(int(value), attrs)
 
     def start_span(
         self,

--- a/website/docs/reference/hooks.md
+++ b/website/docs/reference/hooks.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Hooks reference"
-description: "The ten Hermes lifecycle hooks this plugin subscribes to, and the span operation each performs."
+description: "The Hermes lifecycle hooks this plugin subscribes to, and the span operation each performs."
 ---
 
 # Hooks reference
 
-hermes-otel subscribes to ten Hermes lifecycle hooks. Six are "always available" on any Hermes version with plugin support. Four are newer (two session hooks and two sub-agent hooks) and are registered conditionally.
+hermes-otel subscribes to a set of Hermes lifecycle hooks. Six are "always available" on any Hermes version with plugin support. The rest are newer (the session hooks, the sub-agent delegation hooks, and `api_request_error`) and are registered conditionally — older Hermes builds simply register fewer.
 
 ## Always available
 
@@ -57,6 +57,18 @@ Fires when the HTTP response is parsed.
 - **Span op:** closes the `api.*` span
 - **Attributes set on end:** token counts (both conventions), `gen_ai.response.finish_reason`, `http.duration_ms`
 - **Metrics:** `hermes.tokens.*` counters, `hermes.api.duration` histogram
+
+### `api_request_error`
+
+Fires when a provider API request **fails** (rate limit, timeout, 5xx, network error) instead of returning a response. Registered conditionally (newer Hermes).
+
+- **Span op:** closes the in-flight `api.{model}` span (key `api:{task_id}`) as **ERROR** with a recorded `exception` event. Without this hook that span would be left to the orphan sweep and end `OK` — hiding the failure. If no in-flight span exists (error before `pre_api_request`, or already swept) a short-lived `api.error` span is created so the failure is still visible.
+- **Attributes set on end:** `error.type`, `http.response.status_code` + `gen_ai.response.status_code`, `hermes.retry.count`, `hermes.max_retries`, `hermes.retryable`, `llm.response.duration_ms`
+- **Span event:** `exception` (`exception.type`, `exception.message`, `exception.escaped`)
+- **Metrics:** `hermes.api.error.count{error_type, status_class, retryable}` counter; `hermes.retry.count` counter (incremented once per *retryable* failure)
+- **Side effect:** records the `error.type` on the session aggregator so `on_session_end` can stamp it on the turn's root span
+
+Only API-level failures become `ERROR`. Tool timeout/blocked outcomes deliberately stay `OK` (see [Limitations](/reference/limitations)) so they don't inflate error rates.
 
 ## Newer (session + sub-agent hooks)
 
@@ -112,7 +124,8 @@ pre_api_request          open  api.{model}       (child of llm)
 pre_tool_call            open  tool.{name}       (child of api or llm)
 subagent_start           open  subagent.{role}   (child of api or llm)
 post_tool_call           close tool.{name}
-post_api_request         close api.{model}
+post_api_request         close api.{model}        (OK)
+api_request_error        close api.{model}        (ERROR + exception + retry attrs/metrics)
 post_llm_call            close llm.{model}
 subagent_stop            close subagent.{role}   + status + duration + metrics
 on_session_end           close agent/cron        + turn summary + force-flush

--- a/website/docs/reference/limitations.md
+++ b/website/docs/reference/limitations.md
@@ -47,6 +47,21 @@ Delegated child agents (`delegate_task`) are modeled as `subagent.*` spans, and 
 
 If a future Hermes version runs delegated children **in a separate process**, that registry won't hold the live span. The plugin then degrades gracefully: the child root attaches an OTel **span link** to the delegation span's `SpanContext` (when available) and is tagged with `hermes.subagent.parent_session_id` for correlation — but the child becomes its own trace rather than nesting in the parent. True cross-process trace-context *propagation* (injecting the parent context into the child process) is out of scope for now; open an issue if you need it.
 
+## API error capture depends on the `api_request_error` hook
+
+Failed provider API requests (rate limits, timeouts, 5xx, network errors) are
+now captured: the `api.{model}` span ends `ERROR` with a recorded exception and
+retry metadata, via the `api_request_error` hook. On older Hermes builds that
+don't fire that hook, a failed request's span is instead finalized by the
+[orphan sweep](/architecture/orphan-sweep) on the next turn and ends `OK` — so
+on those builds failures remain invisible until you upgrade Hermes.
+
+A hard crash *before* the error hook fires (or before the next sweep) can still
+lose the in-flight span, the same buffered-span trade-off described above.
+
+Note the deliberate asymmetry: only API-level failures map to `ERROR`. Tool
+`timeout`/`blocked` outcomes stay `OK` so they don't inflate error rates.
+
 ## Sampling is head-based only
 
 `ParentBased(TraceIdRatioBased(rate))` makes the sampling decision at the **root**. There's no tail-based sampler that boosts on error or keeps all traces above a duration threshold.

--- a/website/docs/reference/span-attributes.md
+++ b/website/docs/reference/span-attributes.md
@@ -89,6 +89,24 @@ Span kind: `LLM` (OpenInference).
 | `gen_ai.response.finish_reason` | gen_ai | string | `stop`, `tool_use`, `length`, etc. |
 | `http.duration_ms` | hermes | int | Wall-clock HTTP duration |
 
+### `api.*` on failure (`api_request_error`)
+
+When the request fails, the span ends with `StatusCode.ERROR`, an `exception`
+event (`exception.type` / `exception.message` / `exception.escaped`), and:
+
+| Attribute | Convention | Type | Meaning |
+|---|---|---|---|
+| `error.type` | OTel | string | Error class reported by Hermes (e.g. `RateLimitError`) |
+| `http.response.status_code` | OTel | int | HTTP status (omitted for network errors) |
+| `gen_ai.response.status_code` | gen_ai | int | Same value, gen_ai spelling |
+| `hermes.retry.count` | hermes | int | Retries attempted so far for this request |
+| `hermes.max_retries` | hermes | int | Configured retry ceiling |
+| `hermes.retryable` | hermes | bool | Whether the error is retryable |
+| `llm.response.duration_ms` | hermes | float | Wall-clock of the failed attempt |
+
+The most recent `error.type` is also stamped on the turn's root `agent` span at
+`on_session_end`.
+
 ## `tool.*`
 
 Span kind: `TOOL` (OpenInference).
@@ -141,5 +159,11 @@ Emitted via `PeriodicExportingMetricReader` on backends that support OTLP metric
 | `hermes.sessions` | Counter | count | `kind`, `final_status` |
 | `hermes.subagent.count` | Counter | count | `role`, `status` |
 | `hermes.subagent.duration` | Histogram | ms | `role` |
+| `hermes.api.error.count` | Counter | count | `error_type`, `status_class`, `retryable`, `model`, `provider` |
+| `hermes.retry.count` | Counter | count | `model`, `provider` |
+
+`status_class` is bucketed to `2xx`/`3xx`/`4xx`/`5xx`/`network`/`other` to keep
+cardinality bounded. `hermes.retry.count` increments once per *retryable*
+failure.
 
 Label cardinality is bounded by normalised values (outcomes, finish reasons) and small dimension sets (model, tool name). No user IDs or other high-cardinality labels.


### PR DESCRIPTION
Closes #28

## API error & retry telemetry

Consume the `api_request_error` hook so failed provider API requests are recorded instead of silently disappearing. Previously the `api.{model}` span opened by `on_pre_api_request` was only ever closed by `on_post_api_request` (success) — on failure it was left open and either ended `OK` via the orphan sweep or (in a oneshot) was never exported at all. Every rate-limit, timeout, and 5xx was invisible.

### What changed
- **`api_request_error` handler** closes the in-flight `api.{model}` span as **ERROR** with an `exception` event and retry metadata: `error.type`, `http.response.status_code` + `gen_ai.response.status_code`, `hermes.retry.count`, `hermes.max_retries`, `hermes.retryable`, `llm.response.duration_ms`.
- **Fallback `api.error` span** when there's no in-flight span (error before `pre_api_request`, or already swept) — the failure stays visible. Fails open.
- **Root propagation:** the last `error.type` is stamped on the turn's root `agent` span at `on_session_end`.
- **Metrics:** `hermes.api.error.count{error_type, status_class, retryable, model, provider}` and `hermes.retry.count` (incremented once per *retryable* failure) — the latter was specced in `docs/PRD_metrics.md` but blocked on this hook until now.
- New pure helpers (`http_status_class`, `coerce_bool`, `to_optional_int`); registered forward-compatibly in `__init__.py` + `plugin.yaml`.
- Only API-level failures become `ERROR`; tool `timeout`/`blocked` outcomes still map to `OK`.

### Tests
33 new unit + integration tests (ERROR status + recorded exception, status-class/retryable/int helpers, fallback span, retry-then-success, fatal-error root propagation, fan-out, network-vs-http class, metrics). Full suite: **536 passing, 89.5% coverage**.

### Verified end-to-end in Phoenix
Forced an API failure (unreachable `base_url`) and ran the same prompt on `main` vs this branch:

| | Before (`main`) | After |
|---|---|---|
| Spans exported on API failure | **0** (no trace — failure invisible) | **6**, all `ERROR` |
| Exception event | — | ✓ `exception` |
| Error attributes | — | `error.type=APIConnectionError`, `hermes.retryable=true`, retry count, duration |

### Docs
Updated hooks reference, span-attributes (error attrs + exception event + the two new metrics), limitations, README, and marked `hermes.retry.count` implemented in `docs/PRD_metrics.md`. Docusaurus build passes.

---
Implemented using the new committed `hermes-otel-pr` workflow skill.
