### PR TITLE
feat(usage): capture reasoning output tokens (gen_ai.usage.reasoning.output_tokens)

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,9 @@ The plugin emits **dual-convention** attributes so both backends work:
 | Total tokens | `gen_ai.usage.total_tokens` | `llm.token_count.total` |
 | Cache read | `gen_ai.usage.cache_read.input_tokens` (`gen_ai.usage.cache_read_input_tokens` also kept) | `llm.token_count.prompt_details.cache_read` |
 | Cache write | `gen_ai.usage.cache_creation.input_tokens` (`gen_ai.usage.cache_creation_input_tokens` also kept) | `llm.token_count.prompt_details.cache_write` |
+| Reasoning | `gen_ai.usage.reasoning.output_tokens` | `llm.token_count.completion_details.reasoning` |
+
+Reasoning ("thinking") tokens are emitted only by reasoning-capable models that report them. They are a **subset of the completion/output count** — already included in the completion and total figures — and are surfaced separately for visibility, so they should not be added on top of the total.
 
 LLM and API spans also expose standard GenAI request/response metadata where Hermes provides it, including `gen_ai.provider.name`, `gen_ai.request.model`, request parameters such as `gen_ai.request.temperature`, and response fields such as `gen_ai.response.model` and `gen_ai.response.finish_reasons`.
 

--- a/hooks.py
+++ b/hooks.py
@@ -126,6 +126,7 @@ _USAGE_FIELDS = (
     "total_tokens",
     "cache_read_tokens",
     "cache_write_tokens",
+    "reasoning_tokens",
 )
 
 
@@ -134,8 +135,10 @@ def _normalize_usage(usage: dict) -> Dict[str, int]:
 
     Hermes exposes ``output_tokens``; some providers use ``completion_tokens``.
     Similarly ``input_tokens`` vs ``prompt_tokens``. Total is derived from
-    the reported value or sum(prompt, completion) when absent. Returns all
-    five canonical fields, zero-filled.
+    the reported value or sum(prompt, completion) when absent. ``reasoning_tokens``
+    is a *subset* of ``completion_tokens`` (the thinking portion of the output),
+    not an additive bucket, so it is never folded into ``total_tokens``. Returns
+    all canonical fields, zero-filled.
     """
     completion = _to_int(usage.get("output_tokens") or usage.get("completion_tokens", 0))
     prompt = _to_int(usage.get("prompt_tokens") or usage.get("input_tokens", 0))
@@ -146,6 +149,7 @@ def _normalize_usage(usage: dict) -> Dict[str, int]:
         "total_tokens": total,
         "cache_read_tokens": _to_int(usage.get("cache_read_tokens")),
         "cache_write_tokens": _to_int(usage.get("cache_write_tokens")),
+        "reasoning_tokens": _to_int(usage.get("reasoning_tokens")),
     }
 
 
@@ -162,6 +166,7 @@ def _usage_attributes(totals: Dict[str, int]) -> Dict[str, Any]:
     total = totals["total_tokens"]
     cache_read = totals["cache_read_tokens"]
     cache_write = totals["cache_write_tokens"]
+    reasoning = totals.get("reasoning_tokens", 0)
 
     attrs: Dict[str, Any] = {
         # OpenInference (Phoenix)
@@ -183,6 +188,13 @@ def _usage_attributes(totals: Dict[str, int]) -> Dict[str, Any]:
         attrs["llm.token_count.prompt_details.cache_write"] = cache_write
         attrs["gen_ai.usage.cache_creation.input_tokens"] = cache_write
         attrs["gen_ai.usage.cache_creation_input_tokens"] = cache_write
+    if reasoning:
+        # Reasoning ("thinking") tokens are a subset of the output/completion
+        # count, surfaced as a breakdown. OpenInference (Phoenix) reads
+        # ``completion_details.reasoning``; OTel GenAI uses
+        # ``gen_ai.usage.reasoning.output_tokens``.
+        attrs["llm.token_count.completion_details.reasoning"] = reasoning
+        attrs["gen_ai.usage.reasoning.output_tokens"] = reasoning
     return attrs
 
 
@@ -191,6 +203,7 @@ _USAGE_METRIC_LABELS = (
     ("completion_tokens", "output"),
     ("cache_read_tokens", "cacheRead"),
     ("cache_write_tokens", "cacheCreation"),
+    ("reasoning_tokens", "reasoning"),
 )
 
 

--- a/session_state.py
+++ b/session_state.py
@@ -71,6 +71,7 @@ def _empty_usage() -> Dict[str, int]:
         "total_tokens": 0,
         "cache_read_tokens": 0,
         "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
     }
 
 

--- a/tests/integration/test_inmemory_pipeline.py
+++ b/tests/integration/test_inmemory_pipeline.py
@@ -139,6 +139,57 @@ class TestApiSpanExport:
         assert attrs["llm.token_count.completion"] == 50
         assert attrs["gen_ai.usage.output_tokens"] == 50
 
+    def test_api_span_exports_reasoning_tokens(self, inmemory_otel_setup):
+        exporter, plugin = inmemory_otel_setup
+
+        on_pre_api_request(
+            task_id="t1",
+            session_id="s1",
+            platform="cli",
+            model="o3",
+            provider="openai",
+            base_url="",
+            api_mode="chat",
+            api_call_count=1,
+            message_count=5,
+            tool_count=0,
+            approx_input_tokens=500,
+            request_char_count=2000,
+            max_tokens=1024,
+        )
+        on_post_api_request(
+            task_id="t1",
+            session_id="s1",
+            platform="cli",
+            model="o3",
+            provider="openai",
+            base_url="",
+            api_mode="chat",
+            api_call_count=1,
+            api_duration=0.5,
+            finish_reason="stop",
+            message_count=5,
+            response_model="o3",
+            # reasoning_tokens is a subset of output_tokens (the thinking portion).
+            usage={
+                "prompt_tokens": 100,
+                "output_tokens": 80,
+                "total_tokens": 180,
+                "reasoning_tokens": 60,
+            },
+            assistant_content_chars=200,
+            assistant_tool_call_count=0,
+        )
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        attrs = dict(spans[0].attributes)
+        assert attrs["llm.token_count.completion_details.reasoning"] == 60
+        assert attrs["gen_ai.usage.reasoning.output_tokens"] == 60
+        # Total stays input + output; reasoning is not double-counted.
+        assert attrs["gen_ai.usage.total_tokens"] == 180
+        assert attrs["gen_ai.usage.output_tokens"] == 80
+
 
 class TestSessionSpanExport:
     def test_session_span_exports(self, inmemory_otel_setup):

--- a/tests/integration/test_metrics_pipeline.py
+++ b/tests/integration/test_metrics_pipeline.py
@@ -93,6 +93,55 @@ class TestTokenUsageMetric:
         # 100 (input) + 50 (output) = 150
         assert value == 150
 
+    def test_reasoning_token_type_recorded(self, inmemory_otel_with_metrics):
+        _, metric_reader, _ = inmemory_otel_with_metrics
+
+        on_pre_api_request(
+            task_id="t1",
+            session_id="s1",
+            platform="cli",
+            model="o3",
+            provider="openai",
+            base_url="",
+            api_mode="chat",
+            api_call_count=1,
+            message_count=5,
+            tool_count=0,
+            approx_input_tokens=500,
+            request_char_count=2000,
+            max_tokens=1024,
+        )
+        on_post_api_request(
+            task_id="t1",
+            session_id="s1",
+            platform="cli",
+            model="o3",
+            provider="openai",
+            base_url="",
+            api_mode="chat",
+            api_call_count=1,
+            api_duration=0.5,
+            finish_reason="stop",
+            message_count=5,
+            response_model="o3",
+            usage={
+                "prompt_tokens": 100,
+                "output_tokens": 80,
+                "total_tokens": 180,
+                "reasoning_tokens": 60,
+            },
+            assistant_content_chars=200,
+            assistant_tool_call_count=0,
+        )
+
+        metric = _get_metric(metric_reader, "hermes.token.usage")
+        assert metric is not None
+        reasoning_points = [
+            dp for dp in metric.data.data_points if dp.attributes.get("token_type") == "reasoning"
+        ]
+        assert len(reasoning_points) == 1
+        assert reasoning_points[0].value == 60
+
 
 class TestToolDurationMetric:
     def test_tool_duration_recorded(self, inmemory_otel_with_metrics):

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -148,6 +148,7 @@ class TestOnSessionEnd:
                 "total_tokens": 150,
                 "cache_read_tokens": 20,
                 "cache_write_tokens": 10,
+                "reasoning_tokens": 15,
             }
         )
         ps.usage_updated = True
@@ -161,6 +162,9 @@ class TestOnSessionEnd:
         assert attrs["gen_ai.usage.output_tokens"] == 50
         assert attrs["llm.token_count.prompt_details.cache_read"] == 20
         assert attrs["gen_ai.usage.cache_creation_input_tokens"] == 10
+        # Reasoning tokens roll up to the session span (subset of output).
+        assert attrs["llm.token_count.completion_details.reasoning"] == 15
+        assert attrs["gen_ai.usage.reasoning.output_tokens"] == 15
         # Verify cleanup — PerSession popped from registry.
         assert mock_tracer.sessions.peek("s1") is None
 

--- a/tests/unit/test_hooks_helpers.py
+++ b/tests/unit/test_hooks_helpers.py
@@ -2,7 +2,12 @@
 
 import pytest
 from hermes_otel.helpers import truncate_string
-from hermes_otel.hooks import _detect_session_kind, _to_int
+from hermes_otel.hooks import (
+    _detect_session_kind,
+    _normalize_usage,
+    _to_int,
+    _usage_attributes,
+)
 
 
 class TestTruncateString:
@@ -116,3 +121,66 @@ class TestDetectSessionKind:
     def test_session_type_takes_priority(self):
         # session_type wins even when job_id is also present
         assert _detect_session_kind("cron", {"session_type": "manual", "job_id": "j1"}) == "manual"
+
+
+class TestNormalizeUsageReasoning:
+    def test_reasoning_tokens_parsed(self):
+        totals = _normalize_usage(
+            {"input_tokens": 100, "output_tokens": 50, "reasoning_tokens": 15}
+        )
+        assert totals["reasoning_tokens"] == 15
+
+    def test_reasoning_absent_defaults_zero(self):
+        totals = _normalize_usage({"input_tokens": 100, "output_tokens": 50})
+        assert totals["reasoning_tokens"] == 0
+
+    def test_reasoning_not_added_to_total(self):
+        # Reasoning is a subset of output, so it must never inflate the total.
+        totals = _normalize_usage(
+            {"input_tokens": 100, "output_tokens": 50, "reasoning_tokens": 30}
+        )
+        assert totals["total_tokens"] == 150  # 100 + 50, reasoning excluded
+
+
+class TestUsageAttributesReasoning:
+    def test_reasoning_dual_convention_attributes(self):
+        attrs = _usage_attributes(
+            {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "total_tokens": 150,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 15,
+            }
+        )
+        # OpenInference (Phoenix) + OTel GenAI (Langfuse) spellings.
+        assert attrs["llm.token_count.completion_details.reasoning"] == 15
+        assert attrs["gen_ai.usage.reasoning.output_tokens"] == 15
+
+    def test_zero_reasoning_omitted(self):
+        attrs = _usage_attributes(
+            {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "total_tokens": 150,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+            }
+        )
+        assert "llm.token_count.completion_details.reasoning" not in attrs
+        assert "gen_ai.usage.reasoning.output_tokens" not in attrs
+
+    def test_missing_reasoning_key_tolerated(self):
+        # _usage_attributes uses .get for reasoning so older totals dicts work.
+        attrs = _usage_attributes(
+            {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "total_tokens": 150,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+            }
+        )
+        assert "gen_ai.usage.reasoning.output_tokens" not in attrs

--- a/website/docs/architecture/attributes.md
+++ b/website/docs/architecture/attributes.md
@@ -19,8 +19,9 @@ hermes-otel emits **both** conventions on the same span so whichever backend rea
 | Total tokens | — | `llm.token_count.total` |
 | Cache read | `gen_ai.usage.cache_read_input_tokens` | `llm.token_count.cache_read` |
 | Cache write | `gen_ai.usage.cache_creation_input_tokens` | `llm.token_count.cache_write` |
+| Reasoning | `gen_ai.usage.reasoning.output_tokens` | `llm.token_count.completion_details.reasoning` |
 
-Phoenix adds a `total` variant that's the sum; gen_ai doesn't. Cache read/write are only populated when the provider reports them (Anthropic's prompt caching, OpenAI's — both surface them in their API responses).
+Phoenix adds a `total` variant that's the sum; gen_ai doesn't. Cache read/write are only populated when the provider reports them (Anthropic's prompt caching, OpenAI's — both surface them in their API responses). Reasoning tokens are emitted only by reasoning-capable models and are a **subset of completion/output tokens** (already counted in the completion and total figures), surfaced separately for visibility — don't add them on top of the total.
 
 ## Message content (on `llm.*` spans)
 

--- a/website/docs/reference/span-attributes.md
+++ b/website/docs/reference/span-attributes.md
@@ -81,10 +81,12 @@ Span kind: `LLM` (OpenInference).
 | `llm.token_count.total` | OpenInference | int | Sum |
 | `llm.token_count.cache_read` | OpenInference | int | Cache read (optional) |
 | `llm.token_count.cache_write` | OpenInference | int | Cache write (optional) |
+| `llm.token_count.completion_details.reasoning` | OpenInference | int | Reasoning/thinking tokens — a subset of completion (optional) |
 | `gen_ai.usage.input_tokens` | gen_ai | int | Prompt tokens |
 | `gen_ai.usage.output_tokens` | gen_ai | int | Completion tokens |
 | `gen_ai.usage.cache_read_input_tokens` | gen_ai | int | Cache read (optional) |
 | `gen_ai.usage.cache_creation_input_tokens` | gen_ai | int | Cache write (optional) |
+| `gen_ai.usage.reasoning.output_tokens` | gen_ai | int | Reasoning/thinking tokens — a subset of output (optional) |
 | `llm.invocation_parameters` | OpenInference | string (JSON) | Request params |
 | `gen_ai.response.finish_reason` | gen_ai | string | `stop`, `tool_use`, `length`, etc. |
 | `http.duration_ms` | hermes | int | Wall-clock HTTP duration |
@@ -152,6 +154,7 @@ Emitted via `PeriodicExportingMetricReader` on backends that support OTLP metric
 | `hermes.tokens.total` | Counter | tokens | `model`, `provider` |
 | `hermes.tokens.cache_read` | Counter | tokens | `model`, `provider` |
 | `hermes.tokens.cache_write` | Counter | tokens | `model`, `provider` |
+| `hermes.tokens.reasoning` | Counter | tokens | `model`, `provider` |
 | `hermes.tool.calls` | Counter | count | `tool_name`, `outcome` |
 | `hermes.tool.duration` | Histogram | ms | `tool_name`, `outcome` |
 | `hermes.api.duration` | Histogram | ms | `model`, `provider`, `finish_reason` |
@@ -165,5 +168,12 @@ Emitted via `PeriodicExportingMetricReader` on backends that support OTLP metric
 `status_class` is bucketed to `2xx`/`3xx`/`4xx`/`5xx`/`network`/`other` to keep
 cardinality bounded. `hermes.retry.count` increments once per *retryable*
 failure.
+
+`hermes.tokens.reasoning` (token_type `reasoning`) counts the model's
+thinking tokens. These are a **subset of completion/output tokens**, not an
+additive bucket — they are reported separately for visibility but are already
+included in `hermes.tokens.completion` and `total_tokens`, so do not sum
+reasoning into the total. Only emitted by reasoning-capable models that report
+a non-zero count.
 
 Label cardinality is bounded by normalised values (outcomes, finish reasons) and small dimension sets (model, tool name). No user IDs or other high-cardinality labels.


### PR DESCRIPTION
Closes #40

## Summary

Capture **reasoning ("thinking") output tokens** from reasoning-capable models and emit them as dual-convention span attributes, rolled into the session token total and the token-usage metric.

### Investigation result (the issue's gating step)
Hermes **does** expose the count. The `usage` dict passed to `post_api_request` is `asdict(normalize_usage(...))` over `CanonicalUsage`, which includes a `reasoning_tokens` field (`agent/usage_pricing.py`). The CLI labels it **"Reasoning (subset)"** (`cli.py`), confirming it is a *subset of `output_tokens`*, not an additive bucket.

## Changes
- `_normalize_usage` now parses `reasoning_tokens`; `_USAGE_FIELDS` + `_empty_usage()` include it, so it rolls up to the session span automatically.
- `_usage_attributes` emits (only when non-zero):
  - `gen_ai.usage.reasoning.output_tokens` — OTel GenAI
  - `llm.token_count.completion_details.reasoning` — OpenInference (Phoenix)
- `token_usage` metric gains a `token_type=reasoning` data point.
- **Not double-counted:** reasoning is a subset of output, so it is never added into `total_tokens`. Mirrors how cache tokens (subsets of prompt) are already handled.

## Tests
- Unit (`test_hooks_helpers.py`): `_normalize_usage` parses/defaults/excludes-from-total; `_usage_attributes` dual-convention emit, zero-omitted, missing-key tolerated.
- Unit (`test_hooks_callbacks.py`): session roll-up includes reasoning on `on_session_end`.
- Integration (`test_inmemory_pipeline.py`): API span exports both reasoning attributes; total stays input+output.
- Integration (`test_metrics_pipeline.py`): `token_type=reasoning` metric data point recorded.

## Checks (run locally, matching CI)
- `ruff check .` — pass
- `black --check .` — pass
- `pytest --cov=hermes_otel --cov-fail-under=85` — **544 passed, 3 skipped**, coverage **89.52%**
- `website` docs build — clean (`[SUCCESS]`)

## Docs
Updated the token-attribute mapping tables in `README.md`, `website/docs/architecture/attributes.md`, and `website/docs/reference/span-attributes.md` (attributes + `hermes.tokens.reasoning` metric row), each noting the subset/no-double-count semantics.

## Upstream dependency (hermes-agent)

This plugin emits the reasoning attributes whenever the host passes a non-zero `reasoning_tokens`. Today hermes-agent's `normalize_usage` (`agent/usage_pricing.py`) reads reasoning **only** from `output_tokens_details.reasoning_tokens` (OpenAI *Responses API* shape). Chat-completions providers (OpenAI, OpenRouter, Groq) report it under `completion_tokens_details.reasoning_tokens`, so on an unpatched host this attribute stays `0` for those providers.

The upstream gap is already tracked and fixed-in-review — no new issue/PR needed:
- Issue: NousResearch/hermes-agent#18466
- Fix PRs: NousResearch/hermes-agent#18484 (and parallel NousResearch/hermes-agent#52728)

Once one of those merges, reasoning tokens flow for chat-completions models. **Live-validated** against `nvidia/nemotron-3-ultra-550b-a55b:free` (OpenRouter) with that fix applied locally: `gen_ai.usage.reasoning.output_tokens = 34` landed in Phoenix on both the `api.*` and `agent` spans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

