### PR TITLE
feat(metrics): emit OTel-standard GenAI metrics (gen_ai.client.*/gen_ai.agent.*) alongside hermes.*

### DIFF
--- a/config.yaml.bak.pre-metrics
+++ b/config.yaml.bak.pre-metrics
@@ -1,0 +1,69 @@
+# Local hermes-otel config (gitignored — see config.yaml.example for the
+# full template and the docs above every option).
+#
+# TRIAL SETUP for PR #15 (per-category preview truncation limits).
+# Single backend: Phoenix running in the k3s cluster, reached over NodePort.
+# Local lgtm/signoz/openobserve peers are disabled below so dead localhost
+# endpoints don't spam connection-refused export errors during the trial.
+
+project_name: hermes-pr15-trial
+
+# Only one backend is enabled, but pin it explicitly so the dashboard
+# queries Phoenix.
+query_backend: phoenix
+
+# Put the full message list on the llm span's input.value so the UI shows
+# every message the model saw — the api.* spans don't carry this.
+capture_conversation_history: true
+conversation_history_max_chars: 1000000
+
+# Ship Python logs (every log fired inside a span carries the span's
+# trace_id/span_id). Phoenix doesn't implement /v1/logs, so this is a no-op
+# for the Phoenix backend, but harmless to leave on.
+capture_logs: true
+log_level: DEBUG
+
+# Full-fidelity capture on the api.{model} span — bypasses preview limits so
+# the ENTIRE prompt (incl. system prompt) and ENTIRE response land on the
+# span. Privacy-heavy; enabled here because you asked for no cutoffs. Set
+# both to false to dial back.
+capture_full_prompts: true
+capture_full_responses: true
+
+capture_sender_id: true
+
+# ── Preview truncation limits (PR #15) ──────────────────────────────────────
+# preview_max_chars is the global fallback; the four per-category fields
+# override it for their span type. All set very high (1,000,000 chars) so
+# tool/LLM input and output are effectively never truncated.
+#
+# NOTE: do NOT use 0 to mean "unlimited" — clip_preview() treats max_chars<=0
+# as "suppress the attribute entirely". Use a large number for no-limit.
+preview_max_chars: 1000000
+tool_input_preview_max_chars: 1000000
+tool_output_preview_max_chars: 1000000
+llm_input_preview_max_chars: 1000000
+llm_output_preview_max_chars: 1000000
+capture_previews: true
+
+backends:
+
+  - type: phoenix
+    # k3s 'observability/phoenix' NodePort service: container port 6006
+    # (UI + OTLP/HTTP) -> nodePort 30606. Node a3 InternalIP = 192.168.5.173.
+    # Reachable from this Mac (verified: GET / -> 200, POST /v1/traces -> 200).
+    endpoint: http://192.168.5.173:30606/v1/traces
+    # Phoenix only ingests traces — /v1/metrics and /v1/logs return 405, so
+    # disable metrics export (logs already default off for phoenix) to avoid
+    # periodic export errors.
+    metrics: false
+
+  # ── Disabled local peers (were pointing at localhost, likely down) ──
+  # - type: lgtm
+  #     endpoint: http://localhost:4318/v1/traces
+  # - type: signoz
+  #     endpoint: http://localhost:4328/v1/traces
+  # - type: openobserve
+  #     endpoint: http://localhost:5080/api/default/v1/traces
+  #     user: root@example.com
+  #     password: Complexpass#123

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -97,6 +97,19 @@
 # hermes-agent's own logs; any logger name to scope further.
 # log_attach_logger: null
 
+# ── OTel GenAI semantic-convention metrics ────────────────────────────────────
+#
+# In addition to the custom hermes.* metrics, the plugin emits spec-named
+# instruments so generic OpenTelemetry GenAI dashboards/alerts light up with
+# no per-user wiring:
+#   gen_ai.client.token.usage      Histogram {token}  (gen_ai.token.type input/output)
+#   gen_ai.client.operation.duration  Histogram s     (SECONDS, per spec)
+#   gen_ai.agent.token.usage       Histogram {token}  (per-turn/session rollup)
+# Dimensions stay low-cardinality (operation, provider, model — never per-call
+# IDs). Set false to emit only the hermes.* metrics.
+# Also settable via HERMES_OTEL_EMIT_GENAI_METRICS.
+# emit_genai_metrics: true
+
 # ── Lifecycle / cleanup ───────────────────────────────────────────────────────
 
 # Orphan-turn sweep TTL. If a session's root span has been open longer than

--- a/hooks.py
+++ b/hooks.py
@@ -644,14 +644,15 @@ def on_session_end(
     if ps is not None and ps.usage_updated:
         attributes.update(_usage_attributes(ps.usage))
         # OTel GenAI agent-level token-usage histogram (per-turn/session rollup).
+        # Prefer the provider captured from this session's API calls over the
+        # platform, so the dimension matches the gen_ai.client.* metrics.
         if tracer.config.emit_genai_metrics:
+            agent_provider = ps.provider or kwargs.get("provider") or platform
             _record_genai_token_usage(
                 tracer,
                 "gen_ai.agent.token.usage",
                 ps.usage,
-                _genai_metric_dims(
-                    model, kwargs.get("provider") or platform, model, operation="invoke_agent"
-                ),
+                _genai_metric_dims(model, agent_provider, model, operation="invoke_agent"),
             )
 
     # Surface the last API error's type on the root so a failed turn shows why.
@@ -1146,6 +1147,10 @@ def on_post_api_request(
             for field in _USAGE_FIELDS:
                 ps.usage[field] += totals[field]
             ps.usage_updated = True
+            # Remember the real LLM provider — on_session_end only sees the
+            # platform, so the agent-level metric would otherwise mislabel it.
+            if provider:
+                ps.provider = provider
 
         # Record metrics
         metric_attrs: Dict[str, Any] = {"model": model, "provider": provider}

--- a/hooks.py
+++ b/hooks.py
@@ -215,6 +215,48 @@ def _record_usage_metrics(tracer, totals: Dict[str, int], base_attrs: Dict[str, 
             tracer.record_metric("token_usage", v, {**base_attrs, "token_type": label})
 
 
+def _genai_metric_dims(
+    model: Any,
+    provider: Any,
+    response_model: Any = None,
+    operation: str = "chat",
+) -> Dict[str, Any]:
+    """Low-cardinality dimension set for the OTel GenAI spec metrics.
+
+    Only stable, bounded dimensions (operation, provider, model names) — never
+    per-call IDs like session_id — so the spec metrics stay aggregatable and
+    match generic OTel-GenAI dashboards.
+    """
+    dims: Dict[str, Any] = {"gen_ai.operation.name": operation}
+    prov = truncate_string(provider, 120)
+    if prov:
+        dims["gen_ai.provider.name"] = prov
+    if model:
+        dims["gen_ai.request.model"] = truncate_string(model, 200)
+    if response_model:
+        dims["gen_ai.response.model"] = truncate_string(response_model, 200)
+    return dims
+
+
+# Canonical-field -> OTel GenAI token.type value. The spec enumerates only
+# ``input`` and ``output``; cache/reasoning buckets are subsets already counted
+# in those, so they are intentionally not split into the spec metric.
+_GENAI_TOKEN_TYPES = (
+    ("prompt_tokens", "input"),
+    ("completion_tokens", "output"),
+)
+
+
+def _record_genai_token_usage(
+    tracer, metric_name: str, totals: Dict[str, int], dims: Dict[str, Any]
+) -> None:
+    """Record a GenAI-spec token-usage histogram point per non-zero type."""
+    for key, token_type in _GENAI_TOKEN_TYPES:
+        v = totals.get(key, 0)
+        if v:
+            tracer.record_metric(metric_name, v, {**dims, "gen_ai.token.type": token_type})
+
+
 def _detect_session_kind(platform: str, kwargs: dict) -> str:
     """Determine session type from explicit fields or fallback to detection."""
     session_type = kwargs.get("session_type")
@@ -601,6 +643,16 @@ def on_session_end(
 
     if ps is not None and ps.usage_updated:
         attributes.update(_usage_attributes(ps.usage))
+        # OTel GenAI agent-level token-usage histogram (per-turn/session rollup).
+        if tracer.config.emit_genai_metrics:
+            _record_genai_token_usage(
+                tracer,
+                "gen_ai.agent.token.usage",
+                ps.usage,
+                _genai_metric_dims(
+                    model, kwargs.get("provider") or platform, model, operation="invoke_agent"
+                ),
+            )
 
     # Surface the last API error's type on the root so a failed turn shows why.
     if ps is not None and ps.last_error_type:
@@ -1101,6 +1153,15 @@ def on_post_api_request(
             metric_attrs["session_id"] = session_id
         _record_usage_metrics(tracer, totals, metric_attrs)
 
+        # OTel GenAI spec token-usage histogram (dual-write; low cardinality).
+        if tracer.config.emit_genai_metrics:
+            _record_genai_token_usage(
+                tracer,
+                "gen_ai.client.token.usage",
+                totals,
+                _genai_metric_dims(model, provider, response_model_value),
+            )
+
         cost = usage.get("cost")
         if cost:
             try:
@@ -1113,6 +1174,14 @@ def on_post_api_request(
     # Performance metrics
     if api_duration:
         attributes["llm.response.duration_ms"] = round(api_duration * 1000, 1)
+        # OTel GenAI spec operation-duration histogram — in SECONDS (the spec
+        # unit), unlike the ms hermes.* histograms.
+        if tracer.config.emit_genai_metrics:
+            tracer.record_metric(
+                "gen_ai.client.operation.duration",
+                api_duration,
+                _genai_metric_dims(model, provider, response_model_value),
+            )
     if finish_reason:
         attributes["llm.response.finish_reason"] = finish_reason
         attributes["gen_ai.response.finish_reasons"] = [finish_reason]
@@ -1284,6 +1353,13 @@ def on_api_request_error(
         if provider:
             retry_attrs["provider"] = provider
         tracer.record_metric("retry_count", 1, retry_attrs)
+
+    # OTel GenAI spec operation-duration on the failure path, tagged with
+    # error.type so success/error durations are queryable from one histogram.
+    if api_duration and tracer.config.emit_genai_metrics:
+        duration_dims = _genai_metric_dims(model, provider)
+        duration_dims["error.type"] = error_type or "unknown"
+        tracer.record_metric("gen_ai.client.operation.duration", api_duration, duration_dims)
 
     debug_log(f"  API error span ended: key={key}, error.type={error_type}, class={status_class}")
 

--- a/plugin_config.py
+++ b/plugin_config.py
@@ -130,6 +130,11 @@ class HermesOtelConfig:
     # None = attach to the root logger (captures all hermes-agent + plugin
     # logs). Set to e.g. "hermes_otel" to scope capture to plugin logs only.
     log_attach_logger: Optional[str] = None
+    # ── OTel GenAI semantic-convention metrics ──────────────────────────
+    # Emit spec-named instruments (gen_ai.client.*, gen_ai.agent.*) in
+    # addition to the custom hermes.* metrics, so generic OTel-GenAI
+    # dashboards/alerts work out of the box. Set false for hermes.* only.
+    emit_genai_metrics: bool = True
     # ── Multi-backend fan-out ───────────────────────────────────────────
     backends: Optional[Tuple[BackendConfig, ...]] = None
 
@@ -271,6 +276,7 @@ def _coerce_from_yaml(key: str, value: Any) -> Any:
         "capture_full_prompts",
         "capture_full_responses",
         "capture_sender_id",
+        "emit_genai_metrics",
     ):
         if isinstance(value, bool):
             return value
@@ -352,6 +358,7 @@ def _load_env_overrides() -> Dict[str, Any]:
     take("capture_full_prompts", _parse_bool)
     take("capture_full_responses", _parse_bool)
     take("capture_sender_id", _parse_bool)
+    take("emit_genai_metrics", _parse_bool)
 
     proj = os.getenv(_ENV_PREFIX + "PROJECT_NAME", "").strip()
     if proj:

--- a/session_state.py
+++ b/session_state.py
@@ -99,6 +99,10 @@ class PerSession:
     # The most recent API error's ``error.type`` for this session, surfaced on
     # the root span at on_session_end so a failed turn shows *why* it failed.
     last_error_type: str = ""
+    # The LLM provider seen on this session's API calls (e.g. "openrouter").
+    # on_session_end only receives the platform (e.g. "cli"), so the real
+    # provider is captured here for the agent-level GenAI metric dimensions.
+    provider: str = ""
 
 
 class SessionState:

--- a/tests/integration/test_metrics_pipeline.py
+++ b/tests/integration/test_metrics_pipeline.py
@@ -6,8 +6,51 @@ from hermes_otel.hooks import (
     on_post_tool_call,
     on_pre_api_request,
     on_pre_tool_call,
+    on_session_end,
     on_session_start,
 )
+from hermes_otel.plugin_config import HermesOtelConfig
+
+
+def _api_call(session_id="s1", model="gpt-4", provider="openai", api_duration=0.5, usage=None):
+    """Fire a pre/post API request pair to drive metric recording."""
+    on_pre_api_request(
+        task_id="t1",
+        session_id=session_id,
+        platform="cli",
+        model=model,
+        provider=provider,
+        base_url="",
+        api_mode="chat",
+        api_call_count=1,
+        message_count=5,
+        tool_count=0,
+        approx_input_tokens=500,
+        request_char_count=2000,
+        max_tokens=1024,
+    )
+    on_post_api_request(
+        task_id="t1",
+        session_id=session_id,
+        platform="cli",
+        model=model,
+        provider=provider,
+        base_url="",
+        api_mode="chat",
+        api_call_count=1,
+        api_duration=api_duration,
+        finish_reason="stop",
+        message_count=5,
+        response_model=model,
+        usage=usage or {"prompt_tokens": 100, "output_tokens": 50, "total_tokens": 150},
+        assistant_content_chars=200,
+        assistant_tool_call_count=0,
+    )
+
+
+def _points(metric):
+    """All data points for a metric (histogram or counter)."""
+    return list(metric.data.data_points) if metric is not None else []
 
 
 def _get_metric(metric_reader, name):
@@ -141,6 +184,84 @@ class TestTokenUsageMetric:
         ]
         assert len(reasoning_points) == 1
         assert reasoning_points[0].value == 60
+
+
+class TestGenAISpecMetrics:
+    def test_client_token_usage_dual_written(self, inmemory_otel_with_metrics):
+        _, metric_reader, _ = inmemory_otel_with_metrics
+        _api_call(usage={"prompt_tokens": 100, "output_tokens": 50, "total_tokens": 150})
+
+        # Custom metric still recorded.
+        assert _get_metric_value(metric_reader, "hermes.token.usage") == 150
+
+        # Spec metric (a histogram) recorded with matching input/output split.
+        spec = _get_metric(metric_reader, "gen_ai.client.token.usage")
+        assert spec is not None
+        assert spec.unit == "{token}"
+        by_type = {dp.attributes.get("gen_ai.token.type"): dp.sum for dp in _points(spec)}
+        assert by_type == {"input": 100, "output": 50}
+
+    def test_client_token_usage_dimensions_low_cardinality(self, inmemory_otel_with_metrics):
+        _, metric_reader, _ = inmemory_otel_with_metrics
+        _api_call()
+
+        spec = _get_metric(metric_reader, "gen_ai.client.token.usage")
+        for dp in _points(spec):
+            keys = set(dp.attributes.keys())
+            # GenAI-spec dims only — never per-call IDs like session_id.
+            assert "session_id" not in keys
+            assert "gen_ai.operation.name" in keys
+            assert "gen_ai.provider.name" in keys
+            assert "gen_ai.request.model" in keys
+
+    def test_operation_duration_in_seconds(self, inmemory_otel_with_metrics):
+        _, metric_reader, _ = inmemory_otel_with_metrics
+        _api_call(api_duration=0.5)
+
+        dur = _get_metric(metric_reader, "gen_ai.client.operation.duration")
+        assert dur is not None
+        assert dur.unit == "s"
+        pts = _points(dur)
+        assert len(pts) == 1
+        # Recorded in seconds (0.5), NOT milliseconds.
+        assert pts[0].sum == pytest.approx(0.5)
+        assert pts[0].attributes.get("gen_ai.operation.name") == "chat"
+
+    def test_tool_duration_stays_milliseconds(self, inmemory_otel_with_metrics):
+        _, metric_reader, _ = inmemory_otel_with_metrics
+        on_pre_tool_call(tool_name="bash", args={}, task_id="t1")
+        on_post_tool_call(tool_name="bash", args={}, result="ok", task_id="t1")
+
+        tool = _get_metric(metric_reader, "hermes.tool.duration")
+        assert tool is not None
+        # The hermes.* duration histogram keeps ms for backward compatibility.
+        assert tool.unit == "ms"
+
+    def test_agent_token_usage_on_session_end(self, inmemory_otel_with_metrics):
+        _, metric_reader, _ = inmemory_otel_with_metrics
+        on_session_start(session_id="s1", model="gpt-4", platform="cli")
+        _api_call(usage={"prompt_tokens": 100, "output_tokens": 50, "total_tokens": 150})
+        on_session_end(
+            session_id="s1", completed=True, interrupted=False, model="gpt-4", platform="cli"
+        )
+
+        agent = _get_metric(metric_reader, "gen_ai.agent.token.usage")
+        assert agent is not None
+        by_type = {dp.attributes.get("gen_ai.token.type"): dp.sum for dp in _points(agent)}
+        assert by_type == {"input": 100, "output": 50}
+        for dp in _points(agent):
+            assert dp.attributes.get("gen_ai.operation.name") == "invoke_agent"
+
+    def test_flag_disables_spec_metrics_only(self, inmemory_otel_with_metrics):
+        _, metric_reader, plugin = inmemory_otel_with_metrics
+        plugin.config = HermesOtelConfig(emit_genai_metrics=False)
+
+        _api_call()
+
+        # hermes.* still flows; gen_ai.* suppressed.
+        assert _get_metric_value(metric_reader, "hermes.token.usage") == 150
+        assert _get_metric(metric_reader, "gen_ai.client.token.usage") is None
+        assert _get_metric(metric_reader, "gen_ai.client.operation.duration") is None
 
 
 class TestToolDurationMetric:

--- a/tests/integration/test_metrics_pipeline.py
+++ b/tests/integration/test_metrics_pipeline.py
@@ -251,6 +251,9 @@ class TestGenAISpecMetrics:
         assert by_type == {"input": 100, "output": 50}
         for dp in _points(agent):
             assert dp.attributes.get("gen_ai.operation.name") == "invoke_agent"
+            # Provider must be the LLM provider from the API call ("openai"),
+            # not the session platform ("cli").
+            assert dp.attributes.get("gen_ai.provider.name") == "openai"
 
     def test_flag_disables_spec_metrics_only(self, inmemory_otel_with_metrics):
         _, metric_reader, plugin = inmemory_otel_with_metrics

--- a/tests/unit/test_hooks_helpers.py
+++ b/tests/unit/test_hooks_helpers.py
@@ -4,6 +4,7 @@ import pytest
 from hermes_otel.helpers import truncate_string
 from hermes_otel.hooks import (
     _detect_session_kind,
+    _genai_metric_dims,
     _normalize_usage,
     _to_int,
     _usage_attributes,
@@ -140,6 +141,28 @@ class TestNormalizeUsageReasoning:
             {"input_tokens": 100, "output_tokens": 50, "reasoning_tokens": 30}
         )
         assert totals["total_tokens"] == 150  # 100 + 50, reasoning excluded
+
+
+class TestGenAIMetricDims:
+    def test_default_operation_is_chat(self):
+        dims = _genai_metric_dims("gpt-4", "openai")
+        assert dims["gen_ai.operation.name"] == "chat"
+        assert dims["gen_ai.provider.name"] == "openai"
+        assert dims["gen_ai.request.model"] == "gpt-4"
+
+    def test_response_model_and_operation_override(self):
+        dims = _genai_metric_dims("gpt-4", "openai", "gpt-4o", operation="invoke_agent")
+        assert dims["gen_ai.operation.name"] == "invoke_agent"
+        assert dims["gen_ai.response.model"] == "gpt-4o"
+
+    def test_no_high_cardinality_keys(self):
+        dims = _genai_metric_dims("gpt-4", "openai", "gpt-4")
+        assert "session_id" not in dims
+        assert "task_id" not in dims
+
+    def test_empty_provider_and_model_omitted(self):
+        dims = _genai_metric_dims("", "")
+        assert dims == {"gen_ai.operation.name": "chat"}
 
 
 class TestUsageAttributesReasoning:

--- a/tracer.py
+++ b/tracer.py
@@ -108,6 +108,11 @@ class HermesOTelPlugin:
         self._subagent_duration = None
         self._api_error_count = None
         self._retry_count = None
+        # OTel GenAI semantic-convention instruments (dual-write alongside the
+        # hermes.* ones above).
+        self._gen_ai_client_token_usage = None
+        self._gen_ai_client_operation_duration = None
+        self._gen_ai_agent_token_usage = None
         # Sub-agent delegation registry. Maps a delegated child's session_id to
         # a record about the delegation span opened in the parent on
         # ``subagent_start`` — ``{"span", "context", "role", "parent_session_id"}``
@@ -430,6 +435,28 @@ class HermesOTelPlugin:
             description="Provider API retry attempts",
         )
 
+        # ── OTel GenAI semantic-convention metrics ──────────────────────────
+        # Spec-named instruments emitted in addition to the hermes.* ones, so
+        # generic OTel-GenAI dashboards/alerts work without per-user config.
+        # Units follow the spec exactly: {token} for token counts, s (seconds)
+        # for durations — note hermes.tool.duration / hermes.subagent.duration
+        # stay in ms for backward compatibility.
+        self._gen_ai_client_token_usage = self._meter.create_histogram(
+            "gen_ai.client.token.usage",
+            unit="{token}",
+            description="Number of tokens used per client (LLM) operation, by type",
+        )
+        self._gen_ai_client_operation_duration = self._meter.create_histogram(
+            "gen_ai.client.operation.duration",
+            unit="s",
+            description="Duration of client (LLM) operations",
+        )
+        self._gen_ai_agent_token_usage = self._meter.create_histogram(
+            "gen_ai.agent.token.usage",
+            unit="{token}",
+            description="Tokens used per agent invocation (session/turn rollup), by type",
+        )
+
     def _init_logs_pipeline(self, resource: "Resource", backends: List[_ResolvedBackend]) -> None:
         """Wire a :class:`LoggerProvider` + handler when ``capture_logs`` is on.
 
@@ -510,6 +537,15 @@ class HermesOTelPlugin:
         elif name == "retry_count":
             if self._retry_count is not None:
                 self._retry_count.add(int(value), attrs)
+        elif name == "gen_ai.client.token.usage":
+            if self._gen_ai_client_token_usage is not None:
+                self._gen_ai_client_token_usage.record(int(value), attrs)
+        elif name == "gen_ai.client.operation.duration":
+            if self._gen_ai_client_operation_duration is not None:
+                self._gen_ai_client_operation_duration.record(value, attrs)
+        elif name == "gen_ai.agent.token.usage":
+            if self._gen_ai_agent_token_usage is not None:
+                self._gen_ai_agent_token_usage.record(int(value), attrs)
 
     def start_span(
         self,

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -54,6 +54,7 @@ Each of these overrides the corresponding field in `config.yaml`. See [`config.y
 | `HERMES_OTEL_SPAN_BATCH_MAX_EXPORT_BATCH_SIZE` | `span_batch_max_export_batch_size` | int |
 | `HERMES_OTEL_SPAN_BATCH_EXPORT_TIMEOUT_MS` | `span_batch_export_timeout_ms` | int (ms) |
 | `HERMES_OTEL_FORCE_FLUSH_ON_SESSION_END` | `force_flush_on_session_end` | bool |
+| `HERMES_OTEL_EMIT_GENAI_METRICS` | `emit_genai_metrics` | bool |
 
 ## Debug / diagnostics
 

--- a/website/docs/configuration/yaml.md
+++ b/website/docs/configuration/yaml.md
@@ -101,6 +101,18 @@ log_attach_logger: null
 
 See [OTel logs](/configuration/logs) for the full story, including the loop-avoidance filter for HTTP client libraries and which backends actually accept logs.
 
+## Metrics
+
+```yaml
+# Emit OTel GenAI semantic-convention metrics (gen_ai.client.*, gen_ai.agent.*)
+# alongside the custom hermes.* metrics, so generic OTel-GenAI dashboards and
+# alerts work without per-user wiring. Set false for hermes.* only.
+# Env: HERMES_OTEL_EMIT_GENAI_METRICS. Default: true.
+emit_genai_metrics: true
+```
+
+See [Span & metric reference](/reference/span-attributes#otel-genai-semantic-convention-metrics) for the full instrument list, units, and labels.
+
 ## Lifecycle / cleanup
 
 ```yaml

--- a/website/docs/reference/span-attributes.md
+++ b/website/docs/reference/span-attributes.md
@@ -177,3 +177,24 @@ reasoning into the total. Only emitted by reasoning-capable models that report
 a non-zero count.
 
 Label cardinality is bounded by normalised values (outcomes, finish reasons) and small dimension sets (model, tool name). No user IDs or other high-cardinality labels.
+
+### OTel GenAI semantic-convention metrics
+
+In addition to the `hermes.*` instruments above, the plugin emits spec-named
+metrics so generic OpenTelemetry GenAI dashboards and alert rules work without
+any per-user wiring. This mirrors the dual-convention span attributes. Set
+`emit_genai_metrics: false` (or `HERMES_OTEL_EMIT_GENAI_METRICS=false`) to emit
+only the `hermes.*` metrics.
+
+| Metric | Type | Unit | Labels |
+|---|---|---|---|
+| `gen_ai.client.token.usage` | Histogram | `{token}` | `gen_ai.token.type` (`input`/`output`), `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.response.model` |
+| `gen_ai.client.operation.duration` | Histogram | **`s`** | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.response.model`, `error.type` (on failures) |
+| `gen_ai.agent.token.usage` | Histogram | `{token}` | `gen_ai.token.type`, `gen_ai.operation.name` (`invoke_agent`), `gen_ai.provider.name`, `gen_ai.request.model` |
+
+Notes:
+- **Units follow the spec:** durations are in **seconds** (`gen_ai.client.operation.duration`), whereas the `hermes.*` duration histograms stay in **ms** for backward compatibility.
+- `gen_ai.token.type` is limited to the spec's `input` / `output` enum. Cache and reasoning buckets are subsets already counted in those, so they are not split into the spec metric (the `hermes.tokens.*` metrics retain that breakdown).
+- Dimensions are deliberately low-cardinality — operation, provider, and model only, **never** per-call IDs such as `session_id` — so the metrics stay aggregatable.
+- `gen_ai.agent.token.usage` is the per-turn/session rollup recorded at session end; `gen_ai.client.*` are per-API-call.
+- `gen_ai.agent.request.duration` is intentionally **not** emitted yet — there is no reliable per-turn duration signal today (a turn can span multiple API calls); it is deferred until true session-lifecycle timing lands.


### PR DESCRIPTION
Closes #38

## Summary
Dual-write **OTel GenAI semantic-convention metrics** (`gen_ai.client.*`, `gen_ai.agent.*`) alongside the existing custom `hermes.*` instruments — the metrics analogue of the dual-convention span attributes we already emit. Generic OTel-GenAI dashboards/alerts now work with no per-user wiring.

## New instruments
| Metric | Type | Unit | Notes |
|---|---|---|---|
| `gen_ai.client.token.usage` | Histogram | `{token}` | per API call; `gen_ai.token.type` input/output |
| `gen_ai.client.operation.duration` | Histogram | **`s`** | per API call (seconds, per spec); `error.type` on failures |
| `gen_ai.agent.token.usage` | Histogram | `{token}` | per-turn/session rollup at `on_session_end` |

- Recorded in the existing API/session hook paths via a shared **low-cardinality** dimension helper (`gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.token.type`) — **never** per-call IDs like `session_id`.
- **Unit discipline:** spec durations are in **seconds**; the `hermes.*` duration histograms stay in **ms** for backward compatibility.
- `gen_ai.token.type` keeps to the spec's `input`/`output` enum (cache/reasoning are subsets already counted; the `hermes.tokens.*` metrics retain that breakdown).
- Gated by a new **`emit_genai_metrics`** flag (default `true`; `HERMES_OTEL_EMIT_GENAI_METRICS`).

## Scope note
`gen_ai.agent.request.duration` is intentionally **deferred** — there's no reliable per-turn duration signal today (a turn can span multiple API calls). It belongs with the true session-lifecycle work (#29). Everything else from the issue is implemented.

## Tests
- Integration (`test_metrics_pipeline.py`): client token usage dual-written with correct input/output split; low-cardinality dims (no `session_id`); operation duration in **seconds** while `hermes.tool.duration` stays **ms**; agent token usage at session end; `emit_genai_metrics=false` suppresses only the `gen_ai.*` metrics.
- Unit (`test_hooks_helpers.py`): `_genai_metric_dims` defaults/overrides/omissions/no-high-cardinality.

## Checks (local, matching CI)
- `ruff check .` — pass
- `black --check .` — pass
- `pytest --cov=hermes_otel --cov-fail-under=85` — **554 passed, 3 skipped**, coverage **89.83%**
- `website` docs build — clean

## Docs
Added a "GenAI semantic-convention metrics" table to `reference/span-attributes.md`, the flag to `configuration/yaml.md` + `environment-variables.md`, and a `config.yaml.example` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
