### PR TITLE
feat(spans): human-in-the-loop approval spans (approval.<pattern_key>)

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,10 @@ Turn 1:
 | `llm.{model}` | LLM | Model name, provider, user message (input), assistant response (output) |
 | `api.{model}` | LLM | Token counts (prompt + completion), duration, finish reason, cache tokens. On failure: `ERROR` status + recorded exception + retry metadata |
 | `tool.{name}` | TOOL | Tool name, arguments (input), result (output), error status |
+| `approval.{pattern}` | APPROVAL | Human-in-the-loop approval prompt — the **human-decision wait time**, `hermes.approval.choice` (`once`/`session`/`always`/`deny`/`timeout`), correlated to the gated tool via `gen_ai.tool.call.id` |
 | `subagent.{role}` | AGENT | Delegated child agent — role, goal, status, duration, summary; the child's own run nests beneath it so a multi-agent run is **one connected trace** |
+
+**Human-in-the-loop approvals:** when a tool trips a dangerous-command approval rule, the agent blocks waiting for a human (often the dominant chunk of a turn's wall-clock, previously invisible). The plugin opens an `approval.*` span (via the `pre_approval_request` / `post_approval_response` hooks) capturing the wait time and the decision (approve/deny/timeout) — works on CLI and gateway surfaces (Telegram, Discord, …), and feeds `hermes.approval.count` / `hermes.approval.duration` metrics for deny/timeout-rate tracking. Observer-only: telemetry never alters an approval. See [Span hierarchy → `approval.*`](website/docs/architecture/span-hierarchy.md#approval).
 
 **Sub-agent delegation:** when the agent calls `delegate_task`, the plugin opens a `subagent.{role}` span in the parent trace (via the `subagent_start` / `subagent_stop` hooks) and rejoins the delegated child's own root span underneath it. Without this, child agents export as dozens of disconnected traces. See [Span hierarchy → `subagent.*`](website/docs/architecture/span-hierarchy.md) and the `hermes.subagent.count` / `hermes.subagent.duration` metrics.
 

--- a/__init__.py
+++ b/__init__.py
@@ -45,6 +45,8 @@ def register(ctx):
         ("subagent_start", hooks.on_subagent_start),
         ("subagent_stop", hooks.on_subagent_stop),
         ("api_request_error", hooks.on_api_request_error),
+        ("pre_approval_request", hooks.on_pre_approval_request),
+        ("post_approval_response", hooks.on_post_approval_response),
     ]:
         try:
             ctx.register_hook(hook_name, callback)

--- a/helpers.py
+++ b/helpers.py
@@ -204,6 +204,40 @@ def detect_skill(tool_name: Optional[str], args: Optional[Dict[str, Any]]):
     return None, None
 
 
+def session_id_from_turn_id(turn_id: Any) -> str:
+    """Recover the plugin ``session_id`` from a hook ``turn_id``.
+
+    Hermes builds ``turn_id`` as ``"<session_id>:<task_id>:<hex>"``
+    (``agent/turn_context.py``). Hooks that only carry ``turn_id`` (e.g. the
+    approval hooks) can therefore recover the session the plugin keys its spans
+    on by taking the first segment. Returns ``""`` when unavailable.
+    """
+    if not isinstance(turn_id, str) or ":" not in turn_id:
+        return ""
+    head = turn_id.split(":", 1)[0].strip()
+    # ``agent/turn_context.py`` uses the literal "session" placeholder when the
+    # agent has no session_id yet — that's not a real id to correlate on.
+    return "" if head == "session" else head
+
+
+_APPROVAL_GRANT_CHOICES = frozenset({"once", "session", "always"})
+
+
+def classify_approval_choice(choice: Any) -> Dict[str, Any]:
+    """Normalize an approval ``choice`` into telemetry fields.
+
+    ``choice`` is one of ``once`` / ``session`` / ``always`` / ``deny`` /
+    ``timeout``. The first three are grants; ``timeout`` is flagged distinctly.
+    A denied or timed-out approval is a legitimate human outcome, not an error.
+    """
+    c = (choice or "").strip().lower() if isinstance(choice, str) else ""
+    return {
+        "choice": c,
+        "granted": c in _APPROVAL_GRANT_CHOICES,
+        "timed_out": c == "timeout",
+    }
+
+
 # ── Sub-agent / delegation ───────────────────────────────────────────────────
 
 # child_status values hermes-agent reports on subagent_stop that indicate a

--- a/hooks.py
+++ b/hooks.py
@@ -18,12 +18,14 @@ from typing import Any, Dict, List, Optional, TypedDict
 
 from .debug_utils import debug_log
 from .helpers import (
+    classify_approval_choice,
     clip_preview,
     coerce_bool,
     detect_skill,
     extract_tool_result_status,
     http_status_class,
     resolve_tool_identity,
+    session_id_from_turn_id,
     subagent_span_key,
     subagent_status_to_span_status,
     to_optional_int,
@@ -893,6 +895,123 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
         key, attributes=attributes, status=status, error_message=error_msg if has_error else None
     )
     debug_log(f"  span ended: status={status}, outcome={outcome}")
+
+
+def _approval_span_key(session_id: str, tool_call_id: Any, pattern_key: str) -> str:
+    """Stable key for an approval span; correlated to the triggering tool call."""
+    return f"approval:{session_id}:{tool_call_id or pattern_key or 'cmd'}"
+
+
+def on_pre_approval_request(
+    command: str = None,
+    description: str = None,
+    pattern_key: str = None,
+    pattern_keys: list = None,
+    session_key: str = None,
+    surface: str = None,
+    turn_id: str = None,
+    tool_call_id: str = None,
+    **kwargs,
+):
+    """Open a span while the agent blocks waiting on a human approval decision.
+
+    Observer-only: the return value is ignored by the approval system, so this
+    can never veto/alter an approval. Correlates to the turn via ``turn_id``
+    (which embeds the session_id) and to the triggering tool via
+    ``tool_call_id``. Fails open.
+    """
+    debug_log(f"pre_approval_request fired: pattern={pattern_key}, surface={surface}")
+    tracer = get_tracer()
+    if not tracer.is_enabled:
+        return
+
+    tracer.sweep_expired_turns()
+
+    session_id = session_id_from_turn_id(turn_id)
+    pk = truncate_string(pattern_key, 200) or "command"
+    key = _approval_span_key(session_id, tool_call_id, pk)
+
+    attributes: Dict[str, Any] = {
+        "hermes.approval.pattern_key": pk,
+        "hermes.span_kind": "approval",
+    }
+    if tool_call_id:
+        # Correlates the approval to the tool span / call it gates.
+        attributes["gen_ai.tool.call.id"] = truncate_string(tool_call_id, 200)
+    if surface:
+        attributes["hermes.approval.surface"] = truncate_string(surface, 60)
+    if pattern_keys:
+        attributes["hermes.approval.pattern_keys"] = _clip_joined(
+            [str(k) for k in pattern_keys], ","
+        )
+    # command / description follow the same preview policy as tool input.
+    cmd = _preview(
+        command, tracer.config.tool_input_preview_max_chars or tracer.config.preview_max_chars
+    )
+    if cmd is not None:
+        attributes["hermes.approval.command"] = cmd
+    if description:
+        desc = _preview(description, tracer.config.preview_max_chars)
+        if desc is not None:
+            attributes["hermes.approval.description"] = desc
+    attributes.update(_gen_ai_attributes(session_id, "approval", kwargs))
+
+    tracer.spans.record_approval_start(key, time.perf_counter())
+    tracer.start_span(
+        name=f"approval.{pk}",
+        key=key,
+        kind="general",
+        attributes=attributes,
+        session_id=session_id,
+        parent=tracer.spans.get_current_parent(session_id),
+    )
+    debug_log(f"  approval span opened: key={key}")
+
+
+def on_post_approval_response(
+    command: str = None,
+    description: str = None,
+    pattern_key: str = None,
+    pattern_keys: list = None,
+    session_key: str = None,
+    surface: str = None,
+    choice: str = None,
+    turn_id: str = None,
+    tool_call_id: str = None,
+    **kwargs,
+):
+    """Close the approval span with the human's decision + wait duration."""
+    debug_log(f"post_approval_response fired: pattern={pattern_key}, choice={choice}")
+    tracer = get_tracer()
+    if not tracer.is_enabled:
+        return
+
+    session_id = session_id_from_turn_id(turn_id)
+    pk = truncate_string(pattern_key, 200) or "command"
+    key = _approval_span_key(session_id, tool_call_id, pk)
+
+    verdict = classify_approval_choice(choice)
+    attributes: Dict[str, Any] = {
+        "hermes.approval.granted": verdict["granted"],
+        "hermes.approval.timed_out": verdict["timed_out"],
+    }
+    if verdict["choice"]:
+        attributes["hermes.approval.choice"] = verdict["choice"]
+
+    start = tracer.spans.pop_approval_start(key)
+    duration_ms = None
+    if start is not None:
+        duration_ms = (time.perf_counter() - start) * 1000
+        attributes["hermes.approval.duration_ms"] = round(duration_ms, 1)
+
+    # A denied or timed-out approval is a valid human outcome, not an error.
+    tracer.end_span(key, attributes=attributes, status="ok")
+
+    metric_attrs = {"choice": verdict["choice"] or "unknown", "pattern_key": pk}
+    tracer.record_metric("approval_count", 1, metric_attrs)
+    if duration_ms is not None:
+        tracer.record_metric("approval_duration", duration_ms, metric_attrs)
+    debug_log(f"  approval span ended: key={key}, choice={verdict['choice']}, dur={duration_ms}")
 
 
 def on_pre_llm_call(

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -22,3 +22,5 @@ provides_hooks:
   - api_request_error
   - subagent_start
   - subagent_stop
+  - pre_approval_request
+  - post_approval_response

--- a/span_tracker.py
+++ b/span_tracker.py
@@ -71,6 +71,10 @@ class SpanTracker:
         # turn boundary — they are tracked here (NOT on the parent stack) so
         # several can be active at once without disturbing tool/LLM nesting.
         self._session_skill_spans: Dict[str, Dict[str, str]] = {}
+        # approval span key -> perf_counter start, so post_approval_response can
+        # compute the human-wait duration. Flat (not per-session) — keys are
+        # already namespaced by session_id + tool_call_id.
+        self._approval_starts: Dict[str, float] = {}
 
     def _parent_stack(self) -> list:
         """Return this context's parent span stack, creating it if needed."""
@@ -137,6 +141,14 @@ class SpanTracker:
         """Return and clear all open skill spans for a session (skill -> key)."""
         return self._session_skill_spans.pop(session_id, {})
 
+    def record_approval_start(self, key: str, started_at: float) -> None:
+        """Stash the start time of an approval wait, keyed by span key."""
+        self._approval_starts[key] = started_at
+
+    def pop_approval_start(self, key: str) -> Optional[float]:
+        """Return and remove an approval's start time, or None if unknown."""
+        return self._approval_starts.pop(key, None)
+
     def get_current_parent(self, session_id: Optional[str] = None):
         """Return the current parent span, or None.
 
@@ -197,6 +209,7 @@ class SpanTracker:
         self._active_spans.clear()
         self._session_parent_stacks.clear()
         self._session_skill_spans.clear()
+        self._approval_starts.clear()
         stack = _PARENT_STACK.get()
         if stack is not None:
             stack.clear()

--- a/tests/integration/test_approval_spans.py
+++ b/tests/integration/test_approval_spans.py
@@ -1,0 +1,160 @@
+"""Integration tests for human-in-the-loop approval spans (issue #30)."""
+
+from hermes_otel.hooks import (
+    on_post_approval_response,
+    on_post_tool_call,
+    on_pre_approval_request,
+    on_pre_tool_call,
+    on_session_end,
+    on_session_start,
+)
+
+SID = "20260626_010101_abc123"
+TURN = f"{SID}:task7:deadbeef"
+
+
+def _parent_span_id(span):
+    return span.parent.span_id if span.parent is not None else None
+
+
+def _one(spans, name):
+    matches = [s for s in spans if s.name == name]
+    assert len(matches) == 1, f"expected one {name!r}, got {[s.name for s in spans]}"
+    return matches[0]
+
+
+def _approve(choice, tool_call_id="tc1", pattern_key="rm_rf", command="rm -rf /tmp/x"):
+    on_pre_approval_request(
+        command=command,
+        description="Delete a directory tree",
+        pattern_key=pattern_key,
+        pattern_keys=[pattern_key, "danger"],
+        session_key="agent:main:telegram:dm:5490634439",
+        surface="gateway",
+        turn_id=TURN,
+        tool_call_id=tool_call_id,
+    )
+    on_post_approval_response(
+        command=command,
+        pattern_key=pattern_key,
+        session_key="agent:main:telegram:dm:5490634439",
+        surface="gateway",
+        choice=choice,
+        turn_id=TURN,
+        tool_call_id=tool_call_id,
+    )
+
+
+class TestApprovalSpanFlow:
+    def test_full_flow_grant_under_turn_correlated_to_tool(self, inmemory_otel_setup):
+        exporter, _ = inmemory_otel_setup
+        on_session_start(session_id=SID, model="gpt-4", platform="telegram")
+        on_pre_tool_call(
+            tool_name="bash", args={"command": "rm -rf /tmp/x"}, task_id="tc1", session_id=SID
+        )
+        _approve("once", tool_call_id="tc1")
+        on_post_tool_call(tool_name="bash", args={}, result="ok", task_id="tc1", session_id=SID)
+        on_session_end(
+            session_id=SID, completed=True, interrupted=False, model="gpt-4", platform="telegram"
+        )
+
+        spans = exporter.get_finished_spans()
+        approval = _one(spans, "approval.rm_rf")
+        agent = _one(spans, "agent")
+        attrs = dict(approval.attributes)
+        assert attrs["hermes.approval.choice"] == "once"
+        assert attrs["hermes.approval.granted"] is True
+        assert attrs["hermes.approval.timed_out"] is False
+        assert attrs["hermes.approval.surface"] == "gateway"
+        assert attrs["gen_ai.tool.call.id"] == "tc1"  # correlates to the tool call
+        assert "hermes.approval.command" in attrs
+        assert attrs["hermes.approval.duration_ms"] >= 0
+        # Parented within the turn (under the agent root in this minimal flow).
+        assert _parent_span_id(approval) == agent.context.span_id
+
+    def test_deny_path(self, inmemory_otel_setup):
+        exporter, _ = inmemory_otel_setup
+        on_session_start(session_id=SID, model="gpt-4", platform="telegram")
+        _approve("deny")
+        on_session_end(
+            session_id=SID, completed=True, interrupted=False, model="gpt-4", platform="telegram"
+        )
+        attrs = dict(_one(exporter.get_finished_spans(), "approval.rm_rf").attributes)
+        assert attrs["hermes.approval.choice"] == "deny"
+        assert attrs["hermes.approval.granted"] is False
+        assert attrs["hermes.approval.timed_out"] is False
+
+    def test_timeout_path(self, inmemory_otel_setup):
+        exporter, _ = inmemory_otel_setup
+        on_session_start(session_id=SID, model="gpt-4", platform="telegram")
+        _approve("timeout")
+        on_session_end(
+            session_id=SID, completed=True, interrupted=False, model="gpt-4", platform="telegram"
+        )
+        attrs = dict(_one(exporter.get_finished_spans(), "approval.rm_rf").attributes)
+        assert attrs["hermes.approval.timed_out"] is True
+        assert attrs["hermes.approval.granted"] is False
+
+    def test_post_without_pre_does_not_raise(self, inmemory_otel_setup):
+        exporter, _ = inmemory_otel_setup
+        on_session_start(session_id=SID, model="gpt-4", platform="telegram")
+        # No pre_approval_request — must not raise, just no span / no duration.
+        on_post_approval_response(
+            pattern_key="rm_rf", choice="once", turn_id=TURN, tool_call_id="tc1"
+        )
+        on_session_end(
+            session_id=SID, completed=True, interrupted=False, model="gpt-4", platform="telegram"
+        )
+        assert [s for s in exporter.get_finished_spans() if s.name == "approval.rm_rf"] == []
+
+
+class TestApprovalPrivacy:
+    def test_command_suppressed_when_capture_previews_off(self, inmemory_otel_setup):
+        exporter, plugin = inmemory_otel_setup
+        from hermes_otel.plugin_config import HermesOtelConfig
+
+        plugin.config = HermesOtelConfig(capture_previews=False)
+        on_session_start(session_id=SID, model="gpt-4", platform="telegram")
+        _approve("once", command="rm -rf /secret")
+        on_session_end(
+            session_id=SID, completed=True, interrupted=False, model="gpt-4", platform="telegram"
+        )
+        attrs = dict(_one(exporter.get_finished_spans(), "approval.rm_rf").attributes)
+        # The privacy kill-switch suppresses the command/description previews,
+        # but the decision metadata still flows.
+        assert "hermes.approval.command" not in attrs
+        assert "hermes.approval.description" not in attrs
+        assert attrs["hermes.approval.choice"] == "once"
+        assert attrs["hermes.approval.pattern_key"] == "rm_rf"
+
+
+class TestApprovalFanout:
+    def test_fans_out_to_both_backends(self, two_exporter_pipeline):
+        exporter_a, exporter_b, _ = two_exporter_pipeline
+        on_session_start(session_id=SID, model="gpt-4", platform="telegram")
+        _approve("session")
+        on_session_end(
+            session_id=SID, completed=True, interrupted=False, model="gpt-4", platform="telegram"
+        )
+        for exp in (exporter_a, exporter_b):
+            assert any(s.name == "approval.rm_rf" for s in exp.get_finished_spans())
+
+
+class TestApprovalMetrics:
+    def test_count_and_duration_recorded(self, inmemory_otel_with_metrics):
+        _, metric_reader, _ = inmemory_otel_with_metrics
+        on_session_start(session_id=SID, model="gpt-4", platform="telegram")
+        _approve("once")
+        on_session_end(
+            session_id=SID, completed=True, interrupted=False, model="gpt-4", platform="telegram"
+        )
+
+        data = metric_reader.get_metrics_data()
+        metrics = {
+            m.name: m for rm in data.resource_metrics for sm in rm.scope_metrics for m in sm.metrics
+        }
+        assert "hermes.approval.count" in metrics
+        assert "hermes.approval.duration" in metrics
+        count_pt = next(iter(metrics["hermes.approval.count"].data.data_points))
+        assert count_pt.attributes.get("choice") == "once"
+        assert count_pt.attributes.get("pattern_key") == "rm_rf"

--- a/tests/unit/test_hooks_helpers.py
+++ b/tests/unit/test_hooks_helpers.py
@@ -1,7 +1,12 @@
 """Tests for pure helper functions in hooks.py and helpers.py."""
 
 import pytest
-from hermes_otel.helpers import detect_skill, truncate_string
+from hermes_otel.helpers import (
+    classify_approval_choice,
+    detect_skill,
+    session_id_from_turn_id,
+    truncate_string,
+)
 from hermes_otel.hooks import (
     _detect_session_kind,
     _genai_metric_dims,
@@ -9,6 +14,44 @@ from hermes_otel.hooks import (
     _to_int,
     _usage_attributes,
 )
+
+
+class TestSessionIdFromTurnId:
+    def test_extracts_session_id_head(self):
+        assert session_id_from_turn_id("20260626_x:task7:hex") == "20260626_x"
+
+    def test_session_placeholder_is_empty(self):
+        # turn_context uses "session" when the agent has no real session_id.
+        assert session_id_from_turn_id("session:task:hex") == ""
+
+    def test_no_colon_returns_empty(self):
+        assert session_id_from_turn_id("nocolon") == ""
+
+    def test_non_string_returns_empty(self):
+        assert session_id_from_turn_id(None) == ""
+        assert session_id_from_turn_id(12345) == ""
+
+
+class TestClassifyApprovalChoice:
+    def test_grants(self):
+        for c in ("once", "session", "always"):
+            v = classify_approval_choice(c)
+            assert v == {"choice": c, "granted": True, "timed_out": False}
+
+    def test_deny_is_not_granted_not_timeout(self):
+        assert classify_approval_choice("deny") == {
+            "choice": "deny",
+            "granted": False,
+            "timed_out": False,
+        }
+
+    def test_timeout_flagged(self):
+        v = classify_approval_choice("TimeOut")
+        assert v["timed_out"] is True and v["granted"] is False
+
+    def test_empty_or_none(self):
+        assert classify_approval_choice(None)["choice"] == ""
+        assert classify_approval_choice("")["granted"] is False
 
 
 class TestDetectSkill:

--- a/tracer.py
+++ b/tracer.py
@@ -108,6 +108,8 @@ class HermesOTelPlugin:
         self._subagent_duration = None
         self._api_error_count = None
         self._retry_count = None
+        self._approval_count = None
+        self._approval_duration = None
         # OTel GenAI semantic-convention instruments (dual-write alongside the
         # hermes.* ones above).
         self._gen_ai_client_token_usage = None
@@ -434,6 +436,15 @@ class HermesOTelPlugin:
             "hermes.retry.count",
             description="Provider API retry attempts",
         )
+        self._approval_count = self._meter.create_counter(
+            "hermes.approval.count",
+            description="Human-in-the-loop approval prompts by choice / pattern",
+        )
+        self._approval_duration = self._meter.create_histogram(
+            "hermes.approval.duration",
+            unit="ms",
+            description="Human-decision wait time on approval prompts",
+        )
 
         # ── OTel GenAI semantic-convention metrics ──────────────────────────
         # Spec-named instruments emitted in addition to the hermes.* ones, so
@@ -537,6 +548,12 @@ class HermesOTelPlugin:
         elif name == "retry_count":
             if self._retry_count is not None:
                 self._retry_count.add(int(value), attrs)
+        elif name == "approval_count":
+            if self._approval_count is not None:
+                self._approval_count.add(1, attrs)
+        elif name == "approval_duration":
+            if self._approval_duration is not None:
+                self._approval_duration.record(value, attrs)
         elif name == "gen_ai.client.token.usage":
             if self._gen_ai_client_token_usage is not None:
                 self._gen_ai_client_token_usage.record(int(value), attrs)

--- a/website/docs/architecture/span-hierarchy.md
+++ b/website/docs/architecture/span-hierarchy.md
@@ -18,6 +18,7 @@ agent / cron                                  [AGENT]
     │   ├── tool.{name}                       [TOOL]
     │   ├── tool.skill_view                   [TOOL] (the call that *loads* skill.{name})
     │   ├── tool.{name}                       [TOOL] (parallel tool calls — siblings)
+    │   ├── approval.{pattern_key}            [APPROVAL] (human-in-the-loop wait; gen_ai.tool.call.id → the gated tool)
     │   ├── tool.delegate_task                [TOOL] (the tool call that delegates)
     │   └── subagent.{role}                   [AGENT] (delegation span)
     │       └── agent (child session root)    [AGENT] (the child rejoins this trace)
@@ -30,6 +31,7 @@ agent / cron                                  [AGENT]
 - **`llm.*`** — one per logical model turn. Wraps one or more HTTP round-trips to the provider.
 - **`api.*`** — one per HTTP round-trip. Tools run during a round-trip, so their parent is `api.*`, not `llm.*`.
 - **`tool.*`** — one per tool invocation. Parallel tool calls are siblings under the same `api.*`.
+- **`approval.*`** — one per dangerous-command approval prompt. Spans the time the agent blocks waiting for a human to approve/deny, correlated to the gated tool via `gen_ai.tool.call.id`. See [`approval.*`](#approval) below.
 - **`subagent.*`** — one per delegated child agent. The child's own root span nests under it so a multi-agent run is one connected trace. See [`subagent.*`](#subagent) below.
 
 ## `session.*` / `cron`
@@ -152,6 +154,39 @@ are emitted regardless.
 
 Status is always `OK` — a skill being active is never itself an error; the
 turn's outcome rides on `hermes.skill.result_status`.
+
+## `approval.*` {#approval}
+
+One per dangerous-command approval prompt. When a tool trips an approval rule,
+the agent **blocks waiting for a human** to approve or deny — often the single
+biggest chunk of a turn's wall-clock, and previously invisible. This span makes
+that human-decision latency a first-class part of the trace, and records what
+was decided (an audit signal for allowlist tuning).
+
+The span opens on `pre_approval_request` and closes on `post_approval_response`,
+nested within the turn (under the active `api.*`/`agent` span) and correlated to
+the tool it gates via `gen_ai.tool.call.id`. It's keyed off the `turn_id` the
+hook carries (which embeds the session id), so it lands in the right trace even
+though the approval system runs on its own executor thread. Works on both the
+CLI (`surface=cli`) and gateway surfaces (`surface=gateway` — Telegram, Discord,
+Slack, …).
+
+| Attribute | Convention | Meaning |
+|---|---|---|
+| `hermes.approval.pattern_key` | hermes-specific | The matched approval rule (e.g. `rm_rf`) — also the span name |
+| `hermes.approval.choice` | hermes-specific | `once` · `session` · `always` · `deny` · `timeout` |
+| `hermes.approval.granted` | hermes-specific | `true` for once/session/always |
+| `hermes.approval.timed_out` | hermes-specific | `true` when the human never answered |
+| `hermes.approval.duration_ms` | hermes-specific | Human-decision wait time (ms) |
+| `hermes.approval.surface` | hermes-specific | `cli` or `gateway` |
+| `hermes.approval.command` | hermes-specific | The command awaiting approval (preview-clipped; suppressed when `capture_previews=false`) |
+| `hermes.approval.description` | hermes-specific | Why approval is required (preview-clipped) |
+| `gen_ai.tool.call.id` | gen_ai | The gated tool call — correlates this approval to its `tool.*` span |
+
+Status is always `OK` — a denial or timeout is a legitimate human outcome, not
+an error. Metrics: `hermes.approval.count` (by `choice` / `pattern_key`) and
+`hermes.approval.duration` (the wait histogram). These spans are observer-only —
+the plugin never vetoes or alters an approval.
 
 ## `subagent.*` {#subagent}
 

--- a/website/docs/configuration/privacy.md
+++ b/website/docs/configuration/privacy.md
@@ -32,6 +32,7 @@ When `capture_previews: false`:
 - `gen_ai.content.prompt` / `gen_ai.content.completion` on `llm.*` spans
 - `input.value` on `tool.*` spans (tool args)
 - `output.value` on `tool.*` spans (tool result)
+- `hermes.approval.command` / `hermes.approval.description` on `approval.*` spans (the command awaiting human approval)
 - The conversation-history JSON when [conversation capture](/configuration/conversation-capture) is also enabled
 
 These attributes are **never set** on the span — not "set and then redacted". A reader can't pull them back out.
@@ -46,6 +47,7 @@ Everything that isn't user-originated content:
 - Token counts (`gen_ai.usage.*`, `llm.token_count.*`)
 - Model name, provider, finish reason
 - Per-turn summary (tool count, skill count, API call count, final status)
+- Approval decisions and wait times (`hermes.approval.choice` / `.granted` / `.timed_out` / `.duration_ms`, `hermes.approval.pattern_key`) — the *outcome* of an approval flows even when the command text is suppressed
 - Metrics (all of them — counters and histograms)
 
 So you still get a useful operational view: how many tools ran, which tools they were, how long each took, how many tokens the model burned, and whether the turn completed or timed out. You just don't see the message content.

--- a/website/docs/reference/hooks.md
+++ b/website/docs/reference/hooks.md
@@ -113,6 +113,24 @@ Fires when a delegated child agent returns or fails.
 
 When the delegated child runs **in the same process** (the default for `delegate_task`), `on_session_start` for the child finds the stashed delegation span and nests the child's root span directly under it — so the whole multi-agent run is **one connected trace**. When only a `SpanContext` is available (cross-process delegation), the child root attaches a span **link** to the delegation span instead and is tagged with `hermes.subagent.parent_session_id` for correlation. See [Limitations](/reference/limitations).
 
+### `pre_approval_request`
+
+Fires when a tool trips a dangerous-command approval rule and the agent blocks waiting on a human.
+
+- **Span op:** opens an `approval.{pattern_key}` span (within the turn; correlated to the gated tool via `gen_ai.tool.call.id`)
+- **Attributes set on start:** `hermes.approval.pattern_key`, `hermes.approval.surface`, `hermes.approval.command` / `hermes.approval.description` (preview-clipped), `gen_ai.tool.call.id`
+- **Correlation:** keyed off `turn_id` (which embeds the session id), so it lands in the right trace even though approvals run on a separate executor thread
+- **Observer-only:** the return value is ignored — the plugin **cannot veto or pre-answer** an approval (use `pre_tool_call` blocking for that)
+
+### `post_approval_response`
+
+Fires when the human answers (or the prompt times out).
+
+- **Span op:** closes the `approval.{pattern_key}` span
+- **Attributes set on end:** `hermes.approval.choice` (`once`/`session`/`always`/`deny`/`timeout`), `hermes.approval.granted`, `hermes.approval.timed_out`, `hermes.approval.duration_ms`
+- **Span status:** always `OK` — a denial or timeout is a legitimate human decision, not an error
+- **Metrics:** `hermes.approval.count{choice, pattern_key}` counter, `hermes.approval.duration{choice, pattern_key}` histogram
+
 ## Hook → span mapping
 
 ```text
@@ -128,6 +146,8 @@ post_api_request         close api.{model}        (OK)
 api_request_error        close api.{model}        (ERROR + exception + retry attrs/metrics)
 post_llm_call            close llm.{model}
 subagent_stop            close subagent.{role}   + status + duration + metrics
+pre_approval_request     open  approval.{pattern} (child of api/turn; → gated tool)
+post_approval_response   close approval.{pattern} + choice + wait duration + metrics
 on_session_end           close agent/cron        + turn summary + force-flush
 ```
 

--- a/website/docs/reference/span-attributes.md
+++ b/website/docs/reference/span-attributes.md
@@ -164,6 +164,8 @@ Emitted via `PeriodicExportingMetricReader` on backends that support OTLP metric
 | `hermes.subagent.duration` | Histogram | ms | `role` |
 | `hermes.api.error.count` | Counter | count | `error_type`, `status_class`, `retryable`, `model`, `provider` |
 | `hermes.retry.count` | Counter | count | `model`, `provider` |
+| `hermes.approval.count` | Counter | count | `choice`, `pattern_key` |
+| `hermes.approval.duration` | Histogram | ms | `choice`, `pattern_key` |
 
 `status_class` is bucketed to `2xx`/`3xx`/`4xx`/`5xx`/`network`/`other` to keep
 cardinality bounded. `hermes.retry.count` increments once per *retryable*


### PR DESCRIPTION
Closes #30

## Summary
Surface dangerous-command approval prompts as **`approval.<pattern_key>` spans** capturing the **human-decision wait time** and the decision. Approval wait is frequently the dominant chunk of a turn's wall-clock and was 100% invisible; it's also a security/audit signal (deny/timeout rates, what was approved).

## How it works
- `on_pre_approval_request` opens the span; `on_post_approval_response` closes it with the choice + wait duration.
- **Correlation** (the crux): the hooks carry `turn_id` = `"<session_id>:<task_id>:<hex>"`, so `session_id_from_turn_id()` recovers the session the plugin keys its spans on — the approval span lands in the right trace even though the approval system runs on its own executor thread. `gen_ai.tool.call.id` links it to the gated `tool.*` span.
- **Observer-only:** upstream ignores the return value, so telemetry can never veto/alter an approval (verified against `tools/approval.py` dispatch).
- **Status** always `OK` (a deny/timeout is a valid human outcome); `timeout` flagged via `hermes.approval.timed_out`.
- **Metrics:** `hermes.approval.count{choice, pattern_key}`, `hermes.approval.duration` (ms histogram).
- **Privacy:** `command`/`description` follow the `capture_previews` preview policy (suppressed when off; decision metadata still flows).
- Works on CLI (`surface=cli`) and gateway surfaces (`surface=gateway`: Telegram, Discord, Slack, …).

## Tests
- Integration (`test_approval_spans.py`): full grant flow (span under the turn, `gen_ai.tool.call.id` correlation, duration set); deny path; timeout (`timed_out=true`); `post` without `pre` doesn't raise; privacy suppression; two-exporter fan-out; metrics (count by choice/pattern + duration).
- Unit: `session_id_from_turn_id` (extract / placeholder / non-string) and `classify_approval_choice` (grants / deny / timeout / empty).

## Checks (local, matching CI)
- `ruff` ✓ · `black --check` ✓ · `pytest --cov-fail-under=85` → **586 passed**, coverage **91.96%** · docs build ✓

## Docs
`hooks.md` (both hooks + hook→span map), `span-hierarchy.md` (tree + `approval.*` section), `span-attributes.md` (metrics), `privacy.md` (command/description follow privacy controls), `README.md` (features).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
