### PR TITLE
feat(dashboard): in-process live telemetry store + /live API (zero-config foundation)

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -123,6 +123,18 @@
 # Also settable via HERMES_OTEL_SKILL_SPANS.
 # skill_spans: true
 
+# ── Live dashboard (in-process store) ─────────────────────────────────────────
+#
+# The built-in dashboard tab has a "Live" mode that renders your agent's recent
+# spans + metrics + logs from a small in-memory ring buffer kept in the plugin
+# process — so the dashboard works the instant you install the plugin, with NO
+# external backend configured. The buffer is bounded and cheap. Set false to
+# disable the in-process store entirely (the dashboard then needs a configured
+# backend to show anything).
+# Also settable via HERMES_OTEL_DASHBOARD_LIVE / HERMES_OTEL_DASHBOARD_LIVE_MAX_SPANS.
+# dashboard_live: true
+# dashboard_live_max_spans: 1000
+
 # ── Lifecycle / cleanup ───────────────────────────────────────────────────────
 
 # Orphan-turn sweep TTL. If a session's root span has been open longer than

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -35,6 +35,76 @@ from backends import (  # noqa: E402  (after the path shim above)
 router = APIRouter()
 
 
+def _get_live_store():
+    """Return the in-process LiveStore the tracer feeds, or None.
+
+    Must import the SAME ``hermes_otel.live_store`` module the tracer uses so
+    the singleton is shared (the dashboard runs in the same process). The
+    plugin package's parent is added to sys.path defensively in case this API
+    module was loaded before ``hermes_otel`` was importable.
+    """
+    try:
+        from hermes_otel.live_store import get_live_store
+    except Exception:
+        pkg_parent = _HERE.parent.parent  # …/plugins  (so `hermes_otel` resolves)
+        if str(pkg_parent) not in sys.path:
+            sys.path.insert(0, str(pkg_parent))
+        try:
+            from hermes_otel.live_store import get_live_store
+        except Exception:
+            return None
+    return get_live_store()
+
+
+@router.get("/live/status")
+def live_status() -> Dict[str, Any]:
+    """Whether the in-process live store is active, and its current fill."""
+    store = _get_live_store()
+    if store is None:
+        return {
+            "live": False,
+            "reason": "live store unavailable (dashboard_live off / no telemetry yet)",
+        }
+    return {"live": True, **store.stats()}
+
+
+@router.get("/live/spans")
+def live_spans(
+    since: int = Query(0, ge=0, description="Return items with seq > since"),
+    limit: int = Query(500, ge=1, le=5000),
+) -> Dict[str, Any]:
+    store = _get_live_store()
+    if store is None:
+        return {"live": False, "spans": [], "cursor": 0}
+    return {"live": True, "spans": store.spans(since=since, limit=limit), "cursor": store.cursor()}
+
+
+@router.get("/live/metrics")
+def live_metrics(
+    since: int = Query(0, ge=0),
+    limit: int = Query(2000, ge=1, le=10000),
+) -> Dict[str, Any]:
+    store = _get_live_store()
+    if store is None:
+        return {"live": False, "metrics": [], "cursor": 0}
+    return {
+        "live": True,
+        "metrics": store.metrics(since=since, limit=limit),
+        "cursor": store.cursor(),
+    }
+
+
+@router.get("/live/logs")
+def live_logs(
+    since: int = Query(0, ge=0),
+    limit: int = Query(2000, ge=1, le=10000),
+) -> Dict[str, Any]:
+    store = _get_live_store()
+    if store is None:
+        return {"live": False, "logs": [], "cursor": 0}
+    return {"live": True, "logs": store.logs(since=since, limit=limit), "cursor": store.cursor()}
+
+
 @router.get("/status")
 def status() -> Dict[str, Any]:
     """Report the active query backend + every configured backend."""

--- a/live_store.py
+++ b/live_store.py
@@ -1,0 +1,139 @@
+"""In-process bounded telemetry store for the zero-config dashboard.
+
+The plugin normally fires telemetry off to OTLP backends and keeps nothing
+locally. For the dashboard's **Live** mode we additionally retain a small,
+bounded, in-memory window of recent spans / metric events / logs so the
+dashboard (which runs in the *same* process and reads :func:`get_live_store`)
+can render the agent's activity in real time — with **no external backend
+required**.
+
+Design:
+- Three ring buffers (``collections.deque(maxlen=…)``) — old items drop off.
+- Every item carries a monotonically increasing ``seq`` cursor so the dashboard
+  can poll/stream incrementally (``since=<cursor>``) instead of re-fetching.
+- Thread-safe: Hermes dispatches hooks across executor threads, so all mutation
+  and reads take a lock. Reads return shallow copies.
+- Zero allocation when disabled: the store is only created/fed when
+  ``dashboard_live`` is on.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from typing import Any, Deque, Dict, List, Optional
+
+
+class LiveStore:
+    """Bounded, thread-safe ring buffers for recent spans / metrics / logs."""
+
+    def __init__(
+        self,
+        max_spans: int = 1000,
+        max_metrics: int = 5000,
+        max_logs: int = 2000,
+    ) -> None:
+        self._spans: Deque[Dict[str, Any]] = deque(maxlen=max_spans)
+        self._metrics: Deque[Dict[str, Any]] = deque(maxlen=max_metrics)
+        self._logs: Deque[Dict[str, Any]] = deque(maxlen=max_logs)
+        self._lock = threading.Lock()
+        self._seq = 0
+
+    def _next_seq(self) -> int:
+        self._seq += 1
+        return self._seq
+
+    # ── writers (called from the hot path — keep cheap, never raise) ──────
+
+    def add_span(self, span: Dict[str, Any]) -> None:
+        try:
+            with self._lock:
+                span["seq"] = self._next_seq()
+                self._spans.append(span)
+        except Exception:  # pragma: no cover — telemetry must never break the agent
+            pass
+
+    def add_metric(self, name: str, value: float, attributes: Dict[str, Any], ts_ns: int) -> None:
+        try:
+            with self._lock:
+                self._metrics.append(
+                    {
+                        "seq": self._next_seq(),
+                        "name": name,
+                        "value": value,
+                        "attributes": dict(attributes or {}),
+                        "time_unix_nano": ts_ns,
+                    }
+                )
+        except Exception:  # pragma: no cover
+            pass
+
+    def add_log(self, record: Dict[str, Any]) -> None:
+        try:
+            with self._lock:
+                record["seq"] = self._next_seq()
+                self._logs.append(record)
+        except Exception:  # pragma: no cover
+            pass
+
+    # ── readers (called from the dashboard API) ───────────────────────────
+
+    @staticmethod
+    def _since(items: Deque[Dict[str, Any]], since: int, limit: int) -> List[Dict[str, Any]]:
+        out = [it for it in items if it.get("seq", 0) > since]
+        if limit and len(out) > limit:
+            out = out[-limit:]
+        return out
+
+    def spans(self, since: int = 0, limit: int = 0) -> List[Dict[str, Any]]:
+        with self._lock:
+            return self._since(self._spans, since, limit)
+
+    def metrics(self, since: int = 0, limit: int = 0) -> List[Dict[str, Any]]:
+        with self._lock:
+            return self._since(self._metrics, since, limit)
+
+    def logs(self, since: int = 0, limit: int = 0) -> List[Dict[str, Any]]:
+        with self._lock:
+            return self._since(self._logs, since, limit)
+
+    def cursor(self) -> int:
+        with self._lock:
+            return self._seq
+
+    def stats(self) -> Dict[str, int]:
+        with self._lock:
+            return {
+                "spans": len(self._spans),
+                "metrics": len(self._metrics),
+                "logs": len(self._logs),
+                "cursor": self._seq,
+            }
+
+    def clear(self) -> None:
+        with self._lock:
+            self._spans.clear()
+            self._metrics.clear()
+            self._logs.clear()
+            self._seq = 0
+
+
+# Module-level singleton so the dashboard API (loaded separately by the Hermes
+# web server, but in the same process) reads the exact store the tracer feeds.
+_LIVE_STORE: Optional[LiveStore] = None
+_LIVE_LOCK = threading.Lock()
+
+
+def get_live_store(create: bool = False, **kwargs: Any) -> Optional[LiveStore]:
+    """Return the process-wide :class:`LiveStore`.
+
+    ``create=True`` lazily builds it (used by the tracer when ``dashboard_live``
+    is enabled). The dashboard API calls with ``create=False`` and treats
+    ``None`` as "live mode unavailable".
+    """
+    global _LIVE_STORE
+    if _LIVE_STORE is None and create:
+        with _LIVE_LOCK:
+            if _LIVE_STORE is None:
+                _LIVE_STORE = LiveStore(**kwargs)
+    return _LIVE_STORE

--- a/plugin_config.py
+++ b/plugin_config.py
@@ -141,6 +141,12 @@ class HermesOtelConfig:
     # overlap freely. Set false to keep only the hermes.skill.* attribute and
     # the skill_inferred counter.
     skill_spans: bool = True
+    # ── Live dashboard (in-process store) ───────────────────────────────
+    # Keep a bounded, in-memory window of recent spans + metrics + logs so the
+    # built-in dashboard's "Live" mode works with NO external backend. Cheap
+    # (ring buffers); set false to disable the in-process store entirely.
+    dashboard_live: bool = True
+    dashboard_live_max_spans: int = 1000
     # ── Multi-backend fan-out ───────────────────────────────────────────
     backends: Optional[Tuple[BackendConfig, ...]] = None
 
@@ -284,6 +290,7 @@ def _coerce_from_yaml(key: str, value: Any) -> Any:
         "capture_sender_id",
         "emit_genai_metrics",
         "skill_spans",
+        "dashboard_live",
     ):
         if isinstance(value, bool):
             return value
@@ -311,6 +318,7 @@ def _coerce_from_yaml(key: str, value: Any) -> Any:
         "span_batch_max_export_batch_size",
         "span_batch_export_timeout_ms",
         "conversation_history_max_chars",
+        "dashboard_live_max_spans",
     ):
         if isinstance(value, bool):
             return None  # bools are ints in python; reject explicitly
@@ -367,6 +375,8 @@ def _load_env_overrides() -> Dict[str, Any]:
     take("capture_sender_id", _parse_bool)
     take("emit_genai_metrics", _parse_bool)
     take("skill_spans", _parse_bool)
+    take("dashboard_live", _parse_bool)
+    take("dashboard_live_max_spans", _parse_int)
 
     proj = os.getenv(_ENV_PREFIX + "PROJECT_NAME", "").strip()
     if proj:

--- a/tests/integration/test_live_store_pipeline.py
+++ b/tests/integration/test_live_store_pipeline.py
@@ -1,0 +1,89 @@
+"""Integration: the live span processor + record_metric tap feed the store.
+
+Mirrors conftest's in-memory plugin wiring but adds a ``_LiveSpanProcessor`` and
+flips ``_live_active`` on — the same shape the zero-config (no-backend) path
+produces in ``_init_otlp_pipeline``.
+"""
+
+import pytest
+from hermes_otel import hooks
+from hermes_otel.live_store import LiveStore, get_live_store
+from hermes_otel.plugin_config import HermesOtelConfig
+
+
+@pytest.fixture()
+def live_plugin():
+    import hermes_otel.live_store as ls
+    import hermes_otel.tracer as tracer_mod
+    from hermes_otel.tracer import HermesOTelPlugin, _LiveSpanProcessor
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+
+    ls._LIVE_STORE = LiveStore()  # fresh store for this test
+    store = get_live_store()
+
+    provider = TracerProvider(resource=Resource.create({"service.name": "live-test"}))
+    provider.add_span_processor(_LiveSpanProcessor(store))
+
+    plugin = HermesOTelPlugin()
+    plugin.tracer = provider.get_tracer("live-test")
+    plugin._initialized = True
+    plugin._live_active = True
+    plugin.config = HermesOtelConfig(dashboard_live=True)
+
+    prev = tracer_mod._tracer
+    tracer_mod._tracer = plugin
+    try:
+        yield store, plugin
+    finally:
+        tracer_mod._tracer = prev
+        ls._LIVE_STORE = None
+        provider.shutdown()
+
+
+class TestLivePipeline:
+    def test_full_turn_lands_in_store(self, live_plugin):
+        store, _ = live_plugin
+        hooks.on_session_start(session_id="s1", model="gpt-4", platform="telegram")
+        hooks.on_pre_tool_call(
+            tool_name="bash", args={"command": "ls"}, task_id="t1", session_id="s1"
+        )
+        hooks.on_post_tool_call(
+            tool_name="bash", args={}, result="ok", task_id="t1", session_id="s1"
+        )
+        hooks.on_session_end(
+            session_id="s1", completed=True, interrupted=False, model="gpt-4", platform="telegram"
+        )
+
+        spans = store.spans()
+        names = sorted(s["name"] for s in spans)
+        assert "agent" in names and "tool.bash" in names
+        # span dicts carry the trace tree + attributes the dashboard renders
+        agent = next(s for s in spans if s["name"] == "agent")
+        assert len(agent["trace_id"]) == 32 and len(agent["span_id"]) == 16
+        assert agent["status"] in ("OK", "UNSET")
+        assert agent["attributes"].get("hermes.session.kind") == "session"
+        # tool span is a child (has a parent in the same trace)
+        tool = next(s for s in spans if s["name"] == "tool.bash")
+        assert tool["parent_span_id"] is not None
+        assert tool["trace_id"] == agent["trace_id"]
+
+    def test_metrics_tapped_without_meterprovider(self, live_plugin):
+        # No MeterProvider is wired (live-only), yet record_metric still feeds
+        # the live store because the tap runs before the meter guard.
+        store, plugin = live_plugin
+        assert plugin._meter is None
+        hooks.on_session_start(session_id="s2", model="gpt-4", platform="cli")
+        names = [m["name"] for m in store.metrics()]
+        assert "session_count" in names
+
+    def test_incremental_cursor(self, live_plugin):
+        store, _ = live_plugin
+        hooks.on_session_start(session_id="s3", model="gpt-4", platform="cli")
+        cur = store.cursor()
+        assert store.spans(since=cur) == []
+        hooks.on_session_end(
+            session_id="s3", completed=True, interrupted=False, model="gpt-4", platform="cli"
+        )
+        fresh = store.spans(since=cur)
+        assert any(s["name"] == "agent" for s in fresh)

--- a/tests/integration/test_multi_backend.py
+++ b/tests/integration/test_multi_backend.py
@@ -319,6 +319,7 @@ class TestPartialBackendFailure:
         _clear_backend_env(monkeypatch)
         cfg = HermesOtelConfig(
             backends=(BackendConfig(type="phoenix", endpoint="http://broken/v1/traces"),),
+            dashboard_live=False,  # isolate the OTLP path; live store would otherwise keep it up
         )
         plugin = HermesOTelPlugin(config=cfg)
 

--- a/tests/unit/test_live_store.py
+++ b/tests/unit/test_live_store.py
@@ -1,0 +1,68 @@
+"""Unit tests for the in-process live store (zero-config dashboard)."""
+
+from hermes_otel.live_store import LiveStore, get_live_store
+
+
+class TestLiveStore:
+    def test_bounded_ring_buffer(self):
+        s = LiveStore(max_spans=3)
+        for i in range(5):
+            s.add_span({"name": f"s{i}"})
+        names = [sp["name"] for sp in s.spans()]
+        assert names == ["s2", "s3", "s4"]  # oldest dropped
+
+    def test_monotonic_cursor_and_since(self):
+        s = LiveStore()
+        s.add_span({"name": "a"})
+        s.add_metric("m", 1, {}, 0)
+        s.add_span({"name": "b"})
+        cur_after_a = s.spans()[0]["seq"]
+        # since filters strictly greater
+        later = s.spans(since=cur_after_a)
+        assert [sp["name"] for sp in later] == ["b"]
+        assert s.cursor() == 3  # 3 items total, shared sequence
+
+    def test_seq_shared_across_signals(self):
+        s = LiveStore()
+        s.add_span({"name": "a"})
+        s.add_metric("m", 1, {}, 0)
+        s.add_log({"body": "x"})
+        assert s.spans()[0]["seq"] == 1
+        assert s.metrics()[0]["seq"] == 2
+        assert s.logs()[0]["seq"] == 3
+
+    def test_limit(self):
+        s = LiveStore()
+        for i in range(10):
+            s.add_span({"name": str(i)})
+        assert len(s.spans(limit=3)) == 3
+        assert [sp["name"] for sp in s.spans(limit=3)] == ["7", "8", "9"]
+
+    def test_metric_shape(self):
+        s = LiveStore()
+        s.add_metric("hermes.cost.usage", 0.05, {"model": "gpt-4"}, 1234)
+        m = s.metrics()[0]
+        assert m["name"] == "hermes.cost.usage"
+        assert m["value"] == 0.05
+        assert m["attributes"] == {"model": "gpt-4"}
+        assert m["time_unix_nano"] == 1234
+
+    def test_stats_and_clear(self):
+        s = LiveStore()
+        s.add_span({"name": "a"})
+        s.add_metric("m", 1, {}, 0)
+        st = s.stats()
+        assert st["spans"] == 1 and st["metrics"] == 1 and st["cursor"] == 2
+        s.clear()
+        assert s.stats() == {"spans": 0, "metrics": 0, "logs": 0, "cursor": 0}
+
+    def test_singleton_create_flag(self):
+        # create=False never builds it; create=True does and is sticky.
+        import hermes_otel.live_store as ls
+
+        ls._LIVE_STORE = None
+        assert get_live_store(create=False) is None
+        a = get_live_store(create=True, max_spans=10)
+        b = get_live_store(create=False)
+        assert a is b is not None
+        ls._LIVE_STORE = None  # cleanup for other tests

--- a/tests/unit/test_tracer_init.py
+++ b/tests/unit/test_tracer_init.py
@@ -4,6 +4,7 @@ import base64
 from unittest.mock import MagicMock, patch
 
 import pytest
+from hermes_otel.plugin_config import HermesOtelConfig
 from hermes_otel.tracer import HermesOTelPlugin
 
 
@@ -45,9 +46,26 @@ class TestInitPhoenix:
     def test_init_no_endpoint_returns_false(self, monkeypatch):
         _clear_backend_env(monkeypatch)
 
-        plugin = HermesOTelPlugin()
+        # With the live store disabled, no backend means truly nothing to do.
+        plugin = HermesOTelPlugin(config=HermesOtelConfig(dashboard_live=False))
         assert plugin.init() is False
         assert plugin.is_enabled is False
+
+    def test_init_no_backend_live_only_succeeds(self, monkeypatch):
+        _clear_backend_env(monkeypatch)
+        import hermes_otel.live_store as ls
+
+        # Zero-config default: no backend, but the in-process live store keeps
+        # the plugin enabled (the dashboard's Live mode). Patch the global
+        # provider set so we don't mutate process-wide OTel state.
+        plugin = HermesOTelPlugin(config=HermesOtelConfig(dashboard_live=True))
+        with patch("hermes_otel.tracer.trace.set_tracer_provider"):
+            try:
+                assert plugin.init() is True
+                assert plugin.is_enabled is True
+                assert plugin._live_active is True
+            finally:
+                ls._LIVE_STORE = None  # don't leak the singleton into other tests
 
     def test_init_with_explicit_endpoint_arg(self, monkeypatch):
         _clear_backend_env(monkeypatch)
@@ -136,7 +154,8 @@ class TestInitLangSmith:
         monkeypatch.setenv("LANGSMITH_TRACING", "false")
         monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2_key")
 
-        plugin = HermesOTelPlugin()
+        # dashboard_live off so the assertion isolates the LangSmith gate.
+        plugin = HermesOTelPlugin(config=HermesOtelConfig(dashboard_live=False))
         assert plugin.init() is False
 
 

--- a/tracer.py
+++ b/tracer.py
@@ -37,7 +37,7 @@ try:
     from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
     from opentelemetry.sdk.resources import Resource
-    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
     from opentelemetry.trace import INVALID_SPAN, set_span_in_context
 
@@ -52,6 +52,63 @@ except ImportError as e:
     print(
         f"[hermes-otel] OpenTelemetry import error: {e}. Run: pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http"
     )
+
+
+def _attr_value(v: Any) -> Any:
+    """Make a span attribute value JSON-friendly for the live store."""
+    if isinstance(v, (list, tuple)):
+        return [str(x) for x in v]
+    return v
+
+
+def _serialize_span(span: Any) -> Dict[str, Any]:
+    """Compact dict for the live dashboard — the trace tree + attributes."""
+    ctx = span.get_span_context()
+    parent = getattr(span, "parent", None)
+    start = span.start_time or 0
+    end = span.end_time or 0
+    try:
+        status = span.status.status_code.name  # OK / ERROR / UNSET
+    except Exception:
+        status = "UNSET"
+    return {
+        "trace_id": format(ctx.trace_id, "032x"),
+        "span_id": format(ctx.span_id, "016x"),
+        "parent_span_id": format(parent.span_id, "016x") if parent is not None else None,
+        "name": span.name,
+        "start_time_unix_nano": start,
+        "end_time_unix_nano": end,
+        "duration_ms": round((end - start) / 1e6, 3) if (end and start) else None,
+        "status": status,
+        "attributes": {k: _attr_value(v) for k, v in (span.attributes or {}).items()},
+    }
+
+
+if _OTEL_AVAILABLE:
+
+    class _LiveSpanProcessor(SpanProcessor):
+        """SpanProcessor that mirrors finished spans into the in-process LiveStore."""
+
+        def __init__(self, store: Any) -> None:
+            self._store = store
+
+        def on_start(self, span: Any, parent_context: Any = None) -> None:  # noqa: D401
+            pass
+
+        def on_end(self, span: Any) -> None:
+            try:
+                self._store.add_span(_serialize_span(span))
+            except Exception:  # pragma: no cover — never break the SDK export path
+                pass
+
+        def shutdown(self) -> None:
+            pass
+
+        def force_flush(self, timeout_millis: int = 30000) -> bool:
+            return True
+
+else:  # pragma: no cover — plugin is unusable without OTel
+    _LiveSpanProcessor = None  # type: ignore[assignment, misc]
 
 
 class HermesOTelPlugin:
@@ -79,6 +136,8 @@ class HermesOTelPlugin:
         # re-create the tracer singleton automatically get a fresh set.
         self.sessions = SessionState()
         self._initialized = False
+        # True when the in-process live store (zero-config dashboard) is wired.
+        self._live_active = False
         # OTLP fan-out: one BatchSpanProcessor + one PeriodicExportingMetricReader
         # per backend. The singular ``_span_processor`` / ``_metric_reader``
         # attributes are kept as aliases pointing at the first entry so legacy
@@ -203,6 +262,14 @@ class HermesOTelPlugin:
         """
         rb = _backends.resolve_from_env()
         if rb is None:
+            # No external backend — but the in-process live store still gives a
+            # working zero-config dashboard. Stand up a live-only pipeline.
+            if self.config.dashboard_live:
+                logger.info(
+                    "[hermes-otel] No OTLP backend configured — running in "
+                    "live-only mode (in-process dashboard store)."
+                )
+                return self._init_otlp_pipeline([])
             logger.warning(
                 "[hermes-otel] ✗ No backend configured "
                 "(set OTEL_PHOENIX_ENDPOINT, OTEL_SIGNOZ_ENDPOINT, "
@@ -305,6 +372,21 @@ class HermesOTelPlugin:
                 provider_kwargs["sampler"] = ParentBased(TraceIdRatioBased(self.config.sample_rate))
             provider = TracerProvider(**provider_kwargs)
 
+            # In-process live store for the zero-config dashboard. Added FIRST so
+            # the dashboard renders the agent's activity even with no OTLP
+            # backend configured — install the plugin, open the tab, see traces.
+            self._live_active = False
+            if self.config.dashboard_live and _LiveSpanProcessor is not None:
+                from .live_store import get_live_store
+
+                store = get_live_store(
+                    create=True,
+                    max_spans=self.config.dashboard_live_max_spans,
+                )
+                if store is not None:
+                    provider.add_span_processor(_LiveSpanProcessor(store))
+                    self._live_active = True
+
             metric_readers: List[Any] = []
 
             for b in backends:
@@ -345,11 +427,14 @@ class HermesOTelPlugin:
                     + (" (traces only)" if b.supports_traces and not b.supports_metrics else "")
                 )
 
-            if not self._span_processors:
+            # Proceed when *either* an OTLP backend or the live store is active.
+            # (Live-only = the zero-config dashboard with no external collector.)
+            if not self._span_processors and not self._live_active:
                 return False
 
             # Back-compat singular aliases — first entry wins.
-            self._span_processor = self._span_processors[0]
+            if self._span_processors:
+                self._span_processor = self._span_processors[0]
             if self._metric_readers:
                 self._metric_reader = self._metric_readers[0]
 
@@ -380,6 +465,11 @@ class HermesOTelPlugin:
                     f"[hermes-otel] ✓ Multi-backend fan-out active "
                     f"({len(self._span_processors)} collectors, "
                     f"{len(self._metric_readers)} with metrics)"
+                )
+            if self._live_active:
+                logger.info(
+                    "[hermes-otel] ✓ Live dashboard store active"
+                    + ("" if self._span_processors else " (no OTLP backend — live-only)")
                 )
             return True
         except Exception as e:
@@ -516,6 +606,20 @@ class HermesOTelPlugin:
 
     def record_metric(self, name: str, value: float, attributes: dict = None, bucket: str = None):
         """Record a metric value."""
+        # Mirror into the live store BEFORE the meter guard so live metrics work
+        # even with no OTLP backend (no MeterProvider) — the zero-config path.
+        if self._live_active:
+            try:
+                import time as _time
+
+                from .live_store import get_live_store
+
+                store = get_live_store()
+                if store is not None:
+                    store.add_metric(name, value, attributes or {}, _time.time_ns())
+            except Exception:  # pragma: no cover — never break the hot path
+                pass
+
         if not self._meter:
             return
 

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -56,6 +56,8 @@ Each of these overrides the corresponding field in `config.yaml`. See [`config.y
 | `HERMES_OTEL_FORCE_FLUSH_ON_SESSION_END` | `force_flush_on_session_end` | bool |
 | `HERMES_OTEL_EMIT_GENAI_METRICS` | `emit_genai_metrics` | bool |
 | `HERMES_OTEL_SKILL_SPANS` | `skill_spans` | bool |
+| `HERMES_OTEL_DASHBOARD_LIVE` | `dashboard_live` | bool |
+| `HERMES_OTEL_DASHBOARD_LIVE_MAX_SPANS` | `dashboard_live_max_spans` | int |
 
 ## Debug / diagnostics
 


### PR DESCRIPTION
## Dashboard overhaul — Phase 0a: the zero-config live store

First phase toward the "crown jewel" dashboard. The headline: **the built-in dashboard now works the instant you install the plugin — no external backend required.**

### The unlock
The plugin used to fire telemetry off to OTLP and keep nothing locally, so the dashboard could only ever proxy a configured backend (Phoenix/Tempo/…). This adds a small, bounded, in-process store that the dashboard (same process) reads directly.

- **`live_store.py`** — thread-safe ring buffers (spans / metrics / logs), monotonic `seq` cursor for incremental polling, process-wide singleton.
- **`tracer.py`** — a `_LiveSpanProcessor` mirrors finished spans into the store; `record_metric` taps it *before* the meter guard (live metrics work even with no MeterProvider). The pipeline now stands up with **only** the live store when no OTLP backend is configured (**live-only mode**) — so the plugin is enabled and produces telemetry the dashboard can render with zero config.
- **`dashboard/plugin_api.py`** — `/live/status`, `/live/spans`, `/live/metrics`, `/live/logs` (cursor-based incremental reads).
- **Config** — `dashboard_live` (default `true`) + `dashboard_live_max_spans`.

### ⚠️ Contract change
With `dashboard_live` on (the default), **"no backend configured" now succeeds in live-only mode** instead of `init()` returning `False`. The plugin becomes enabled and buffers a bounded window of telemetry in memory. Set `dashboard_live: false` to restore the old "needs a backend" behavior. The 3 tests that asserted the old contract were updated (and a new test asserts the live-only success path).

### Tests
- Unit: `LiveStore` (bounded ring buffer, cursor, since-filtering, limit, stats/clear, singleton).
- Integration: a zero-backend turn lands in the store with the full trace tree + attributes; metrics tapped without a MeterProvider; incremental cursor.
- `ruff` ✓ · `black` ✓ · `pytest --cov-fail-under=85` → **597 passed**, coverage **92.19%**.

### Scope
Backend foundation only — the **existing trace browser is unchanged**. The frontend (esbuild build pipeline + Live UI + all-signals views) lands in the next phases. This PR is independently mergeable and de-risks the architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
