### PR TITLE
feat(backends): add Weave (W&B) backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Tested with:
 - **[Uptrace](https://uptrace.dev)** (self-hosted) — traces + metrics + logs
 - **[OpenObserve](https://openobserve.ai)** (self-hosted) — traces + metrics + logs
 - **[Honeycomb](https://www.honeycomb.io/)** (cloud) — traces + metrics + logs — see [HONEYCOMB.md](HONEYCOMB.md)
+- **[W&B Weave](https://docs.wandb.ai/weave/)** (cloud / Dedicated Cloud / self-managed) — traces only
 
 Any OTLP HTTP endpoint should work.
 
@@ -200,13 +201,14 @@ path or starve the others — span end is just a non-blocking enqueue. Both
 trace and metrics export run in parallel across all configured backends.
 
 Supported `type` values: `phoenix`, `langfuse`, `signoz`, `jaeger`, `tempo`,
-`otlp`, `lgtm`, `uptrace`, `openobserve`. Use `otlp` for any collector
+`otlp`, `lgtm`, `uptrace`, `openobserve`, `honeycomb`, `weave`. Use `otlp` for any collector
 that doesn't have a dedicated type. Backends marked
-traces-only (`langfuse`, `jaeger`, `tempo`) are auto-detected and skip
+traces-only (`langfuse`, `jaeger`, `tempo`, `weave`) are auto-detected and skip
 the metrics reader. Override with `metrics: true|false` per entry if
 needed. See `config.yaml.example` for the full list of fields each type
 accepts — Uptrace takes a `dsn:` for the `uptrace-dsn` header, OpenObserve
-takes `user:` / `password:` for HTTP Basic auth, and so on.
+takes `user:` / `password:` for HTTP Basic auth, and Weave takes W&B routing
+fields (`entity` / `project`) for `wandb.entity` / `wandb.project`.
 
 ### Full-conversation capture
 
@@ -323,6 +325,19 @@ export OTEL_PROJECT_NAME=hermes-otel-honeycomb
 For region selection (`us`/`eu`), a dataset, and the metrics `unknown_metrics`
 gotcha, use the multi-backend `config.yaml` form instead — see [HONEYCOMB.md](HONEYCOMB.md).
 
+### W&B Weave
+```bash
+export WANDB_API_KEY="..."                 # wandb-api-key header
+export WANDB_ENTITY="my-team"              # Resource: wandb.entity
+export WANDB_PROJECT="hermes-agent"        # Resource: wandb.project
+# Optional Dedicated Cloud / Self-Managed:
+# export OTEL_WEAVE_BASE_URL="https://acme.wandb.io"
+```
+
+Weave is trace ingest only by default. The dedicated `type: weave` config
+also supports `api_key_env`, `entity`, `project`, `base_url`, and explicit
+`endpoint`; see `config.yaml.example` and the website docs for details.
+
 ### Optional
 ```bash
 export OTEL_PROJECT_NAME="hermes-agent"   # Shown in Phoenix
@@ -339,7 +354,7 @@ export HERMES_OTEL_DEBUG=true
 
 Debug output is written to `~/.hermes/plugins/hermes_otel/debug.log` and does not clutter hermes stdout.
 
-**Priority order:** LangSmith (if `LANGSMITH_TRACING=true`) > Langfuse (if credentials set) > SigNoz (`OTEL_SIGNOZ_ENDPOINT`) > Uptrace (`OTEL_UPTRACE_ENDPOINT` + DSN) > OpenObserve (`OTEL_OPENOBSERVE_ENDPOINT` + creds) > Honeycomb (`HONEYCOMB_API_KEY`) > Jaeger (`OTEL_JAEGER_ENDPOINT`) > Tempo (`OTEL_TEMPO_ENDPOINT`) > Phoenix (`OTEL_PHOENIX_ENDPOINT`).
+**Priority order:** LangSmith (if `LANGSMITH_TRACING=true`) > Langfuse (if credentials set) > SigNoz (`OTEL_SIGNOZ_ENDPOINT`) > Uptrace (`OTEL_UPTRACE_ENDPOINT` + DSN) > OpenObserve (`OTEL_OPENOBSERVE_ENDPOINT` + creds) > Weave (`WANDB_API_KEY` + `WANDB_ENTITY` + `WANDB_PROJECT`) > Honeycomb (`HONEYCOMB_API_KEY`) > Jaeger (`OTEL_JAEGER_ENDPOINT`) > Tempo (`OTEL_TEMPO_ENDPOINT`) > Phoenix (`OTEL_PHOENIX_ENDPOINT`).
 
 ### Shaping knobs — `config.yaml` and `HERMES_OTEL_*` env vars
 
@@ -499,7 +514,7 @@ Reasoning ("thinking") tokens are emitted only by reasoning-capable models that 
 
 LLM and API spans also expose standard GenAI request/response metadata where Hermes provides it, including `gen_ai.provider.name`, `gen_ai.request.model`, request parameters such as `gen_ai.request.temperature`, and response fields such as `gen_ai.response.model` and `gen_ai.response.finish_reasons`.
 
-Phoenix uses `input.value` and `output.value` for previews. When full prompt/response capture is explicitly enabled, the plugin also writes the corresponding GenAI content attributes (`gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.system_instructions`).
+Phoenix uses `input.value` and `output.value` for previews. Weave and other GenAI-aware backends also receive privacy-gated `gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.tool.call.arguments`, and `gen_ai.tool.call.result` where Hermes exposes the content. When full prompt/response capture is explicitly enabled, the plugin writes the corresponding full GenAI content attributes (`gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.system_instructions`).
 
 ## Trace propagation to MCP servers
 
@@ -545,6 +560,7 @@ This plugin speaks plain OTLP/HTTP, so any OTLP-compatible backend should work t
 | [OpenObserve](https://openobserve.ai) | traces + metrics + logs | Local (single binary / docker) · Cloud | OSS, no account · free tier + paid cloud | ✅ |
 | [Uptrace](https://uptrace.dev) | traces + metrics + logs | Local (docker compose) · Cloud | OSS, no account · free tier + paid cloud | ✅ |
 | [Honeycomb](https://www.honeycomb.io) | traces + metrics | Cloud only | Free tier + paid | 🔲 |
+| [W&B Weave](https://docs.wandb.ai/weave/) | traces | W&B Cloud · Dedicated Cloud · Self-Managed | W&B account | ✅ |
 | [New Relic](https://newrelic.com) | traces + metrics + logs | Cloud only | Free tier (100 GB/mo) + paid | 🔲 |
 | [Elastic APM](https://www.elastic.co/observability/application-performance-monitoring) | traces + metrics + logs | Local (docker) · Elastic Cloud | OSS self-host · trial + paid cloud | 🔲 |
 | [Datadog](https://www.datadoghq.com) | traces + metrics + logs | Cloud only | Trial only, paid thereafter | 🔲 |
@@ -553,13 +569,14 @@ This plugin speaks plain OTLP/HTTP, so any OTLP-compatible backend should work t
 
 - **Fully offline / no account ever:** Phoenix, Langfuse (self-hosted), Jaeger, SigNoz, Grafana Tempo+Mimir, OpenObserve, Uptrace, Elastic APM self-host. All runnable via `docker compose up`.
 - **Free SaaS (personal / hobby tier, no credit card):** Langfuse Cloud, LangSmith, SigNoz Cloud, Grafana Cloud, Honeycomb, New Relic. Best if you don't want to run infrastructure.
+- **W&B agent experiment tracking:** W&B Weave, using OTLP trace ingest plus GenAI agent attributes.
 - **Paid only (credit card required after trial):** Datadog, Dynatrace, LangSmith self-hosted (enterprise plan).
 
 > Free-tier limits change frequently — check each vendor's pricing page before committing. The table reflects what's advertised as of this writing.
 
 ### Signals note
 
-Jaeger and Tempo are both **traces only**. If you want both spans and the token/tool/cost metrics this plugin emits (via `PeriodicExportingMetricReader`), pair them with Prometheus, or pick one of the traces+metrics backends above.
+Jaeger, Tempo, and Weave are **traces only** by default. If you want both spans and the token/tool/cost metrics this plugin emits (via `PeriodicExportingMetricReader`), pair them with Prometheus, or pick one of the traces+metrics backends above.
 
 ## Current limitations
 
@@ -567,3 +584,4 @@ Jaeger and Tempo are both **traces only**. If you want both spans and the token/
 - **Langfuse auth** — Requires both public and secret keys; Basic Auth is constructed automatically. If only one key is set, Langfuse mode won't activate.
 - **No gRPC** — Only OTLP over HTTP/JSON is used. gRPC exporters are not included.
 - **Single session per run** — Span tracking is in-memory; if Hermes restarts mid-session, active spans are lost. A TTL-based sweeper finalizes abandoned sessions (see "Orphan-span sweep" above), but the orphaned process's buffered spans still need a graceful `atexit` to flush.
+- **Weave trace-only ingest** — `type: weave` disables metrics/logs by default and routes all spans in one Hermes process to one `wandb.entity` / `wandb.project`.

--- a/backends.py
+++ b/backends.py
@@ -28,7 +28,7 @@ from typing import Callable, Dict, List, Optional
 from .plugin_config import BackendConfig
 
 # Backend types whose collectors do not accept OTLP metrics. Pure traces.
-_TRACES_ONLY = {"langfuse", "jaeger", "tempo"}
+_TRACES_ONLY = {"langfuse", "jaeger", "tempo", "weave"}
 
 # Backend types whose collectors accept OTLP logs. Everything else defaults
 # to "logs off" — Phoenix/Langfuse/Jaeger/Tempo don't implement /v1/logs, and
@@ -49,6 +49,7 @@ _DISPLAY_NAMES = {
     "uptrace": "Uptrace",
     "openobserve": "OpenObserve",
     "honeycomb": "Honeycomb",
+    "weave": "W&B Weave",
 }
 
 # Honeycomb OTLP/HTTP base endpoints by region (the SDK-style ``/v1/traces``
@@ -59,6 +60,8 @@ _HONEYCOMB_ENDPOINTS = {
     "eu": "https://api.eu1.honeycomb.io",
 }
 
+_WEAVE_DEFAULT_ENDPOINT = "https://trace.wandb.ai/otel/v1/traces"
+
 # Priority for env-var-driven single-backend detection. First backend whose
 # required env vars are fully set wins.
 _ENV_PRIORITY = [
@@ -66,6 +69,7 @@ _ENV_PRIORITY = [
     "signoz",
     "uptrace",
     "openobserve",
+    "weave",
     "honeycomb",
     "jaeger",
     "tempo",
@@ -89,6 +93,7 @@ class _ResolvedBackend:
     supports_traces: bool = True
     supports_metrics: bool = True
     supports_logs: bool = False
+    resource_attributes: Optional[Dict[str, str]] = None
 
 
 # ── Shared helpers ─────────────────────────────────────────────────────────
@@ -420,6 +425,76 @@ def _resolve_honeycomb(bc: BackendConfig) -> _ResolvedBackend:
     )
 
 
+def _weave_endpoint_from_base(base_url: Optional[str]) -> str:
+    """Build Weave's OTLP traces endpoint from a W&B base URL."""
+    base = (base_url or "").strip().rstrip("/")
+    if not base:
+        return _WEAVE_DEFAULT_ENDPOINT
+    if base.endswith("/v1/traces"):
+        return base
+    if base.endswith("/otel") or base.endswith("/traces/otel"):
+        return f"{base}/v1/traces"
+    if "trace.wandb.ai" in base:
+        return f"{base}/otel/v1/traces"
+    # Dedicated Cloud / Self-Managed use the org host plus the /traces prefix.
+    return f"{base}/traces/otel/v1/traces"
+
+
+def _resolve_weave(bc: BackendConfig) -> _ResolvedBackend:
+    """Resolve W&B Weave's dedicated OTLP trace ingest endpoint.
+
+    Weave authenticates trace ingest with the ``wandb-api-key`` header and
+    routes spans by OTel Resource attributes: ``wandb.entity`` and
+    ``wandb.project``. The latter can be supplied either on this backend entry
+    (``entity`` / ``project``) or globally via ``resource_attributes``.
+    """
+    key = _resolve_secret(
+        bc.api_key,
+        bc.api_key_env,
+        ["WANDB_API_KEY"],
+    )
+    if not key:
+        raise ValueError("weave requires api_key (or set WANDB_API_KEY)")
+
+    ep = (
+        bc.endpoint or os.getenv("OTEL_WEAVE_ENDPOINT", "") or os.getenv("WANDB_OTLP_ENDPOINT", "")
+    ).strip()
+    if not ep:
+        ep = _weave_endpoint_from_base(
+            bc.base_url or os.getenv("OTEL_WEAVE_BASE_URL", "") or os.getenv("WANDB_BASE_URL", "")
+        )
+
+    headers: Dict[str, str] = {"wandb-api-key": key}
+    headers.update(bc.headers or {})
+
+    resource_attrs: Dict[str, str] = {}
+    entity = _resolve_secret(
+        bc.entity,
+        bc.entity_env,
+        ["WANDB_ENTITY", "DEFAULT_WANDB_ENTITY"],
+    )
+    project = _resolve_secret(
+        bc.project,
+        bc.project_env,
+        ["WANDB_PROJECT", "DEFAULT_WANDB_PROJECT"],
+    )
+    if entity:
+        resource_attrs["wandb.entity"] = entity
+    if project:
+        resource_attrs["wandb.project"] = project
+
+    return _ResolvedBackend(
+        type="weave",
+        endpoint=ep,
+        display_name=_display(bc, "weave"),
+        headers=headers,
+        supports_traces=_traces_for(bc.traces),
+        supports_metrics=_metrics_for("weave", bc.metrics),
+        supports_logs=_logs_for("weave", bc.logs),
+        resource_attributes=resource_attrs or None,
+    )
+
+
 _RESOLVERS: Dict[str, Callable[[BackendConfig], _ResolvedBackend]] = {
     "phoenix": _resolve_phoenix,
     "langfuse": _resolve_langfuse,
@@ -431,6 +506,7 @@ _RESOLVERS: Dict[str, Callable[[BackendConfig], _ResolvedBackend]] = {
     "uptrace": _resolve_uptrace,
     "openobserve": _resolve_openobserve,
     "honeycomb": _resolve_honeycomb,
+    "weave": _resolve_weave,
 }
 
 
@@ -457,7 +533,12 @@ def resolve_from_env() -> Optional[_ResolvedBackend]:
     """
     for backend_type in _ENV_PRIORITY:
         try:
-            return resolve(BackendConfig(type=backend_type))
+            rb = resolve(BackendConfig(type=backend_type))
+            if backend_type == "weave":
+                attrs = rb.resource_attributes or {}
+                if not (attrs.get("wandb.entity") and attrs.get("wandb.project")):
+                    continue
+            return rb
         except ValueError:
             continue
     return None

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -187,6 +187,10 @@
 #   honeycomb    — Honeycomb (SaaS). Traces + metrics + logs. Set `api_key`
 #                  (or `api_key_env`) and `region:` (us|eu); the plugin fills in
 #                  the endpoint and `x-honeycomb-team` header. See HONEYCOMB.md.
+#   weave        — W&B Weave (SaaS / Dedicated Cloud / Self-Managed). Traces
+#                  only by default. Set `api_key_env`, `entity`, and `project`;
+#                  the plugin fills in the endpoint, `wandb-api-key` header, and
+#                  `wandb.entity` / `wandb.project` resource attributes.
 #
 # `traces: false`, `metrics: false`, or `logs: false` per entry opt a backend
 # out of that signal. This is useful when an entry is dashboard/query-only
@@ -296,6 +300,21 @@
 #     # dataset: hermes
 #     # endpoint:                             # optional; overrides the region default
 # capture_logs: true
+
+# ── W&B Weave quickstart ──────────────────────────────────────────────────────
+#
+# W&B Weave ingests OTLP traces at https://trace.wandb.ai/otel/v1/traces and
+# routes them by OTel Resource attributes `wandb.entity` and `wandb.project`.
+# It is traces-only by default; keep metrics/logs in Phoenix, LGTM, SigNoz, etc.
+#
+# backends:
+#   - type: weave
+#     api_key_env: WANDB_API_KEY              # or inline api_key: (discouraged)
+#     entity: my-team                         # or entity_env: WANDB_ENTITY
+#     project: hermes-agent                   # or project_env: WANDB_PROJECT
+#     # Dedicated Cloud / Self-Managed:
+#     # base_url: https://acme.wandb.io       # plugin appends /traces/otel/v1/traces
+#     # endpoint: https://trace.wandb.ai/otel/v1/traces  # optional full override
 
 # ── LangSmith (env-var only, alternative to the above) ────────────────────────
 #

--- a/hooks.py
+++ b/hooks.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import os
 import time
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Dict, List, Optional, TypedDict
 
 from .debug_utils import debug_log
@@ -69,6 +70,7 @@ class HookContext(TypedDict, total=False):
 
 
 _MAX_SUMMARY_CHARS = 500
+_DEFAULT_AGENT_NAME = "hermes-agent"
 
 
 def _clip_joined(items: List[str], sep: str, limit: int = _MAX_SUMMARY_CHARS) -> str:
@@ -324,6 +326,45 @@ def _gen_ai_attributes(
     return attrs
 
 
+def _package_version() -> Optional[str]:
+    try:
+        return version("hermes-otel")
+    except PackageNotFoundError:
+        return None
+
+
+def _weave_turn_attributes(
+    session_id: Optional[str],
+    extra_kwargs: Optional[dict] = None,
+) -> Dict[str, Any]:
+    """Attributes that make raw OTLP spans render cleanly in Weave's Agents UI."""
+    kwargs = extra_kwargs or {}
+    agent_name = truncate_string(kwargs.get("agent_name") or _DEFAULT_AGENT_NAME, 200)
+    attrs: Dict[str, Any] = {
+        "gen_ai.agent.name": agent_name,
+        "wandb.is_turn": True,
+    }
+    session_text = truncate_string(session_id, 200)
+    if session_text:
+        attrs["wandb.thread_id"] = session_text
+    package_version = _package_version()
+    if package_version:
+        attrs["weave.agent.version"] = package_version
+    return attrs
+
+
+def _message_json(role: str, content: Any) -> Optional[str]:
+    if content is None or content == "":
+        return None
+    try:
+        return json.dumps(
+            [{"role": role, "content": str(content)}],
+            ensure_ascii=False,
+        )
+    except (TypeError, ValueError):
+        return None
+
+
 def _provider_attributes(provider: Any) -> Dict[str, str]:
     """Return current and compatibility provider attributes."""
     value = truncate_string(provider, 120)
@@ -549,6 +590,7 @@ def _start_session_span(
     }
     attributes.update(_provider_attributes(extra_kwargs.get("provider") or platform))
     attributes.update(_gen_ai_attributes(session_id, "invoke_agent", extra_kwargs))
+    attributes.update(_weave_turn_attributes(session_id, extra_kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, extra_kwargs))
     if synthesized:
         attributes["hermes.session.synthesized"] = True
@@ -632,6 +674,7 @@ def on_session_end(
     }
     attributes.update(_provider_attributes(kwargs.get("provider") or platform))
     attributes.update(_gen_ai_attributes(session_id, "invoke_agent", kwargs))
+    attributes.update(_weave_turn_attributes(session_id, kwargs))
     attributes.update(_correlation_attributes(tracer, session_id, kwargs))
 
     # Drain the aggregators in one shot. Everything this session buffered
@@ -762,6 +805,7 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
     attributes: Dict[str, Any] = {
         "tool.name": tool_name,
         "gen_ai.tool.name": tool_name,
+        "gen_ai.tool.call.id": truncate_string(task_id, 200),
     }
     preview = _preview(
         json.dumps(args) if args else "{}",
@@ -769,6 +813,7 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
     )
     if preview is not None:
         attributes["input.value"] = preview
+        attributes["gen_ai.tool.call.arguments"] = preview
     if (
         tracer.config.capture_previews
         and tool_name.startswith("mcp_")
@@ -839,7 +884,10 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
         )
 
     # Build final attributes — OpenInference conventions for Phoenix Info
-    attributes: Dict[str, Any] = {}
+    attributes: Dict[str, Any] = {
+        "gen_ai.tool.name": tool_name,
+        "gen_ai.tool.call.id": truncate_string(task_id, 200),
+    }
 
     # Parse the result once
     if isinstance(result, dict):
@@ -870,6 +918,7 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
     )
     if preview is not None:
         attributes["output.value"] = preview
+        attributes["gen_ai.tool.call.result"] = preview
     if (
         tracer.config.capture_previews
         and tool_name.startswith("mcp_")
@@ -1095,6 +1144,7 @@ def on_pre_llm_call(
         if full is not None:
             attributes["input.value"] = full
             attributes["input.mime_type"] = "application/json"
+            attributes["gen_ai.input.messages"] = full
             attributes["hermes.conversation.message_count"] = len(conversation_history)
         else:
             preview = _preview(
@@ -1103,6 +1153,9 @@ def on_pre_llm_call(
             )
             if preview is not None:
                 attributes["input.value"] = preview
+                messages = _message_json("user", preview)
+                if messages is not None:
+                    attributes["gen_ai.input.messages"] = messages
     else:
         preview = _preview(
             user_message,
@@ -1110,6 +1163,9 @@ def on_pre_llm_call(
         )
         if preview is not None:
             attributes["input.value"] = preview
+            messages = _message_json("user", preview)
+            if messages is not None:
+                attributes["gen_ai.input.messages"] = messages
 
     span = tracer.start_span(
         name=f"llm.{model}",
@@ -1177,6 +1233,9 @@ def on_post_llm_call(
     )
     if preview is not None:
         attributes["output.value"] = preview
+        messages = _message_json("assistant", preview)
+        if messages is not None:
+            attributes["gen_ai.output.messages"] = messages
 
     # Pop parent — tool spans after this won't nest under this LLM call
     tracer.spans.pop_parent(session_id=session_id)

--- a/plugin_config.py
+++ b/plugin_config.py
@@ -40,13 +40,15 @@ class BackendConfig:
     discouraged because the file is plaintext.
     """
 
-    type: str  # phoenix | langfuse | signoz | jaeger | tempo | otlp | honeycomb
+    type: str  # phoenix | langfuse | signoz | jaeger | tempo | otlp | honeycomb | weave
     name: Optional[str] = None  # display name (defaults to type)
     endpoint: Optional[str] = None  # OTLP HTTP traces URL
     headers: Optional[Dict[str, str]] = None  # extra/override HTTP headers
     traces: Optional[bool] = None  # None = on. False = dashboard/query-only, no trace export.
     metrics: Optional[bool] = None  # None = auto (off for langfuse/jaeger/tempo)
-    logs: Optional[bool] = None  # None = auto (on for signoz/otlp/lgtm/uptrace/openobserve)
+    logs: Optional[bool] = (
+        None  # None = auto (on for signoz/otlp/lgtm/uptrace/openobserve/honeycomb)
+    )
     # Langfuse credentials
     public_key: Optional[str] = None
     secret_key: Optional[str] = None
@@ -72,6 +74,14 @@ class BackendConfig:
     api_key_env: Optional[str] = None
     dataset: Optional[str] = None
     region: Optional[str] = None
+    # W&B Weave routing. Weave authenticates with ``api_key`` and routes spans
+    # by OTel Resource attributes. These fields are copied to ``wandb.entity``
+    # / ``wandb.project``; users can alternatively set them in top-level
+    # ``resource_attributes``.
+    entity: Optional[str] = None
+    entity_env: Optional[str] = None
+    project: Optional[str] = None
+    project_env: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "hermes-otel"
 version = "0.1.0"
-description = "OpenTelemetry plugin for Hermes Agent — auto-export LLM traces to Phoenix, Langfuse, LangSmith, SigNoz, Jaeger, Tempo."
+description = "OpenTelemetry plugin for Hermes Agent — auto-export LLM traces to Phoenix, Langfuse, LangSmith, SigNoz, Jaeger, Tempo, and W&B Weave."
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.9"
@@ -25,6 +25,7 @@ keywords = [
     "langsmith",
     "signoz",
     "jaeger",
+    "weave",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/tests/integration/test_inmemory_pipeline.py
+++ b/tests/integration/test_inmemory_pipeline.py
@@ -1,6 +1,8 @@
 """Integration tests using InMemorySpanExporter to verify the full
 hook -> span -> export pipeline without any network I/O."""
 
+from dataclasses import replace
+
 import pytest
 from hermes_otel.hooks import (
     on_post_api_request,
@@ -27,6 +29,10 @@ class TestToolSpanExport:
         assert span.name == "tool.bash"
         attrs = dict(span.attributes)
         assert attrs["tool.name"] == "bash"
+        assert attrs["gen_ai.tool.name"] == "bash"
+        assert attrs["gen_ai.tool.call.id"] == "t1"
+        assert attrs["gen_ai.tool.call.arguments"] == '{"cmd": "ls"}'
+        assert attrs["gen_ai.tool.call.result"] == "file.txt"
         assert attrs["openinference.span.kind"] == "TOOL"
         assert "file.txt" in attrs["output.value"]
 
@@ -59,6 +65,33 @@ class TestToolSpanExport:
 
         assert span.status.status_code == StatusCode.OK
 
+    def test_tool_content_aliases_respect_capture_previews(self, inmemory_otel_setup):
+        exporter, plugin = inmemory_otel_setup
+        plugin.config = replace(plugin.config, capture_previews=False)
+
+        on_pre_tool_call(
+            tool_name="bash",
+            args={"cmd": "secret"},
+            task_id="t1",
+            session_id="s1",
+        )
+        on_post_tool_call(
+            tool_name="bash",
+            args={"cmd": "secret"},
+            result="secret output",
+            task_id="t1",
+            session_id="s1",
+        )
+
+        span = exporter.get_finished_spans()[0]
+        attrs = dict(span.attributes)
+        assert attrs["gen_ai.tool.name"] == "bash"
+        assert attrs["gen_ai.tool.call.id"] == "t1"
+        assert "input.value" not in attrs
+        assert "output.value" not in attrs
+        assert "gen_ai.tool.call.arguments" not in attrs
+        assert "gen_ai.tool.call.result" not in attrs
+
 
 class TestLlmSpanExport:
     def test_llm_span_exports(self, inmemory_otel_setup):
@@ -89,6 +122,8 @@ class TestLlmSpanExport:
         assert attrs["openinference.span.kind"] == "LLM"
         assert attrs["input.value"] == "hello"
         assert attrs["output.value"] == "hi there"
+        assert attrs["gen_ai.input.messages"] == '[{"role": "user", "content": "hello"}]'
+        assert attrs["gen_ai.output.messages"] == '[{"role": "assistant", "content": "hi there"}]'
 
 
 class TestApiSpanExport:
@@ -211,3 +246,8 @@ class TestSessionSpanExport:
         attrs = dict(span.attributes)
         assert attrs["openinference.span.kind"] == "AGENT"
         assert attrs["hermes.session.completed"] is True
+        assert attrs["gen_ai.operation.name"] == "invoke_agent"
+        assert attrs["gen_ai.agent.name"] == "hermes-agent"
+        assert attrs["gen_ai.conversation.id"] == "s1"
+        assert attrs["wandb.thread_id"] == "s1"
+        assert attrs["wandb.is_turn"] is True

--- a/tests/unit/test_backends_weave.py
+++ b/tests/unit/test_backends_weave.py
@@ -1,0 +1,142 @@
+"""Unit tests for the W&B Weave backend resolver."""
+
+import pytest
+from hermes_otel import backends
+from hermes_otel.plugin_config import BackendConfig
+
+
+def _clear_env(monkeypatch):
+    for var in (
+        "OTEL_LANGFUSE_PUBLIC_API_KEY",
+        "OTEL_LANGFUSE_SECRET_API_KEY",
+        "LANGFUSE_PUBLIC_KEY",
+        "LANGFUSE_SECRET_KEY",
+        "OTEL_SIGNOZ_ENDPOINT",
+        "OTEL_UPTRACE_ENDPOINT",
+        "OTEL_UPTRACE_DSN",
+        "UPTRACE_DSN",
+        "OTEL_OPENOBSERVE_ENDPOINT",
+        "OTEL_OPENOBSERVE_USER",
+        "OTEL_OPENOBSERVE_PASSWORD",
+        "OPENOBSERVE_USER",
+        "OPENOBSERVE_PASSWORD",
+        "HONEYCOMB_API_KEY",
+        "OTEL_HONEYCOMB_API_KEY",
+        "OTEL_JAEGER_ENDPOINT",
+        "OTEL_TEMPO_ENDPOINT",
+        "OTEL_PHOENIX_ENDPOINT",
+        "WANDB_API_KEY",
+        "WANDB_ENTITY",
+        "WANDB_PROJECT",
+        "DEFAULT_WANDB_ENTITY",
+        "DEFAULT_WANDB_PROJECT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestWeaveBackendType:
+    def test_resolves_with_inline_key_and_default_endpoint(self):
+        rb = backends.resolve(
+            BackendConfig(type="weave", api_key="wandb_key", entity="team", project="proj")
+        )
+        assert rb.type == "weave"
+        assert rb.display_name == "W&B Weave"
+        assert rb.endpoint == "https://trace.wandb.ai/otel/v1/traces"
+        assert rb.headers["wandb-api-key"] == "wandb_key"
+        assert rb.resource_attributes == {
+            "wandb.entity": "team",
+            "wandb.project": "proj",
+        }
+        assert rb.supports_traces is True
+        assert rb.supports_metrics is False
+        assert rb.supports_logs is False
+
+    def test_dedicated_base_url_gets_trace_path(self):
+        rb = backends.resolve(
+            BackendConfig(
+                type="weave",
+                api_key="k",
+                entity="team",
+                project="proj",
+                base_url="https://acme.wandb.io",
+            )
+        )
+        assert rb.endpoint == "https://acme.wandb.io/traces/otel/v1/traces"
+
+    def test_trace_base_url_gets_cloud_path(self):
+        rb = backends.resolve(
+            BackendConfig(
+                type="weave",
+                api_key="k",
+                entity="team",
+                project="proj",
+                base_url="https://trace.wandb.ai",
+            )
+        )
+        assert rb.endpoint == "https://trace.wandb.ai/otel/v1/traces"
+
+    def test_explicit_endpoint_wins(self):
+        rb = backends.resolve(
+            BackendConfig(
+                type="weave",
+                api_key="k",
+                entity="team",
+                project="proj",
+                endpoint="https://proxy.internal/otel/v1/traces",
+            )
+        )
+        assert rb.endpoint == "https://proxy.internal/otel/v1/traces"
+
+    def test_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("WANDB_API_KEY", "env_key")
+        rb = backends.resolve(BackendConfig(type="weave", entity="team", project="proj"))
+        assert rb.headers["wandb-api-key"] == "env_key"
+
+    def test_named_env_fields(self, monkeypatch):
+        monkeypatch.setenv("MY_WANDB_KEY", "named_key")
+        monkeypatch.setenv("MY_WANDB_ENTITY", "env_team")
+        monkeypatch.setenv("MY_WANDB_PROJECT", "env_proj")
+        rb = backends.resolve(
+            BackendConfig(
+                type="weave",
+                api_key_env="MY_WANDB_KEY",
+                entity_env="MY_WANDB_ENTITY",
+                project_env="MY_WANDB_PROJECT",
+            )
+        )
+        assert rb.headers["wandb-api-key"] == "named_key"
+        assert rb.resource_attributes == {
+            "wandb.entity": "env_team",
+            "wandb.project": "env_proj",
+        }
+
+    def test_user_headers_merge_on_top(self):
+        rb = backends.resolve(
+            BackendConfig(
+                type="weave",
+                api_key="k",
+                entity="team",
+                project="proj",
+                headers={"X-Extra": "1"},
+            )
+        )
+        assert rb.headers["wandb-api-key"] == "k"
+        assert rb.headers["X-Extra"] == "1"
+
+    def test_requires_api_key(self):
+        with pytest.raises(ValueError, match="api_key"):
+            backends.resolve(BackendConfig(type="weave", entity="team", project="proj"))
+
+    def test_env_priority_requires_routing(self, monkeypatch):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("WANDB_API_KEY", "env_key")
+        assert backends.resolve_from_env() is None
+
+    def test_env_priority_picks_weave_with_routing(self, monkeypatch):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("WANDB_API_KEY", "env_key")
+        monkeypatch.setenv("WANDB_ENTITY", "team")
+        monkeypatch.setenv("WANDB_PROJECT", "proj")
+        rb = backends.resolve_from_env()
+        assert rb is not None
+        assert rb.type == "weave"

--- a/tests/unit/test_tracer_init.py
+++ b/tests/unit/test_tracer_init.py
@@ -4,7 +4,7 @@ import base64
 from unittest.mock import MagicMock, patch
 
 import pytest
-from hermes_otel.plugin_config import HermesOtelConfig
+from hermes_otel.plugin_config import BackendConfig, HermesOtelConfig
 from hermes_otel.tracer import HermesOTelPlugin
 
 
@@ -23,6 +23,14 @@ def _clear_backend_env(monkeypatch):
         "LANGFUSE_BASE_URL",
         "OTEL_SIGNOZ_ENDPOINT",
         "OTEL_SIGNOZ_INGESTION_KEY",
+        "WANDB_API_KEY",
+        "WANDB_ENTITY",
+        "WANDB_PROJECT",
+        "DEFAULT_WANDB_ENTITY",
+        "DEFAULT_WANDB_PROJECT",
+        "OTEL_WEAVE_ENDPOINT",
+        "OTEL_WEAVE_BASE_URL",
+        "WANDB_OTLP_ENDPOINT",
         "OTEL_JAEGER_ENDPOINT",
         "OTEL_TEMPO_ENDPOINT",
     ]:
@@ -296,6 +304,96 @@ class TestInitTempo:
             plugin.init()
         assert plugin._meter is None
         assert plugin._meter_provider is None
+
+
+class TestInitWeave:
+    def test_env_init_uses_pipeline_to_preserve_resource_attrs(self, monkeypatch):
+        _clear_backend_env(monkeypatch)
+        monkeypatch.setenv("WANDB_API_KEY", "wandb_key")
+        monkeypatch.setenv("WANDB_ENTITY", "team")
+        monkeypatch.setenv("WANDB_PROJECT", "proj")
+
+        plugin = HermesOTelPlugin()
+        with patch.object(plugin, "_init_otlp_pipeline", return_value=True) as mock_pipeline:
+            assert plugin.init() is True
+            backends_arg = mock_pipeline.call_args[0][0]
+            assert len(backends_arg) == 1
+            assert backends_arg[0].type == "weave"
+            assert backends_arg[0].resource_attributes == {
+                "wandb.entity": "team",
+                "wandb.project": "proj",
+            }
+
+    def test_weave_backend_resource_attrs_reach_provider(self, monkeypatch):
+        _clear_backend_env(monkeypatch)
+
+        from opentelemetry.sdk.trace import TracerProvider
+
+        cfg = HermesOtelConfig(
+            backends=(
+                BackendConfig(
+                    type="weave",
+                    api_key="wandb_key",
+                    entity="team",
+                    project="proj",
+                ),
+            )
+        )
+        plugin = HermesOTelPlugin(config=cfg)
+        captured = {}
+        real_tp = TracerProvider
+
+        def _spy(**kwargs):
+            captured["resource"] = kwargs["resource"]
+            return real_tp(**kwargs)
+
+        with (
+            patch("hermes_otel.tracer.TracerProvider", side_effect=_spy),
+            patch("hermes_otel.tracer.trace.set_tracer_provider"),
+        ):
+            assert plugin.init() is True
+
+        attrs = dict(captured["resource"].attributes)
+        assert attrs["wandb.entity"] == "team"
+        assert attrs["wandb.project"] == "proj"
+        assert plugin._meter is None
+
+    def test_weave_can_use_top_level_resource_attrs(self, monkeypatch):
+        _clear_backend_env(monkeypatch)
+
+        rb_config = BackendConfig(type="weave", api_key="wandb_key")
+        cfg = HermesOtelConfig(
+            resource_attributes={
+                "wandb.entity": "team",
+                "wandb.project": "proj",
+            },
+            backends=(rb_config,),
+        )
+        plugin = HermesOTelPlugin(config=cfg)
+        resource = plugin._build_resource([plugin._resolve_backend_config(rb_config)])
+        attrs = dict(resource.attributes)
+        assert attrs["wandb.entity"] == "team"
+        assert attrs["wandb.project"] == "proj"
+
+    def test_conflicting_weave_resource_attrs_fail_init(self, monkeypatch):
+        _clear_backend_env(monkeypatch)
+
+        cfg = HermesOtelConfig(
+            resource_attributes={
+                "wandb.entity": "team-a",
+                "wandb.project": "proj",
+            },
+            backends=(
+                BackendConfig(
+                    type="weave",
+                    api_key="wandb_key",
+                    entity="team-b",
+                    project="proj",
+                ),
+            ),
+        )
+        plugin = HermesOTelPlugin(config=cfg)
+        assert plugin.init() is False
 
 
 class TestInitOtelUnavailable:

--- a/tracer.py
+++ b/tracer.py
@@ -336,6 +336,10 @@ class HermesOTelPlugin:
                 "'backends:' in config.yaml)"
             )
             return False
+        if rb.type == "weave":
+            # Weave routes by Resource attributes, so keep the resolved backend
+            # object intact instead of collapsing it through the legacy wrapper.
+            return self._init_otlp_pipeline([rb])
         return self._init_otlp(rb.endpoint, headers=rb.headers, backend_name=rb.display_name)
 
     def _resolve_backend_config(self, bc: BackendConfig) -> Optional[_ResolvedBackend]:
@@ -383,12 +387,30 @@ class HermesOTelPlugin:
             logger.error(f"[hermes-otel] ✗ LangSmith init failed: {e}")
             return False
 
-    def _build_resource(self) -> "Resource":
+    def _build_resource(self, backends: Optional[List[_ResolvedBackend]] = None) -> "Resource":
         attrs: Dict[str, Any] = {"service.name": "hermes-agent"}
         if self.config.global_tags:
             attrs.update(self.config.global_tags)
         if self.config.resource_attributes:
             attrs.update(self.config.resource_attributes)
+        for b in backends or []:
+            for key, value in (b.resource_attributes or {}).items():
+                existing = attrs.get(key)
+                if existing is not None and str(existing) != str(value):
+                    raise ValueError(
+                        f"{b.display_name} resource attribute {key!r} conflicts with "
+                        f"configured value {existing!r}"
+                    )
+                attrs[key] = value
+        for b in backends or []:
+            if b.type == "weave":
+                missing = [key for key in ("wandb.entity", "wandb.project") if not attrs.get(key)]
+                if missing:
+                    joined = ", ".join(missing)
+                    raise ValueError(
+                        f"Weave requires {joined} as resource attributes "
+                        "(set them under resource_attributes or on the weave backend entry)"
+                    )
         project_name = self.config.project_name or os.getenv("OTEL_PROJECT_NAME", "").strip()
         if project_name:
             attrs["openinference.project.name"] = project_name
@@ -418,7 +440,7 @@ class HermesOTelPlugin:
         metrics, attached to a single shared ``MeterProvider``.
         """
         try:
-            resource = self._build_resource()
+            resource = self._build_resource(backends)
 
             provider_kwargs: Dict[str, Any] = {"resource": resource}
             if self.config.sample_rate is not None:

--- a/website/docs/backends/overview.md
+++ b/website/docs/backends/overview.md
@@ -22,6 +22,7 @@ hermes-otel speaks plain **OTLP/HTTP**, so any OTLP-compatible backend should wo
 | **[Uptrace](/backends/uptrace)** | Traces + metrics + logs | Local (docker compose) · Self-hosted | OSS · premium license for HA features |
 | **[OpenObserve](/backends/openobserve)** | Traces + metrics + logs | Local (single container) · Self-hosted HA | OSS, no account |
 | **[Honeycomb](/backends/honeycomb)** | Traces + metrics + logs | Cloud (US / EU) | Generous free tier · paid plans |
+| **[W&B Weave](/backends/weave)** | Traces | W&B Cloud · Dedicated Cloud · Self-Managed | W&B account |
 | **[Generic OTLP](/backends/otlp)** | Depends on collector | Anywhere | — |
 
 ## Quick picks
@@ -47,6 +48,9 @@ hermes-otel speaks plain **OTLP/HTTP**, so any OTLP-compatible backend should wo
 **"I want a cloud backend with a generous free tier and all three signals"**
 → [Honeycomb](/backends/honeycomb) — OTLP-native, just set `HONEYCOMB_API_KEY` and a region.
 
+**"I want W&B's Agents and Traces UI for Hermes runs"**
+→ [W&B Weave](/backends/weave) — direct OTLP trace ingest with `WANDB_API_KEY`, `wandb.entity`, and `wandb.project`.
+
 **"My company already has an OTel collector / New Relic / Datadog"**
 → [Generic OTLP](/backends/otlp) — point at its ingest endpoint and it just works.
 
@@ -69,6 +73,7 @@ Backends differ in which OTel signals they accept. The plugin auto-skips signals
 | Uptrace | ✅ | ✅ | ✅ |
 | OpenObserve | ✅ | ✅ | ✅ |
 | Honeycomb | ✅ | ✅ | ✅ |
+| W&B Weave | ✅ | ❌ | ❌ |
 | Generic OTLP | ✅ | depends on collector | depends on collector |
 
 If you care about token / tool / cost metrics on a traces-only backend, pair it with a Prometheus-compatible sink or fan out to Phoenix / SigNoz / LGTM alongside. See [OTel logs](/configuration/logs) for the logs pipeline.
@@ -82,10 +87,11 @@ Single-backend selection is env-var-driven. First match wins:
 3. `OTEL_SIGNOZ_ENDPOINT` set → SigNoz
 4. `OTEL_UPTRACE_ENDPOINT` + DSN set → Uptrace
 5. `OTEL_OPENOBSERVE_ENDPOINT` + credentials set → OpenObserve
-6. `HONEYCOMB_API_KEY` set → Honeycomb
-7. `OTEL_JAEGER_ENDPOINT` set → Jaeger
-8. `OTEL_TEMPO_ENDPOINT` set → Tempo
-9. `OTEL_PHOENIX_ENDPOINT` set → Phoenix
+6. `WANDB_API_KEY` + `WANDB_ENTITY` + `WANDB_PROJECT` set → W&B Weave
+7. `HONEYCOMB_API_KEY` set → Honeycomb
+8. `OTEL_JAEGER_ENDPOINT` set → Jaeger
+9. `OTEL_TEMPO_ENDPOINT` set → Tempo
+10. `OTEL_PHOENIX_ENDPOINT` set → Phoenix
 
 Setting `backends:` in `config.yaml` overrides the env-var flow entirely — see [Multi-backend fan-out](/backends/multi-backend).
 

--- a/website/docs/backends/weave.md
+++ b/website/docs/backends/weave.md
@@ -1,0 +1,134 @@
+---
+sidebar_position: 12
+title: "W&B Weave"
+description: "W&B Weave trace ingest for Hermes agent runs, using OTLP/HTTP and GenAI agent attributes."
+---
+
+# W&B Weave
+
+[W&B Weave](https://docs.wandb.ai/weave/) is W&B's tracing and evaluation product for LLM and agent applications. hermes-otel exports directly to Weave's OTLP trace endpoint, so Hermes runs show up in Weave without adding the Weave SDK as a second tracing layer.
+
+**Signals:** traces. **Deployment:** W&B Cloud, Dedicated Cloud, Self-Managed. **Cost:** W&B account required.
+
+## Quick start
+
+Create a W&B API key, then set it in your shell:
+
+```bash
+export WANDB_API_KEY="..."
+```
+
+Declare the backend in `config.yaml`:
+
+```yaml
+backends:
+  - type: weave
+    api_key_env: WANDB_API_KEY
+    entity: my-team
+    project: hermes-agent
+```
+
+The plugin fills in:
+
+- Endpoint: `https://trace.wandb.ai/otel/v1/traces`
+- Header: `wandb-api-key: <WANDB_API_KEY>`
+- Resource attributes: `wandb.entity` and `wandb.project`
+
+You should see `✓ W&B Weave at https://trace.wandb.ai/otel/v1/traces` in startup logs.
+
+## Why a dedicated `type: weave`
+
+Trace export can be hand-written with `type: otlp`, but Weave needs a specific authentication and routing shape. Declaring `type: weave` asks the plugin to:
+
+1. Read the W&B API key from `api_key`, `api_key_env`, or `WANDB_API_KEY`.
+2. Set the `wandb-api-key` request header.
+3. Route spans with `wandb.entity` and `wandb.project` resource attributes.
+4. Default the endpoint for W&B Cloud, while supporting Dedicated Cloud and Self-Managed base URLs.
+5. Disable metrics and logs by default because W&B documents this endpoint for OTLP traces.
+
+Keep the key out of `config.yaml`; use `api_key_env`.
+
+## Configuration reference
+
+| Field | Meaning |
+|---|---|
+| `api_key` / `api_key_env` | W&B API key. Prefer `api_key_env`; falls back to `WANDB_API_KEY`. |
+| `entity` / `entity_env` | W&B team or user name. Falls back to `WANDB_ENTITY` / `DEFAULT_WANDB_ENTITY`. |
+| `project` / `project_env` | W&B project name. Falls back to `WANDB_PROJECT` / `DEFAULT_WANDB_PROJECT`. |
+| `base_url` | W&B base URL. `https://trace.wandb.ai` becomes `/otel/v1/traces`; Dedicated Cloud such as `https://acme.wandb.io` becomes `/traces/otel/v1/traces`. |
+| `endpoint` | Optional full OTLP traces endpoint; overrides `base_url`. Also settable via `OTEL_WEAVE_ENDPOINT` / `WANDB_OTLP_ENDPOINT`. |
+| `metrics` / `logs` / `traces` | Per-signal toggles. Traces default on; metrics and logs default off. |
+| `headers` | Extra headers, merged on top of the generated `wandb-api-key` header. |
+
+You can also put routing attributes at the top level:
+
+```yaml
+resource_attributes:
+  wandb.entity: my-team
+  wandb.project: hermes-agent
+
+backends:
+  - type: weave
+    api_key_env: WANDB_API_KEY
+```
+
+If both places set `wandb.entity` or `wandb.project`, the values must match.
+
+## Single backend (env vars)
+
+Without a `config.yaml` `backends:` list, env-var mode selects Weave when all routing values are present:
+
+```bash
+export WANDB_API_KEY="..."
+export WANDB_ENTITY="my-team"
+export WANDB_PROJECT="hermes-agent"
+```
+
+Optional endpoint overrides:
+
+```bash
+export OTEL_WEAVE_ENDPOINT="https://trace.wandb.ai/otel/v1/traces"
+# or
+export OTEL_WEAVE_BASE_URL="https://acme.wandb.io"
+```
+
+## Agent trace shape
+
+The plugin emits Weave-friendly GenAI attributes while preserving Phoenix/OpenInference attributes:
+
+- Root `agent` / `cron` span: `gen_ai.operation.name=invoke_agent`, `gen_ai.agent.name=hermes-agent`, `gen_ai.conversation.id=<session_id>`, `wandb.thread_id=<session_id>`, `wandb.is_turn=true`.
+- LLM/API spans: `gen_ai.operation.name=chat`, model/provider attributes, usage attributes, and privacy-gated `gen_ai.input.messages` / `gen_ai.output.messages` when content capture is enabled.
+- Tool spans: `gen_ai.operation.name=execute_tool`, `gen_ai.tool.name`, `gen_ai.tool.call.id`, and privacy-gated tool arguments/results.
+- Sub-agent spans: `gen_ai.operation.name=invoke_agent` and `gen_ai.agent.name=<role>`.
+
+`capture_previews: false` suppresses message bodies, tool arguments, and tool results, but keeps structural attributes so traces remain useful.
+
+## Multi-backend fan-out
+
+Weave is a good cloud companion to a local backend:
+
+```yaml
+resource_attributes:
+  wandb.entity: my-team
+  wandb.project: hermes-agent
+
+backends:
+  - type: phoenix
+    endpoint: http://localhost:6006/v1/traces
+  - type: weave
+    api_key_env: WANDB_API_KEY
+```
+
+Each backend gets its own `BatchSpanProcessor`, so W&B network latency does not block local Phoenix export.
+
+## Limitations
+
+- **Trace ingest only by default.** W&B's documented OTLP endpoint is `/otel/v1/traces`; the plugin disables metrics and logs for `type: weave` unless you explicitly override them.
+- **No bundled-dashboard query support.** Use the Weave UI for W&B traces. The hermes-otel bundled dashboard should query a local backend such as Phoenix.
+- **Global W&B routing.** `wandb.entity` and `wandb.project` are OTel Resource attributes on the shared `TracerProvider`, so all spans in the process route to one Weave project.
+
+## See also
+
+- [Send OpenTelemetry Traces to Weave](https://docs.wandb.ai/weave/guides/tracking/otel)
+- [Trace your agents](https://docs.wandb.ai/weave/guides/tracking/trace-agents)
+- [Multi-backend fan-out](/backends/multi-backend)

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -32,6 +32,11 @@ Setting any of these enables the matching backend. First match wins (see [Backen
 | `HONEYCOMB_API_KEY` | Honeycomb | `hcaik_...` |
 | `OTEL_HONEYCOMB_API_KEY` | Honeycomb (plugin-specific alias) | `hcaik_...` |
 | `OTEL_HONEYCOMB_ENDPOINT` | Honeycomb (optional; overrides region default) | `https://api.eu1.honeycomb.io/v1/traces` |
+| `WANDB_API_KEY` | W&B Weave | `...` |
+| `WANDB_ENTITY` | W&B Weave routing | `my-team` |
+| `WANDB_PROJECT` | W&B Weave routing | `hermes-agent` |
+| `OTEL_WEAVE_ENDPOINT` | W&B Weave (optional full endpoint) | `https://trace.wandb.ai/otel/v1/traces` |
+| `OTEL_WEAVE_BASE_URL` | W&B Weave (optional base URL) | `https://acme.wandb.io` |
 | `OTEL_PROJECT_NAME` | All | `hermes-agent` |
 
 ## Shaping overrides

--- a/website/docs/reference/config-schema.md
+++ b/website/docs/reference/config-schema.md
@@ -42,7 +42,7 @@ Shared fields (all optional unless noted):
 
 | Field | Type | Description |
 |---|---|---|
-| `type` | string | **Required.** One of: `phoenix`, `langfuse`, `langsmith`, `signoz`, `jaeger`, `tempo`, `otlp`, `lgtm`, `uptrace`, `openobserve`, `honeycomb` |
+| `type` | string | **Required.** One of: `phoenix`, `langfuse`, `langsmith`, `signoz`, `jaeger`, `tempo`, `otlp`, `lgtm`, `uptrace`, `openobserve`, `honeycomb`, `weave` |
 | `name` | string | Friendly name shown in logs (default: `type`) |
 | `endpoint` | string | Full OTLP endpoint URL (backend-specific defaults — see below) |
 | `traces` | bool | Override trace-export default (`true`). Set `false` for dashboard/query-only backends that should not receive span exports. `trace` is accepted as an alias. |
@@ -126,6 +126,21 @@ Use `type: lgtm` (not `type: tempo`) when pointing at the `grafana/otel-lgtm` co
 | `endpoint` | string | Override; skips the region default. Also via `OTEL_HONEYCOMB_ENDPOINT` |
 
 The plugin sets `x-honeycomb-team` from the key automatically and enables all three signals. See [Honeycomb](/backends/honeycomb) for dataset routing details.
+
+#### `weave`
+
+| Field | Type | Description |
+|---|---|---|
+| `api_key` | string | W&B API key (inline; discouraged) |
+| `api_key_env` | string | Env var name holding the key (falls back to `WANDB_API_KEY`) |
+| `entity` | string | W&B entity/team; copied to Resource attribute `wandb.entity` |
+| `entity_env` | string | Env var name holding the entity (falls back to `WANDB_ENTITY` / `DEFAULT_WANDB_ENTITY`) |
+| `project` | string | W&B project; copied to Resource attribute `wandb.project` |
+| `project_env` | string | Env var name holding the project (falls back to `WANDB_PROJECT` / `DEFAULT_WANDB_PROJECT`) |
+| `base_url` | string | W&B base URL. Cloud default is `https://trace.wandb.ai`; Dedicated Cloud / Self-Managed hosts such as `https://acme.wandb.io` get `/traces/otel/v1/traces` appended |
+| `endpoint` | string | Override; skips `base_url` construction. Also via `OTEL_WEAVE_ENDPOINT` / `WANDB_OTLP_ENDPOINT` |
+
+The plugin sets the `wandb-api-key` header automatically. Weave is traces-only by default; set `metrics: true` / `logs: true` only if W&B documents ingest for those signals or you are pointing at a compatible collector. `wandb.entity` and `wandb.project` may also be supplied via top-level `resource_attributes`; conflicting values fail startup.
 
 ## Env var interpolation in `headers:`
 

--- a/website/docs/reference/env-vars.md
+++ b/website/docs/reference/env-vars.md
@@ -30,6 +30,15 @@ Complete list. See [Environment variables](/configuration/environment-variables)
 | `HONEYCOMB_API_KEY` | `hcaik_...` | Honeycomb ingest key (`x-honeycomb-team`); enables Honeycomb in env-var mode |
 | `OTEL_HONEYCOMB_API_KEY` | `hcaik_...` | Honeycomb key (plugin-specific alias) |
 | `OTEL_HONEYCOMB_ENDPOINT` | URL | Honeycomb endpoint override (default: US region) |
+| `WANDB_API_KEY` | string | W&B API key; enables Weave in env-var mode when routing vars are also set |
+| `WANDB_ENTITY` | string | W&B entity/team for Weave routing (`wandb.entity`) |
+| `WANDB_PROJECT` | string | W&B project for Weave routing (`wandb.project`) |
+| `DEFAULT_WANDB_ENTITY` | string | Weave entity fallback, useful with an OTel Collector |
+| `DEFAULT_WANDB_PROJECT` | string | Weave project fallback, useful with an OTel Collector |
+| `OTEL_WEAVE_ENDPOINT` | URL | Full Weave OTLP traces endpoint override |
+| `WANDB_OTLP_ENDPOINT` | URL | Weave OTLP endpoint alias used by W&B docs |
+| `OTEL_WEAVE_BASE_URL` | URL | W&B base URL; plugin appends the trace ingest path |
+| `WANDB_BASE_URL` | URL | W&B base URL alias for Dedicated Cloud / Self-Managed |
 | `OTEL_PROJECT_NAME` | string | Resource `service.name` + `openinference.project.name` |
 
 ## Shaping overrides

--- a/website/docs/reference/limitations.md
+++ b/website/docs/reference/limitations.md
@@ -78,6 +78,22 @@ Why: LangSmith uses its own HTTP Run API rather than OTLP; its transport doesn't
 
 Workaround if you need both: run the OTel Collector and have it route traces to LangSmith's OTLP-compatible beta ingest, if/when LangSmith ships one.
 
+## Weave is trace-ingest only
+
+W&B Weave's documented OTLP endpoint is `/otel/v1/traces`, authenticated with
+the `wandb-api-key` header and routed by `wandb.entity` / `wandb.project`
+Resource attributes. The dedicated `type: weave` backend therefore disables
+OTLP metrics and logs by default.
+
+If you need `hermes.*` metrics or OTel logs next to Weave traces, fan out to
+Weave plus a metrics/logs-capable backend such as Phoenix, SigNoz, LGTM, or
+OpenObserve. The bundled dashboard also does not query Weave; use Weave's UI
+for W&B traces and point the dashboard at a local backend.
+
+Because `wandb.entity` and `wandb.project` are Resource attributes on the
+shared `TracerProvider`, one Hermes process can route to one Weave project at a
+time. Multiple configured Weave entries must agree on those values.
+
 ## Debug log has no rotation
 
 Enabling `HERMES_OTEL_DEBUG=true` appends to `~/.hermes/plugins/hermes_otel/debug.log` forever. No rotation, no size cap.

--- a/website/docs/reference/span-attributes.md
+++ b/website/docs/reference/span-attributes.md
@@ -18,6 +18,8 @@ Attributes marked **optional** are only set when the underlying data is availabl
 | `service.version` | `hermes-otel` plugin version |
 | `otel.scope.name` | `hermes-otel` |
 | `openinference.project.name` | Same as `service.name` |
+| `wandb.entity` | W&B Weave routing (when configured) |
+| `wandb.project` | W&B Weave routing (when configured) |
 | `telemetry.sdk.*` | Set by OTel SDK |
 | *any* `resource_attributes.*` | From `config.yaml` |
 | *any* `global_tags.*` | From `config.yaml` (overridden by `resource_attributes` on key conflict) |
@@ -31,6 +33,12 @@ Set at **start**:
 | `hermes.session.kind` | string | `cli` · `telegram` · `discord` · `cron` · ... |
 | `hermes.session.id` | string | Hermes session ID |
 | `session.id` | string | Standard OTel alias |
+| `gen_ai.operation.name` | string | `invoke_agent` |
+| `gen_ai.agent.name` | string | Agent name shown in Weave (`hermes-agent` by default) |
+| `gen_ai.conversation.id` | string | Session/conversation grouping ID |
+| `wandb.thread_id` | string | Weave thread grouping ID |
+| `wandb.is_turn` | bool | Marks the root span as a Weave conversation turn |
+| `weave.agent.version` | string | Plugin package version (optional) |
 | `user.id` | string | Hermes user ID (optional) |
 
 Set at **end** (turn summary):
@@ -63,6 +71,8 @@ Span kind: `LLM` (OpenInference).
 | `input.mime_type` | OpenInference | string | `text/plain` OR `application/json` |
 | `output.value` | OpenInference | string | Final assistant response |
 | `output.mime_type` | OpenInference | string | `text/plain` |
+| `gen_ai.input.messages` | gen_ai | string (JSON) | Privacy-gated user message / conversation history for Weave |
+| `gen_ai.output.messages` | gen_ai | string (JSON) | Privacy-gated assistant response for Weave |
 | `gen_ai.content.prompt` | gen_ai | string | User message |
 | `gen_ai.content.completion` | gen_ai | string | Assistant response |
 | `hermes.conversation.message_count` | hermes | int | When conversation capture is on (optional) |
@@ -118,6 +128,11 @@ Span kind: `TOOL` (OpenInference).
 | `tool.name` | OpenInference | string | Tool name |
 | `input.value` | OpenInference | string | Tool args (JSON) |
 | `output.value` | OpenInference | string | Tool result |
+| `gen_ai.operation.name` | gen_ai | string | `execute_tool` |
+| `gen_ai.tool.name` | gen_ai | string | Tool name |
+| `gen_ai.tool.call.id` | gen_ai | string | Tool call/task ID |
+| `gen_ai.tool.call.arguments` | gen_ai | string | Privacy-gated tool args (JSON preview or full capture) |
+| `gen_ai.tool.call.result` | gen_ai | string | Privacy-gated tool result |
 | `hermes.tool.target` | hermes | string | Inferred file path / URL (optional) |
 | `hermes.tool.command` | hermes | string | Inferred shell command (optional) |
 | `hermes.tool.outcome` | hermes | string | `completed` · `error` · `timeout` · `blocked` |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -30,6 +30,7 @@ const sidebars: SidebarsConfig = {
         'backends/uptrace',
         'backends/openobserve',
         'backends/honeycomb',
+        'backends/weave',
         'backends/multi-backend',
       ],
     },


### PR DESCRIPTION
Adds [Weave](https://weave-docs.wandb.ai/) (W&B) as an OTLP backend — config, env vars, docs, and tests included.