### PR TITLE
docs(backends): add telemetry.dev backend guide

### DIFF
--- a/website/docs/backends/otlp.md
+++ b/website/docs/backends/otlp.md
@@ -47,6 +47,19 @@ backends:
       x-honeycomb-dataset: hermes-agent
 ```
 
+### telemetry.dev
+
+```yaml
+backends:
+  - type: otlp
+    name: telemetry-dev
+    endpoint: https://ingest.telemetry.dev/v1/traces
+    headers:
+      Authorization: Bearer ${TELEMETRY_DEV_API_KEY}
+```
+
+See the dedicated [telemetry.dev](/backends/telemetry) page for endpoints, attribute fit, and troubleshooting.
+
 ### New Relic (OTLP endpoint)
 
 ```yaml

--- a/website/docs/backends/overview.md
+++ b/website/docs/backends/overview.md
@@ -23,6 +23,7 @@ hermes-otel speaks plain **OTLP/HTTP**, so any OTLP-compatible backend should wo
 | **[OpenObserve](/backends/openobserve)** | Traces + metrics + logs | Local (single container) · Self-hosted HA | OSS, no account |
 | **[Honeycomb](/backends/honeycomb)** | Traces + metrics + logs | Cloud (US / EU) | Generous free tier · paid plans |
 | **[W&B Weave](/backends/weave)** | Traces | W&B Cloud · Dedicated Cloud · Self-Managed | W&B account |
+| **[telemetry.dev](/backends/telemetry)** (via generic `otlp`) | Traces + metrics + logs | Cloud | Free tier + paid plans |
 | **[Generic OTLP](/backends/otlp)** | Depends on collector | Anywhere | — |
 
 ## Quick picks
@@ -51,6 +52,9 @@ hermes-otel speaks plain **OTLP/HTTP**, so any OTLP-compatible backend should wo
 **"I want W&B's Agents and Traces UI for Hermes runs"**
 → [W&B Weave](/backends/weave) — direct OTLP trace ingest with `WANDB_API_KEY`, `wandb.entity`, and `wandb.project`.
 
+**"I want a hosted backend purpose-built for LLM/agent telemetry, `gen_ai.*`-native"**
+→ [telemetry.dev](/backends/telemetry) — OTLP ingest with a single `Authorization: Bearer` header, via the generic `otlp` type.
+
 **"My company already has an OTel collector / New Relic / Datadog"**
 → [Generic OTLP](/backends/otlp) — point at its ingest endpoint and it just works.
 
@@ -74,6 +78,7 @@ Backends differ in which OTel signals they accept. The plugin auto-skips signals
 | OpenObserve | ✅ | ✅ | ✅ |
 | Honeycomb | ✅ | ✅ | ✅ |
 | W&B Weave | ✅ | ❌ | ❌ |
+| telemetry.dev | ✅ | ✅ | ✅ |
 | Generic OTLP | ✅ | depends on collector | depends on collector |
 
 If you care about token / tool / cost metrics on a traces-only backend, pair it with a Prometheus-compatible sink or fan out to Phoenix / SigNoz / LGTM alongside. See [OTel logs](/configuration/logs) for the logs pipeline.

--- a/website/docs/backends/telemetry.md
+++ b/website/docs/backends/telemetry.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 13
+title: "telemetry.dev"
+description: "Send Hermes traces, metrics, and logs to telemetry.dev — hosted LLM/agent observability built on the gen_ai.* semantic conventions, using the generic otlp type."
+---
+
+# telemetry.dev
+
+[telemetry.dev](https://telemetry.dev) is a hosted observability platform purpose-built for LLM and agent telemetry. Its ingest speaks plain **OTLP/HTTP** (protobuf or JSON) and indexes the `gen_ai.*` semantic conventions hermes-otel already emits — so Hermes traces, GenAI metrics, and logs land there with no adapter code, via the [generic `otlp` type](/backends/otlp).
+
+**Signals:** traces + metrics + logs. **Deployment:** cloud. **Cost:** free tier + paid plans.
+
+## Quick start
+
+Create a project at [telemetry.dev](https://telemetry.dev) and copy an ingest API key (`td_live_...`) from the project settings, then set it in your shell:
+
+```bash
+export TELEMETRY_DEV_API_KEY="td_live_..."
+```
+
+Declare the backend in `config.yaml`:
+
+```yaml
+backends:
+  - type: otlp
+    name: telemetry-dev
+    endpoint: https://ingest.telemetry.dev/v1/traces
+    headers:
+      Authorization: Bearer ${TELEMETRY_DEV_API_KEY}
+```
+
+You should see `✓ telemetry-dev connected` in startup logs. Run a Hermes turn, open your project dashboard at [telemetry.dev](https://telemetry.dev), and the session trace is there — no local UI to run.
+
+## Endpoints and auth
+
+| Signal | Endpoint | Notes |
+|---|---|---|
+| Traces | `https://ingest.telemetry.dev/v1/traces` | The one you configure. |
+| Metrics | `https://ingest.telemetry.dev/v1/metrics` | Derived automatically by replacing `/v1/traces` — matches telemetry.dev's path scheme, nothing to configure. |
+| Logs | `https://ingest.telemetry.dev/v1/logs` | Accepted at ingest; ships only when [`capture_logs: true`](/configuration/logs) is set. |
+
+- Auth is a single header: `Authorization: Bearer td_live_...`. Keys are created per project (and per environment), so one Hermes deployment maps cleanly to one project.
+- Both OTLP/HTTP encodings are accepted (`application/x-protobuf` and `application/json`); the plugin's exporters send protobuf.
+
+## Attribute fit
+
+telemetry.dev normalizes the OpenTelemetry **GenAI semantic conventions**, which is one of the two conventions hermes-otel [emits on every span](/architecture/attributes):
+
+- Token usage — `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens`
+- Model + provider — `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.provider.name`
+- Operations — `gen_ai.operation.name` (`invoke_agent` / `chat` / `execute_tool`), `gen_ai.tool.name`
+- Session grouping — `gen_ai.conversation.id` on the root session span
+
+The OpenInference (`llm.*`, `input.value` / `output.value`) attributes ride along and are ignored — no config needed on either side.
+
+## Privacy
+
+Two layers compose:
+
+- **At the source:** `capture_previews: false` strips every input/output preview before export, as with any backend — see [Privacy](/configuration/privacy).
+- **At ingest:** telemetry.dev projects support server-side redaction patterns applied before storage, useful when you want previews for debugging but specific tokens/PII scrubbed.
+
+## Troubleshooting
+
+**`401` in debug logs (`HERMES_OTEL_DEBUG=true`)**
+
+The `Authorization` header is missing or the key is malformed — it must be `Bearer td_live_...`. Check that `TELEMETRY_DEV_API_KEY` is exported in the environment Hermes actually runs in (gateway service files often don't inherit your shell).
+
+**Traces show up; logs don't**
+
+Logs are opt-in on the plugin side: set `capture_logs: true`. See [OTel logs](/configuration/logs).
+
+## See also
+
+- [telemetry.dev](https://telemetry.dev)
+- [Generic OTLP](/backends/otlp) — the backend type this page uses
+- [Multi-backend fan-out](/backends/multi-backend)

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -31,6 +31,7 @@ const sidebars: SidebarsConfig = {
         'backends/openobserve',
         'backends/honeycomb',
         'backends/weave',
+        'backends/telemetry',
         'backends/multi-backend',
       ],
     },


### PR DESCRIPTION
## Summary

Adds [telemetry.dev](https://telemetry.dev) — a hosted observability platform purpose-built for LLM/agent telemetry — to the backend docs. Its ingest speaks plain OTLP/HTTP (protobuf or JSON) on `/v1/traces`, `/v1/metrics`, and `/v1/logs` with a single `Authorization: Bearer td_live_...` header, and it natively indexes the `gen_ai.*` semantic conventions this plugin already emits — so it works today through the generic `otlp` type with no code changes.

## Changes (docs-only)

- **New page** `website/docs/backends/telemetry.md` — quick start via `type: otlp`, endpoint/auth table for all three signals, `gen_ai.*` attribute fit, privacy layering (`capture_previews` + server-side redaction), troubleshooting.
- `website/docs/backends/overview.md` — row in the "Supported today" table (marked *via generic `otlp`*), row in the signal-support matrix (traces ✅ metrics ✅ logs ✅), and a quick-pick entry.
- `website/docs/backends/otlp.md` — telemetry.dev example alongside the Honeycomb / New Relic ones, linking to the dedicated page.
- `website/sidebars.ts` — registers the new page after W&B Weave.

No Python changes — the existing `otlp` resolver covers it (metrics endpoint derivation `/v1/traces` → `/v1/metrics` matches telemetry.dev's path scheme exactly; logs default on for `type: otlp` and only ship with `capture_logs: true`).

## Verification

- `cd website && npm run build` — clean (Docusaurus link check passes, no broken links).
- Endpoint paths, Bearer auth format, accepted content types (`application/x-protobuf` + `application/json`), and `gen_ai.*` normalization verified against the telemetry.dev ingest implementation (I work on it).

Happy to adjust placement if you'd rather keep the overview table to backends with dedicated `type:` values — the page + otlp example stand alone either way.
