### PR TITLE
feat(backends): add Parseable backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Tested with:
 - **[Grafana LGTM](https://github.com/grafana/docker-otel-lgtm)** (local) — traces + metrics + logs
 - **[Uptrace](https://uptrace.dev)** (self-hosted) — traces + metrics + logs
 - **[OpenObserve](https://openobserve.ai)** (self-hosted) — traces + metrics + logs
+- **[Parseable](https://www.parseable.com)** (cloud or self-hosted) — traces + metrics + logs + agent observability
 - **[Honeycomb](https://www.honeycomb.io/)** (cloud) — traces + metrics + logs — see [HONEYCOMB.md](HONEYCOMB.md)
 - **[W&B Weave](https://docs.wandb.ai/weave/)** (cloud / Dedicated Cloud / self-managed) — traces only
 
@@ -26,6 +27,7 @@ Any OTLP HTTP endpoint should work.
 - For Grafana LGTM see [docker-compose/lgtm.yaml](docker-compose/lgtm.yaml) and [docker-compose/lgtm/README.md](docker-compose/lgtm/README.md)
 - For Uptrace see [docker-compose/uptrace.yaml](docker-compose/uptrace.yaml) and [docker-compose/uptrace/README.md](docker-compose/uptrace/README.md)
 - For OpenObserve see [docker-compose/openobserve.yaml](docker-compose/openobserve.yaml) and [docker-compose/openobserve/README.md](docker-compose/openobserve/README.md)
+- For Parseable see the [Hermes integration guide](https://www.parseable.com/docs/ingest-data/ai-agents/hermes)
 
 ## Installation
 
@@ -213,13 +215,14 @@ path or starve the others — span end is just a non-blocking enqueue. Both
 trace and metrics export run in parallel across all configured backends.
 
 Supported `type` values: `phoenix`, `langfuse`, `signoz`, `jaeger`, `tempo`,
-`otlp`, `lgtm`, `uptrace`, `openobserve`, `honeycomb`, `weave`. Use `otlp` for any collector
+`otlp`, `lgtm`, `uptrace`, `openobserve`, `parseable`, `honeycomb`, `weave`. Use `otlp` for any collector
 that doesn't have a dedicated type. Backends marked
 traces-only (`langfuse`, `jaeger`, `tempo`, `weave`) are auto-detected and skip
 the metrics reader. Override with `metrics: true|false` per entry if
 needed. See `config.yaml.example` for the full list of fields each type
 accepts — Uptrace takes a `dsn:` for the `uptrace-dsn` header, OpenObserve
-takes `user:` / `password:` for HTTP Basic auth, and Weave takes W&B routing
+takes `user:` / `password:` for HTTP Basic auth, Parseable takes an `api_key`
+and per-signal dataset names, and Weave takes W&B routing
 fields (`entity` / `project`) for `wandb.entity` / `wandb.project`.
 
 ### Full-conversation capture
@@ -366,7 +369,7 @@ export HERMES_OTEL_DEBUG=true
 
 Debug output is written to `~/.hermes/plugins/hermes_otel/debug.log` and does not clutter hermes stdout.
 
-**Priority order:** LangSmith (if `LANGSMITH_TRACING=true`) > Langfuse (if credentials set) > SigNoz (`OTEL_SIGNOZ_ENDPOINT`) > Uptrace (`OTEL_UPTRACE_ENDPOINT` + DSN) > OpenObserve (`OTEL_OPENOBSERVE_ENDPOINT` + creds) > Weave (`WANDB_API_KEY` + `WANDB_ENTITY` + `WANDB_PROJECT`) > Honeycomb (`HONEYCOMB_API_KEY`) > Jaeger (`OTEL_JAEGER_ENDPOINT`) > Tempo (`OTEL_TEMPO_ENDPOINT`) > Phoenix (`OTEL_PHOENIX_ENDPOINT`).
+**Priority order:** LangSmith (if `LANGSMITH_TRACING=true`) > Langfuse (if credentials set) > SigNoz (`OTEL_SIGNOZ_ENDPOINT`) > Uptrace (`OTEL_UPTRACE_ENDPOINT` + DSN) > OpenObserve (`OTEL_OPENOBSERVE_ENDPOINT` + creds) > Parseable (`OTEL_PARSEABLE_ENDPOINT` + `PARSEABLE_API_KEY`) > Weave (`WANDB_API_KEY` + `WANDB_ENTITY` + `WANDB_PROJECT`) > Honeycomb (`HONEYCOMB_API_KEY`) > Jaeger (`OTEL_JAEGER_ENDPOINT`) > Tempo (`OTEL_TEMPO_ENDPOINT`) > Phoenix (`OTEL_PHOENIX_ENDPOINT`).
 
 ### Shaping knobs — `config.yaml` and `HERMES_OTEL_*` env vars
 
@@ -570,6 +573,7 @@ This plugin speaks plain OTLP/HTTP, so any OTLP-compatible backend should work t
 | [Grafana Tempo](https://grafana.com/oss/tempo/) | traces | Local (docker compose) · Grafana Cloud | OSS, no account · free tier + paid cloud | ✅ |
 | [Grafana LGTM](https://github.com/grafana/docker-otel-lgtm) | traces + metrics + logs | Local (single container) | OSS, no account | ✅ |
 | [OpenObserve](https://openobserve.ai) | traces + metrics + logs | Local (single binary / docker) · Cloud | OSS, no account · free tier + paid cloud | ✅ |
+| [Parseable](https://www.parseable.com) | traces + metrics + logs | Self-hosted · Cloud | OSS · paid cloud | ✅ |
 | [Uptrace](https://uptrace.dev) | traces + metrics + logs | Local (docker compose) · Cloud | OSS, no account · free tier + paid cloud | ✅ |
 | [Honeycomb](https://www.honeycomb.io) | traces + metrics | Cloud only | Free tier + paid | 🔲 |
 | [W&B Weave](https://docs.wandb.ai/weave/) | traces | W&B Cloud · Dedicated Cloud · Self-Managed | W&B account | ✅ |
@@ -579,7 +583,7 @@ This plugin speaks plain OTLP/HTTP, so any OTLP-compatible backend should work t
 
 ### Quick picks
 
-- **Fully offline / no account ever:** Phoenix, Langfuse (self-hosted), Jaeger, SigNoz, Grafana Tempo+Mimir, OpenObserve, Uptrace, Elastic APM self-host. All runnable via `docker compose up`.
+- **Fully offline / no account ever:** Phoenix, Langfuse (self-hosted), Jaeger, SigNoz, Grafana Tempo+Mimir, OpenObserve, Parseable, Uptrace, Elastic APM self-host. All runnable locally.
 - **Free SaaS (personal / hobby tier, no credit card):** Langfuse Cloud, LangSmith, SigNoz Cloud, Grafana Cloud, Honeycomb, New Relic. Best if you don't want to run infrastructure.
 - **W&B agent experiment tracking:** W&B Weave, using OTLP trace ingest plus GenAI agent attributes.
 - **Paid only (credit card required after trial):** Datadog, Dynatrace, LangSmith self-hosted (enterprise plan).

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -189,6 +189,8 @@
 #   openobserve  — OpenObserve (OSS, single container). Traces + metrics + logs.
 #                  Uses HTTP Basic auth — set `user:` + `password:` (or the
 #                  `*_env` variants) and the plugin builds the header for you.
+#   parseable    — Parseable agent observability. Traces + metrics + logs.
+#                  Uses an API key and routes each signal to its own dataset.
 #   honeycomb    — Honeycomb (SaaS). Traces + metrics + logs. Set `api_key`
 #                  (or `api_key_env`) and `region:` (us|eu); the plugin fills in
 #                  the endpoint and `x-honeycomb-team` header. See HONEYCOMB.md.
@@ -204,8 +206,9 @@
 #
 # When `backends:` is absent or empty, the plugin falls back to single-backend
 # env-var detection (LANGSMITH_TRACING, OTEL_LANGFUSE_*, OTEL_SIGNOZ_ENDPOINT,
-# OTEL_JAEGER_ENDPOINT, OTEL_TEMPO_ENDPOINT, OTEL_PHOENIX_ENDPOINT — first
-# match wins). Setting `backends:` takes full control away from env detection.
+# OTEL_PARSEABLE_ENDPOINT, OTEL_JAEGER_ENDPOINT, OTEL_TEMPO_ENDPOINT,
+# OTEL_PHOENIX_ENDPOINT — first match wins). Setting `backends:` takes full
+# control away from env detection.
 #
 # LangSmith remains env-var-only because it doesn't speak OTLP; setting
 # LANGSMITH_TRACING=true will short-circuit the `backends:` list entirely.
@@ -243,7 +246,7 @@
 #     headers:
 #       X-Tenant: acme
 #     metrics: true
-#     logs: true       # override the default (on for otlp/signoz/lgtm/uptrace/openobserve/honeycomb)
+#     logs: true       # override default (on for otlp/signoz/lgtm/uptrace/openobserve/parseable/honeycomb)
 
 # ── LGTM quickstart ──────────────────────────────────────────────────────────
 #
@@ -286,6 +289,21 @@
 #     user: root@example.com                  # or user_env: OPENOBSERVE_USER
 #     password_env: OPENOBSERVE_PASSWORD
 #     # stream_name: default                  # optional; defaults to "default"
+# capture_logs: true
+
+# ── Parseable quickstart ─────────────────────────────────────────────────────
+#
+# Direct OTLP/HTTP export to Parseable. Create the three datasets first; tag
+# the traces dataset `agent-observability` to expose it in Parseable Agents.
+# Full guide: https://www.parseable.com/docs/ingest-data/ai-agents/hermes
+#
+# backends:
+#   - type: parseable
+#     endpoint: https://parseable.example.com/v1/traces
+#     api_key_env: PARSEABLE_API_KEY
+#     traces_dataset: hermes-traces
+#     metrics_dataset: hermes-metrics
+#     logs_dataset: hermes-logs
 # capture_logs: true
 
 # ── Honeycomb quickstart ─────────────────────────────────────────────────────

--- a/hermes_otel/backends.py
+++ b/hermes_otel/backends.py
@@ -34,7 +34,7 @@ _TRACES_ONLY = {"langfuse", "jaeger", "tempo", "weave"}
 # to "logs off" — Phoenix/Langfuse/Jaeger/Tempo don't implement /v1/logs, and
 # we'd rather drop logs on the floor than spray 4xx errors at them. Users
 # can override per-backend via the ``logs:`` field in config.yaml.
-_LOGS_CAPABLE = {"signoz", "otlp", "lgtm", "uptrace", "openobserve", "honeycomb"}
+_LOGS_CAPABLE = {"signoz", "otlp", "lgtm", "uptrace", "openobserve", "parseable", "honeycomb"}
 
 # Display names used in logs. Preferred over ``type.capitalize()`` because
 # some backends use camelCase ("SigNoz") that simple title-case gets wrong.
@@ -48,6 +48,7 @@ _DISPLAY_NAMES = {
     "lgtm": "LGTM",
     "uptrace": "Uptrace",
     "openobserve": "OpenObserve",
+    "parseable": "Parseable",
     "honeycomb": "Honeycomb",
     "weave": "W&B Weave",
 }
@@ -69,6 +70,7 @@ _ENV_PRIORITY = [
     "signoz",
     "uptrace",
     "openobserve",
+    "parseable",
     "weave",
     "honeycomb",
     "jaeger",
@@ -90,6 +92,8 @@ class _ResolvedBackend:
     endpoint: str
     display_name: str = "OTLP"
     headers: Optional[Dict[str, str]] = None
+    metrics_headers: Optional[Dict[str, str]] = None
+    logs_headers: Optional[Dict[str, str]] = None
     supports_traces: bool = True
     supports_metrics: bool = True
     supports_logs: bool = False
@@ -371,6 +375,49 @@ def _resolve_openobserve(bc: BackendConfig) -> _ResolvedBackend:
     )
 
 
+def _resolve_parseable(bc: BackendConfig) -> _ResolvedBackend:
+    """Resolve Parseable direct OTLP/HTTP ingest for all three signals."""
+    ep = (bc.endpoint or os.getenv("OTEL_PARSEABLE_ENDPOINT", "")).strip()
+    if not ep:
+        raise ValueError("parseable requires endpoint")
+    key = _resolve_secret(
+        bc.api_key,
+        bc.api_key_env,
+        ["OTEL_PARSEABLE_API_KEY", "PARSEABLE_API_KEY"],
+    )
+    if not key:
+        raise ValueError("parseable requires api_key")
+
+    traces_dataset = (
+        bc.traces_dataset or os.getenv("PARSEABLE_TRACES_DATASET", "") or "hermes-traces"
+    ).strip()
+    metrics_dataset = (
+        bc.metrics_dataset or os.getenv("PARSEABLE_METRICS_DATASET", "") or "hermes-metrics"
+    ).strip()
+    logs_dataset = (
+        bc.logs_dataset or os.getenv("PARSEABLE_LOGS_DATASET", "") or "hermes-logs"
+    ).strip()
+
+    common = {"X-API-Key": key}
+    trace_headers = {**common, "X-P-Stream": traces_dataset, "X-P-Log-Source": "otel-traces"}
+    metric_headers = {**common, "X-P-Stream": metrics_dataset, "X-P-Log-Source": "otel-metrics"}
+    log_headers = {**common, "X-P-Stream": logs_dataset, "X-P-Log-Source": "otel-logs"}
+    for signal_headers in (trace_headers, metric_headers, log_headers):
+        signal_headers.update(bc.headers or {})
+
+    return _ResolvedBackend(
+        type="parseable",
+        endpoint=ep,
+        display_name=_display(bc, "parseable"),
+        headers=trace_headers,
+        metrics_headers=metric_headers,
+        logs_headers=log_headers,
+        supports_traces=_traces_for(bc.traces),
+        supports_metrics=_metrics_for("parseable", bc.metrics),
+        supports_logs=_logs_for("parseable", bc.logs),
+    )
+
+
 def _resolve_honeycomb(bc: BackendConfig) -> _ResolvedBackend:
     """Resolve Honeycomb (SaaS, OTLP/HTTP — traces + metrics + logs).
 
@@ -505,6 +552,7 @@ _RESOLVERS: Dict[str, Callable[[BackendConfig], _ResolvedBackend]] = {
     "lgtm": _resolve_lgtm,
     "uptrace": _resolve_uptrace,
     "openobserve": _resolve_openobserve,
+    "parseable": _resolve_parseable,
     "honeycomb": _resolve_honeycomb,
     "weave": _resolve_weave,
 }

--- a/hermes_otel/log_handler.py
+++ b/hermes_otel/log_handler.py
@@ -135,7 +135,7 @@ def build_log_processors(
     for b in backends:
         if not b.supports_logs:
             continue
-        merged: Dict[str, str] = dict(b.headers or {})
+        merged: Dict[str, str] = dict(b.logs_headers or b.headers or {})
         if extra_headers:
             merged.update(extra_headers)
         endpoint = _derive_logs_endpoint(b.endpoint)

--- a/hermes_otel/plugin_config.py
+++ b/hermes_otel/plugin_config.py
@@ -88,14 +88,14 @@ class BackendConfig:
     discouraged because the file is plaintext.
     """
 
-    type: str  # phoenix | langfuse | signoz | jaeger | tempo | otlp | honeycomb | weave
+    type: str  # phoenix | langfuse | signoz | jaeger | tempo | otlp | parseable | honeycomb | weave
     name: Optional[str] = None  # display name (defaults to type)
     endpoint: Optional[str] = None  # OTLP HTTP traces URL
     headers: Optional[Dict[str, str]] = None  # extra/override HTTP headers
     traces: Optional[bool] = None  # None = on. False = dashboard/query-only, no trace export.
     metrics: Optional[bool] = None  # None = auto (off for langfuse/jaeger/tempo)
     logs: Optional[bool] = (
-        None  # None = auto (on for signoz/otlp/lgtm/uptrace/openobserve/honeycomb)
+        None  # None = auto (on for signoz/otlp/lgtm/uptrace/openobserve/parseable/honeycomb)
     )
     # Langfuse credentials
     public_key: Optional[str] = None
@@ -115,6 +115,10 @@ class BackendConfig:
     password: Optional[str] = None
     password_env: Optional[str] = None
     stream_name: Optional[str] = None
+    # Parseable dataset routing (one dataset per OTLP signal)
+    traces_dataset: Optional[str] = None
+    metrics_dataset: Optional[str] = None
+    logs_dataset: Optional[str] = None
     # Honeycomb: API key (sent as the ``x-honeycomb-team`` header), optional
     # dataset (``x-honeycomb-dataset``), and ``region`` (``us``|``eu``) used to
     # default the endpoint when one isn't given explicitly.

--- a/hermes_otel/tracer.py
+++ b/hermes_otel/tracer.py
@@ -2,7 +2,7 @@
 
 Provides a singleton tracer manager that fans out spans/metrics to one or more
 collector backends (Phoenix, Langfuse, SigNoz, Jaeger, Tempo, LGTM, Uptrace,
-OpenObserve, or any other OTLP-compatible collector via the ``otlp`` type).
+OpenObserve, Parseable, or any other OTLP-compatible collector via the ``otlp`` type).
 LangSmith remains a separate, env-var-only single-backend path because it uses
 its own HTTP API rather than OTLP.
 
@@ -513,7 +513,10 @@ class HermesOTelPlugin:
                 if b.supports_metrics and _METRICS_AVAILABLE:
                     metrics_endpoint = self._derive_metrics_endpoint(b.endpoint)
                     try:
-                        m_exporter = OTLPMetricExporter(endpoint=metrics_endpoint, headers=hdrs)
+                        metric_hdrs = self._merge_headers(b.metrics_headers or b.headers)
+                        m_exporter = OTLPMetricExporter(
+                            endpoint=metrics_endpoint, headers=metric_hdrs
+                        )
                         reader = PeriodicExportingMetricReader(
                             m_exporter,
                             export_interval_millis=self.config.flush_interval_ms,

--- a/tests/unit/test_log_handler.py
+++ b/tests/unit/test_log_handler.py
@@ -462,6 +462,84 @@ class TestOpenObserveBackendType:
         assert rb.headers["stream-name"] == "my-stream"
 
 
+class TestParseableBackendType:
+    """Parseable backend uses signal-specific dataset and source headers."""
+
+    def test_parseable_resolves_all_signal_headers(self):
+        from hermes_otel import backends
+        from hermes_otel.plugin_config import BackendConfig
+
+        rb = backends.resolve(
+            BackendConfig(
+                type="parseable",
+                endpoint="https://parseable.example.com/v1/traces",
+                api_key="p-key",
+            )
+        )
+
+        assert rb.type == "parseable"
+        assert rb.display_name == "Parseable"
+        assert rb.supports_metrics is True
+        assert rb.supports_logs is True
+        assert rb.headers == {
+            "X-API-Key": "p-key",
+            "X-P-Stream": "hermes-traces",
+            "X-P-Log-Source": "otel-traces",
+        }
+        assert rb.metrics_headers["X-P-Stream"] == "hermes-metrics"
+        assert rb.metrics_headers["X-P-Log-Source"] == "otel-metrics"
+        assert rb.logs_headers["X-P-Stream"] == "hermes-logs"
+        assert rb.logs_headers["X-P-Log-Source"] == "otel-logs"
+
+    def test_parseable_custom_datasets_and_headers(self):
+        from hermes_otel import backends
+        from hermes_otel.plugin_config import BackendConfig
+
+        rb = backends.resolve(
+            BackendConfig(
+                type="parseable",
+                endpoint="https://parseable.example.com/v1/traces",
+                api_key="p-key",
+                traces_dataset="prod-traces",
+                metrics_dataset="prod-metrics",
+                logs_dataset="prod-logs",
+                headers={"X-Tenant": "acme"},
+            )
+        )
+
+        assert rb.headers["X-P-Stream"] == "prod-traces"
+        assert rb.metrics_headers["X-P-Stream"] == "prod-metrics"
+        assert rb.logs_headers["X-P-Stream"] == "prod-logs"
+        assert rb.logs_headers["X-Tenant"] == "acme"
+
+    def test_parseable_requires_endpoint_and_api_key(self):
+        from hermes_otel import backends
+        from hermes_otel.plugin_config import BackendConfig
+
+        with pytest.raises(ValueError, match="endpoint"):
+            backends.resolve(BackendConfig(type="parseable", api_key="p-key"))
+        with pytest.raises(ValueError, match="api_key"):
+            backends.resolve(
+                BackendConfig(
+                    type="parseable",
+                    endpoint="https://parseable.example.com/v1/traces",
+                )
+            )
+
+    def test_parseable_resolves_from_env(self, monkeypatch):
+        from hermes_otel import backends
+
+        monkeypatch.setenv("OTEL_PARSEABLE_ENDPOINT", "https://parseable.example.com/v1/traces")
+        monkeypatch.setenv("PARSEABLE_API_KEY", "env-key")
+        monkeypatch.setenv("PARSEABLE_TRACES_DATASET", "env-traces")
+
+        rb = backends.resolve_from_env()
+
+        assert rb.type == "parseable"
+        assert rb.headers["X-API-Key"] == "env-key"
+        assert rb.headers["X-P-Stream"] == "env-traces"
+
+
 class TestExcludeOTelInternalFilter:
     def _record(self, name: str, level: int = logging.DEBUG) -> logging.LogRecord:
         return logging.LogRecord(

--- a/website/docs/backends/overview.md
+++ b/website/docs/backends/overview.md
@@ -21,6 +21,7 @@ hermes-otel speaks plain **OTLP/HTTP**, so any OTLP-compatible backend should wo
 | **[Grafana LGTM](/backends/lgtm)** | Traces + metrics + logs | Local (single container) | OSS, no account |
 | **[Uptrace](/backends/uptrace)** | Traces + metrics + logs | Local (docker compose) · Self-hosted | OSS · premium license for HA features |
 | **[OpenObserve](/backends/openobserve)** | Traces + metrics + logs | Local (single container) · Self-hosted HA | OSS, no account |
+| **[Parseable](/backends/parseable)** | Traces + metrics + logs | Self-hosted · Cloud | OSS · paid cloud |
 | **[Honeycomb](/backends/honeycomb)** | Traces + metrics + logs | Cloud (US / EU) | Generous free tier · paid plans |
 | **[W&B Weave](/backends/weave)** | Traces | W&B Cloud · Dedicated Cloud · Self-Managed | W&B account |
 | **[telemetry.dev](/backends/telemetry)** (via generic `otlp`) | Traces + metrics + logs | Cloud | Free tier + paid plans |
@@ -52,6 +53,9 @@ hermes-otel speaks plain **OTLP/HTTP**, so any OTLP-compatible backend should wo
 **"I want W&B's Agents and Traces UI for Hermes runs"**
 → [W&B Weave](/backends/weave) — direct OTLP trace ingest with `WANDB_API_KEY`, `wandb.entity`, and `wandb.project`.
 
+**"I want Hermes agent runs plus traces, metrics, and logs in Parseable"**
+→ [Parseable](/backends/parseable) — direct OTLP ingest into three datasets, with Agent Observability and a ready-made dashboard.
+
 **"I want a hosted backend purpose-built for LLM/agent telemetry, `gen_ai.*`-native"**
 → [telemetry.dev](/backends/telemetry) — OTLP ingest with a single `Authorization: Bearer` header, via the generic `otlp` type.
 
@@ -76,6 +80,7 @@ Backends differ in which OTel signals they accept. The plugin auto-skips signals
 | Grafana LGTM | ✅ | ✅ | ✅ |
 | Uptrace | ✅ | ✅ | ✅ |
 | OpenObserve | ✅ | ✅ | ✅ |
+| Parseable | ✅ | ✅ | ✅ |
 | Honeycomb | ✅ | ✅ | ✅ |
 | W&B Weave | ✅ | ❌ | ❌ |
 | telemetry.dev | ✅ | ✅ | ✅ |
@@ -92,11 +97,12 @@ Single-backend selection is env-var-driven. First match wins:
 3. `OTEL_SIGNOZ_ENDPOINT` set → SigNoz
 4. `OTEL_UPTRACE_ENDPOINT` + DSN set → Uptrace
 5. `OTEL_OPENOBSERVE_ENDPOINT` + credentials set → OpenObserve
-6. `WANDB_API_KEY` + `WANDB_ENTITY` + `WANDB_PROJECT` set → W&B Weave
-7. `HONEYCOMB_API_KEY` set → Honeycomb
-8. `OTEL_JAEGER_ENDPOINT` set → Jaeger
-9. `OTEL_TEMPO_ENDPOINT` set → Tempo
-10. `OTEL_PHOENIX_ENDPOINT` set → Phoenix
+6. `OTEL_PARSEABLE_ENDPOINT` + `PARSEABLE_API_KEY` set → Parseable
+7. `WANDB_API_KEY` + `WANDB_ENTITY` + `WANDB_PROJECT` set → W&B Weave
+8. `HONEYCOMB_API_KEY` set → Honeycomb
+9. `OTEL_JAEGER_ENDPOINT` set → Jaeger
+10. `OTEL_TEMPO_ENDPOINT` set → Tempo
+11. `OTEL_PHOENIX_ENDPOINT` set → Phoenix
 
 Setting `backends:` in `config.yaml` overrides the env-var flow entirely — see [Multi-backend fan-out](/backends/multi-backend).
 

--- a/website/docs/backends/parseable.md
+++ b/website/docs/backends/parseable.md
@@ -1,0 +1,79 @@
+---
+sidebar_position: 11
+title: "Parseable"
+description: "Send Hermes traces, metrics and logs to Parseable and inspect agent runs in Agent Observability."
+---
+
+# Parseable
+
+[Parseable](https://www.parseable.com) accepts Hermes telemetry over
+OTLP/HTTP. The dedicated backend sends traces, metrics and logs to separate
+datasets and supplies the Parseable routing headers for each signal.
+
+## Prerequisites
+
+- A Parseable ingestor URL
+- An API key with dataset creation and ingest access
+- Three datasets: `hermes-traces`, `hermes-metrics` and `hermes-logs`
+
+Tag `hermes-traces` with `agent-observability` when creating it. This makes
+the dataset available in Parseable's Agents view. The
+[official Hermes guide](https://www.parseable.com/docs/ingest-data/ai-agents/hermes)
+includes dataset-creation commands and verification steps.
+
+## Configure hermes-otel
+
+```yaml
+backends:
+  - type: parseable
+    endpoint: https://parseable.example.com/v1/traces
+    api_key_env: PARSEABLE_API_KEY
+    traces_dataset: hermes-traces
+    metrics_dataset: hermes-metrics
+    logs_dataset: hermes-logs
+
+capture_logs: true
+```
+
+```bash
+export PARSEABLE_API_KEY="<parseable-api-key>"
+```
+
+Use the Parseable **ingestor** URL. In distributed deployments, the query/UI
+endpoint may reject ingestion. Keep `/v1/traces` on the configured endpoint;
+hermes-otel derives `/v1/metrics` and `/v1/logs` for the other exporters.
+
+The dataset fields are optional and default to the names shown above. The
+plugin adds these headers automatically:
+
+| Signal  | Dataset header               | Source header                  |
+| ------- | ---------------------------- | ------------------------------ |
+| Traces  | `X-P-Stream: hermes-traces`  | `X-P-Log-Source: otel-traces`  |
+| Metrics | `X-P-Stream: hermes-metrics` | `X-P-Log-Source: otel-metrics` |
+| Logs    | `X-P-Stream: hermes-logs`    | `X-P-Log-Source: otel-logs`    |
+
+All three exporters authenticate with `X-API-Key`. Prefer `api_key_env` over
+an inline key so credentials do not enter source control.
+
+## Environment-only setup
+
+Without a `backends:` list, hermes-otel can detect Parseable from:
+
+```bash
+export OTEL_PARSEABLE_ENDPOINT="https://parseable.example.com/v1/traces"
+export PARSEABLE_API_KEY="<parseable-api-key>"
+```
+
+Optional dataset overrides are `PARSEABLE_TRACES_DATASET`,
+`PARSEABLE_METRICS_DATASET` and `PARSEABLE_LOGS_DATASET`.
+
+## Verify
+
+Run a Hermes invocation, then select `hermes-traces` under **Traces** or
+**Agents** in Parseable. A complete run contains a root `agent` span plus
+nested `llm.*`, `api.*`, `tool.*` and `skill.*` spans when applicable.
+
+Parseable also publishes a
+[Hermes Agent Observability dashboard](https://github.com/parseablehq/dashboards/tree/main/hermes-agent-observability)
+covering agent runs, tokens, model calls, tools, latency, errors, traces,
+logs and metrics.

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -29,6 +29,12 @@ Setting any of these enables the matching backend. First match wins (see [Backen
 | `OTEL_JAEGER_ENDPOINT` | Jaeger | `http://localhost:4318/v1/traces` |
 | `OTEL_TEMPO_ENDPOINT` | Tempo | `http://localhost:4318/v1/traces` |
 | `OTEL_PHOENIX_ENDPOINT` | Phoenix | `http://localhost:6006/v1/traces` |
+| `OTEL_PARSEABLE_ENDPOINT` | Parseable ingestor | `https://parseable.example.com/v1/traces` |
+| `PARSEABLE_API_KEY` | Parseable | `p_key_...` |
+| `OTEL_PARSEABLE_API_KEY` | Parseable (plugin-specific alias) | `p_key_...` |
+| `PARSEABLE_TRACES_DATASET` | Parseable traces dataset | `hermes-traces` |
+| `PARSEABLE_METRICS_DATASET` | Parseable metrics dataset | `hermes-metrics` |
+| `PARSEABLE_LOGS_DATASET` | Parseable logs dataset | `hermes-logs` |
 | `HONEYCOMB_API_KEY` | Honeycomb | `hcaik_...` |
 | `OTEL_HONEYCOMB_API_KEY` | Honeycomb (plugin-specific alias) | `hcaik_...` |
 | `OTEL_HONEYCOMB_ENDPOINT` | Honeycomb (optional; overrides region default) | `https://api.eu1.honeycomb.io/v1/traces` |

--- a/website/docs/configuration/yaml.md
+++ b/website/docs/configuration/yaml.md
@@ -82,7 +82,7 @@ See [Conversation capture](/configuration/conversation-capture) for a worked exa
 
 ```yaml
 # Attach an OTel LoggingHandler to Python's logging so stdlib logger.info(...)
-# calls ship to any log-capable backend (SigNoz, LGTM, Uptrace, OpenObserve,
+# calls ship to any log-capable backend (SigNoz, LGTM, Uptrace, OpenObserve, Parseable,
 # or any OTLP collector). Every
 # record gets the active span's trace_id/span_id stamped on it automatically.
 # Off by default because attaching to root is invasive.

--- a/website/docs/reference/config-schema.md
+++ b/website/docs/reference/config-schema.md
@@ -42,12 +42,12 @@ Shared fields (all optional unless noted):
 
 | Field | Type | Description |
 |---|---|---|
-| `type` | string | **Required.** One of: `phoenix`, `langfuse`, `langsmith`, `signoz`, `jaeger`, `tempo`, `otlp`, `lgtm`, `uptrace`, `openobserve`, `honeycomb`, `weave` |
+| `type` | string | **Required.** One of: `phoenix`, `langfuse`, `langsmith`, `signoz`, `jaeger`, `tempo`, `otlp`, `lgtm`, `uptrace`, `openobserve`, `parseable`, `honeycomb`, `weave` |
 | `name` | string | Friendly name shown in logs (default: `type`) |
 | `endpoint` | string | Full OTLP endpoint URL (backend-specific defaults — see below) |
 | `traces` | bool | Override trace-export default (`true`). Set `false` for dashboard/query-only backends that should not receive span exports. `trace` is accepted as an alias. |
 | `metrics` | bool | Override metrics-export default for this backend |
-| `logs` | bool | Override logs-export default (on for `signoz`, `otlp`, `lgtm`, `uptrace`, `openobserve`, `honeycomb`; off elsewhere) |
+| `logs` | bool | Override logs-export default (on for `signoz`, `otlp`, `lgtm`, `uptrace`, `openobserve`, `parseable`, `honeycomb`; off elsewhere) |
 | `headers` | map | Per-backend HTTP headers (merged onto top-level `headers`) |
 
 ### Type-specific fields
@@ -114,6 +114,19 @@ Alias over `otlp` with a dedicated display name and all signals on by default. S
 | `logs` | bool | Default: `true` |
 
 Use `type: lgtm` (not `type: tempo`) when pointing at the `grafana/otel-lgtm` container — `tempo` is traces-only and would disable the logs/metrics fan-out.
+
+#### `parseable`
+
+| Field | Type | Description |
+|---|---|---|
+| `endpoint` | string | **Required.** Parseable ingestor OTLP traces endpoint, ending in `/v1/traces` |
+| `api_key` | string | Parseable API key (inline; discouraged) |
+| `api_key_env` | string | Env var holding the key (falls back to `PARSEABLE_API_KEY` / `OTEL_PARSEABLE_API_KEY`) |
+| `traces_dataset` | string | Traces dataset (default: `hermes-traces`) |
+| `metrics_dataset` | string | Metrics dataset (default: `hermes-metrics`) |
+| `logs_dataset` | string | Logs dataset (default: `hermes-logs`) |
+
+The plugin supplies signal-specific `X-P-Stream` and `X-P-Log-Source` headers automatically. See [Parseable](/backends/parseable).
 
 #### `honeycomb`
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -29,6 +29,7 @@ const sidebars: SidebarsConfig = {
         'backends/lgtm',
         'backends/uptrace',
         'backends/openobserve',
+        'backends/parseable',
         'backends/honeycomb',
         'backends/weave',
         'backends/telemetry',


### PR DESCRIPTION
Closes #57

## Summary

- add Parseable as a first-class OTLP backend
- route traces, metrics, and logs using signal-specific headers
- document configuration, environment variables, and datasets
- add resolver and header-routing tests

## Tests

- 660 tests passed
- coverage: 91.99%
- Ruff passed
- Black passed
- plugin security scan passed
- Docusaurus build passed
