### PR TITLE
fix(tracer): drop successful MCP keepalive ping spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ llm_input_preview_max_chars: 1200
 llm_output_preview_max_chars: 1200
 capture_previews: true          # false = suppress all input.value / output.value
 capture_sender_id: false        # true = add platform-prefixed user.id to spans
+suppress_mcp_ping_spans: true   # drop successful MCP keepalive "ping" spans (SDK 2.x); failed pings are kept
 project_name: hermes-prod       # supersedes OTEL_PROJECT_NAME
 global_tags:
   team: platform
@@ -417,6 +418,7 @@ Every field can be overridden by env var with prefix `HERMES_OTEL_` (scalars onl
 | `llm_output_preview_max_chars` | `HERMES_OTEL_LLM_OUTPUT_PREVIEW_MAX_CHARS` |
 | `capture_previews` | `HERMES_OTEL_CAPTURE_PREVIEWS` |
 | `capture_sender_id` | `HERMES_OTEL_CAPTURE_SENDER_ID` |
+| `suppress_mcp_ping_spans` | `HERMES_OTEL_SUPPRESS_MCP_PING_SPANS` |
 | `project_name` | `HERMES_OTEL_PROJECT_NAME` |
 | `span_batch_max_queue_size` | `HERMES_OTEL_SPAN_BATCH_MAX_QUEUE_SIZE` |
 | `span_batch_schedule_delay_ms` | `HERMES_OTEL_SPAN_BATCH_SCHEDULE_DELAY_MS` |
@@ -425,6 +427,10 @@ Every field can be overridden by env var with prefix `HERMES_OTEL_` (scalars onl
 | `force_flush_on_session_end` | `HERMES_OTEL_FORCE_FLUSH_ON_SESSION_END` |
 
 `pyyaml` is optional — if not installed, the YAML file is silently skipped and only env vars + defaults apply. Malformed YAML logs a single warning and falls back to defaults.
+
+#### MCP keepalive pings
+
+Hermes v0.21.0 moved to MCP Python SDK 2.x, which instruments every outbound MCP request with an OTel span on the global tracer provider — the one this plugin installs. Hermes sends a `ping` on every idle keepalive interval per MCP connection, so each one used to appear as a standalone one-span `MCP send ping` trace, burying real agent activity in the Live and Traces views. The plugin now drops successful pings before they reach any backend or the live store (`suppress_mcp_ping_spans: true`, the default). Pings that fail keep their error status and are always exported, so MCP connectivity problems stay visible. Set `suppress_mcp_ping_spans: false` (or `HERMES_OTEL_SUPPRESS_MCP_PING_SPANS=false`) to see every ping while debugging a server.
 
 #### Privacy mode
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -140,6 +140,18 @@
 # dashboard_live: true
 # dashboard_live_max_spans: 1000
 
+# ── MCP keepalive pings ───────────────────────────────────────────────────────
+#
+# The MCP Python SDK 2.x (Hermes v0.21.0+) creates an OTel span for every
+# JSON-RPC request it sends — including the `ping` Hermes fires on each idle
+# keepalive interval, per MCP connection. Each ping lands as its own one-span
+# "MCP send ping" trace, which quickly buries real agent activity. True drops
+# the successful pings before they reach any backend or the live dashboard.
+# Failed pings (error status) are always kept — they are the useful ones when
+# debugging MCP connectivity. Set false to see every ping.
+# Also settable via HERMES_OTEL_SUPPRESS_MCP_PING_SPANS.
+# suppress_mcp_ping_spans: true
+
 # ── Lifecycle / cleanup ───────────────────────────────────────────────────────
 
 # Orphan-turn sweep TTL. If a session's root span has been open longer than

--- a/hermes_otel/plugin_config.py
+++ b/hermes_otel/plugin_config.py
@@ -209,6 +209,13 @@ class HermesOtelConfig:
     # (ring buffers); set false to disable the in-process store entirely.
     dashboard_live: bool = True
     dashboard_live_max_spans: int = 1000
+    # ── MCP keepalive noise ─────────────────────────────────────────────
+    # MCP Python SDK 2.x (Hermes v0.21.0+) emits a CLIENT span for every
+    # JSON-RPC request, including the periodic keepalive ``ping`` Hermes sends
+    # per MCP connection. Each surfaces as a standalone one-span
+    # "MCP send ping" trace. True (default) drops the successful ones before
+    # they reach any exporter or the live store; failed pings are always kept.
+    suppress_mcp_ping_spans: bool = True
     # ── Multi-backend fan-out ───────────────────────────────────────────
     backends: Optional[Tuple[BackendConfig, ...]] = None
 
@@ -353,6 +360,7 @@ def _coerce_from_yaml(key: str, value: Any) -> Any:
         "emit_genai_metrics",
         "skill_spans",
         "dashboard_live",
+        "suppress_mcp_ping_spans",
     ):
         if isinstance(value, bool):
             return value
@@ -439,6 +447,7 @@ def _load_env_overrides() -> Dict[str, Any]:
     take("skill_spans", _parse_bool)
     take("dashboard_live", _parse_bool)
     take("dashboard_live_max_spans", _parse_int)
+    take("suppress_mcp_ping_spans", _parse_bool)
 
     proj = os.getenv(_ENV_PREFIX + "PROJECT_NAME", "").strip()
     if proj:

--- a/hermes_otel/tracer.py
+++ b/hermes_otel/tracer.py
@@ -108,8 +108,52 @@ if _OTEL_AVAILABLE:
         def force_flush(self, timeout_millis: int = 30000) -> bool:
             return True
 
+    class _MCPPingFilterProcessor(SpanProcessor):
+        """Delegating SpanProcessor that drops successful MCP keepalive ``ping`` spans.
+
+        MCP Python SDK 2.x (Hermes v0.21.0+) instruments every outbound JSON-RPC
+        request with a CLIENT span on the *global* TracerProvider — the one this
+        plugin installs. Hermes sends ``ping`` on every idle keepalive interval,
+        per MCP connection, so each one surfaces as a standalone single-span
+        ``MCP send ping`` trace that carries no agent activity (#62). Skipping
+        them at ``on_end`` keeps them out of the OTLP exporters *and* the live
+        dashboard store alike. Pings that failed (``StatusCode.ERROR``) are
+        passed through — that is the one case where the span is diagnostic.
+        """
+
+        def __init__(self, inner: SpanProcessor) -> None:
+            self._inner = inner
+
+        def on_start(self, span: Any, parent_context: Any = None) -> None:
+            self._inner.on_start(span, parent_context=parent_context)
+
+        def on_end(self, span: Any) -> None:
+            if _is_mcp_keepalive_ping(span):
+                return
+            self._inner.on_end(span)
+
+        def shutdown(self) -> None:
+            self._inner.shutdown()
+
+        def force_flush(self, timeout_millis: int = 30000) -> bool:
+            return self._inner.force_flush(timeout_millis)
+
 else:  # pragma: no cover — plugin is unusable without OTel
     _LiveSpanProcessor = None  # type: ignore[assignment, misc]
+    _MCPPingFilterProcessor = None  # type: ignore[assignment, misc]
+
+
+def _is_mcp_keepalive_ping(span: Any) -> bool:
+    """True for a finished MCP ``ping`` request span that did not fail.
+
+    Matches on the SDK's ``mcp.method.name`` attribute, with the span name as
+    a fallback, so it is robust to either changing on its own.
+    """
+    attrs = getattr(span, "attributes", None) or {}
+    if attrs.get("mcp.method.name") != "ping" and getattr(span, "name", None) != "MCP send ping":
+        return False
+    code = getattr(getattr(span, "status", None), "status_code", None)
+    return getattr(code, "name", None) != "ERROR"
 
 
 class _LiveLogNoiseFilter(logging.Filter):
@@ -452,6 +496,14 @@ class HermesOTelPlugin:
                 provider_kwargs["sampler"] = ParentBased(TraceIdRatioBased(self.config.sample_rate))
             provider = TracerProvider(**provider_kwargs)
 
+            def _attach(processor: Any) -> None:
+                # Every processor sits behind the same MCP keepalive filter so
+                # the OTLP backends and the live dashboard agree on what a
+                # trace list looks like. See _MCPPingFilterProcessor.
+                if self.config.suppress_mcp_ping_spans:
+                    processor = _MCPPingFilterProcessor(processor)
+                provider.add_span_processor(processor)
+
             # In-process live store for the zero-config dashboard. Added FIRST so
             # the dashboard renders the agent's activity even with no OTLP
             # backend configured — install the plugin, open the tab, see traces.
@@ -464,7 +516,7 @@ class HermesOTelPlugin:
                     max_rows=self.config.dashboard_live_max_spans,
                 )
                 if store is not None:
-                    provider.add_span_processor(_LiveSpanProcessor(store))
+                    _attach(_LiveSpanProcessor(store))
                     self._live_active = True
                     # Tail agent logs into the live store too (Logs tab), opt-in
                     # via capture_logs so we don't capture the root logger by default.
@@ -504,7 +556,7 @@ class HermesOTelPlugin:
                             max_export_batch_size=self.config.span_batch_max_export_batch_size,
                             export_timeout_millis=self.config.span_batch_export_timeout_ms,
                         )
-                        provider.add_span_processor(processor)
+                        _attach(processor)
                         self._span_processors.append(processor)
                     except Exception as e:
                         logger.error(f"[hermes-otel] ✗ {b.display_name} traces init failed: {e}")

--- a/tests/unit/test_mcp_ping_filter.py
+++ b/tests/unit/test_mcp_ping_filter.py
@@ -1,0 +1,191 @@
+"""MCP keepalive ``ping`` span suppression (issue #62).
+
+MCP Python SDK 2.x (Hermes v0.21.0+) records a CLIENT span for every
+outbound JSON-RPC request on the global TracerProvider — the one this plugin
+installs — so every keepalive ``ping`` became a standalone one-span
+``MCP send ping`` trace. The plugin wraps each span processor in
+``_MCPPingFilterProcessor`` which drops the successful ones at ``on_end``.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from hermes_otel.plugin_config import HermesOtelConfig, load_config
+from hermes_otel.tracer import HermesOTelPlugin, _is_mcp_keepalive_ping, _MCPPingFilterProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind, Status, StatusCode
+
+# Exactly what mcp/shared/jsonrpc_dispatcher.py emits for a keepalive.
+_PING_ATTRS = {"mcp.method.name": "ping", "jsonrpc.request.id": "42"}
+
+
+def _emit_mcp_request(tracer, method: str, *, error: bool = False, name: str = None):
+    with tracer.start_as_current_span(
+        name or f"MCP send {method}",
+        kind=SpanKind.CLIENT,
+        attributes={"mcp.method.name": method, "jsonrpc.request.id": "42"},
+    ) as span:
+        if error:
+            span.set_status(Status(StatusCode.ERROR, "Connection closed"))
+
+
+@pytest.fixture()
+def filtered_pipeline():
+    """Provider whose single processor sits behind the ping filter."""
+    exporter = InMemorySpanExporter()
+    inner = SimpleSpanProcessor(exporter)
+    provider = TracerProvider(resource=Resource.create({"service.name": "ping-filter-test"}))
+    provider.add_span_processor(_MCPPingFilterProcessor(inner))
+    # Same tracer name the SDK uses, resolved through this provider.
+    tracer = provider.get_tracer("mcp-python-sdk")
+    try:
+        yield exporter, tracer
+    finally:
+        provider.shutdown()
+
+
+class TestPredicate:
+    def test_successful_ping_by_attribute(self):
+        class S:
+            name = "MCP send ping"
+            attributes = _PING_ATTRS
+            status = Status(StatusCode.UNSET)
+
+        assert _is_mcp_keepalive_ping(S()) is True
+
+    def test_failed_ping_is_kept(self):
+        class S:
+            name = "MCP send ping"
+            attributes = _PING_ATTRS
+            status = Status(StatusCode.ERROR, "boom")
+
+        assert _is_mcp_keepalive_ping(S()) is False
+
+    def test_name_fallback_without_attributes(self):
+        class S:
+            name = "MCP send ping"
+            attributes = None
+            status = None
+
+        assert _is_mcp_keepalive_ping(S()) is True
+
+    def test_other_mcp_requests_are_not_pings(self):
+        class S:
+            name = "MCP send tools/call echo"
+            attributes = {"mcp.method.name": "tools/call"}
+            status = Status(StatusCode.OK)
+
+        assert _is_mcp_keepalive_ping(S()) is False
+
+
+class TestFilterProcessor:
+    def test_successful_ping_never_reaches_exporter(self, filtered_pipeline):
+        exporter, tracer = filtered_pipeline
+        _emit_mcp_request(tracer, "ping")
+        assert exporter.get_finished_spans() == ()
+
+    def test_failed_ping_is_exported(self, filtered_pipeline):
+        exporter, tracer = filtered_pipeline
+        _emit_mcp_request(tracer, "ping", error=True)
+        spans = exporter.get_finished_spans()
+        assert [s.name for s in spans] == ["MCP send ping"]
+        assert spans[0].status.status_code == StatusCode.ERROR
+
+    def test_real_mcp_traffic_is_exported(self, filtered_pipeline):
+        exporter, tracer = filtered_pipeline
+        _emit_mcp_request(tracer, "tools/call", name="MCP send tools/call echo")
+        _emit_mcp_request(tracer, "ping")
+        _emit_mcp_request(tracer, "tools/list")
+        assert [s.name for s in exporter.get_finished_spans()] == [
+            "MCP send tools/call echo",
+            "MCP send tools/list",
+        ]
+
+    def test_lifecycle_calls_delegate(self):
+        class Inner:
+            calls = []
+
+            def on_start(self, span, parent_context=None):
+                self.calls.append(("on_start", span, parent_context))
+
+            def on_end(self, span):
+                self.calls.append(("on_end", span))
+
+            def shutdown(self):
+                self.calls.append(("shutdown",))
+
+            def force_flush(self, timeout_millis=30000):
+                self.calls.append(("force_flush", timeout_millis))
+                return True
+
+        inner = Inner()
+        proc = _MCPPingFilterProcessor(inner)
+        proc.on_start("span", parent_context="ctx")
+        assert proc.force_flush(123) is True
+        proc.shutdown()
+        assert inner.calls == [("on_start", "span", "ctx"), ("force_flush", 123), ("shutdown",)]
+
+
+class TestConfig:
+    def test_default_on(self, tmp_path):
+        assert HermesOtelConfig().suppress_mcp_ping_spans is True
+        assert load_config(path=tmp_path / "nonexistent.yaml").suppress_mcp_ping_spans is True
+
+    def test_yaml_opt_out(self, tmp_path):
+        pytest.importorskip("yaml")
+        p = tmp_path / "config.yaml"
+        p.write_text("suppress_mcp_ping_spans: false\n")
+        assert load_config(path=p).suppress_mcp_ping_spans is False
+
+    def test_env_opt_out(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_OTEL_SUPPRESS_MCP_PING_SPANS", "false")
+        assert load_config(path=tmp_path / "nonexistent.yaml").suppress_mcp_ping_spans is False
+
+
+class TestInitWiring:
+    """``init()`` (live-only, zero-config) puts the live store behind the filter."""
+
+    def _init_live_only(self, monkeypatch, suppress: bool):
+        for var in (
+            "OTEL_PHOENIX_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_LANGFUSE_ENDPOINT",
+            "LANGSMITH_TRACING", "OTEL_SIGNOZ_ENDPOINT", "OTEL_JAEGER_ENDPOINT", "OTEL_TEMPO_ENDPOINT",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        import hermes_otel.live_store as ls
+
+        ls._LIVE_STORE = None
+        plugin = HermesOTelPlugin(
+            config=HermesOtelConfig(dashboard_live=True, suppress_mcp_ping_spans=suppress)
+        )
+        # The global-provider install is patched out so the test never mutates
+        # process-wide OTel state; grab the provider the plugin built instead.
+        with patch("hermes_otel.tracer.trace.set_tracer_provider") as set_provider:
+            assert plugin.init() is True
+        provider = set_provider.call_args[0][0]
+        return provider, ls
+
+    @pytest.mark.parametrize("suppress", [True, False])
+    def test_live_store_respects_setting(self, monkeypatch, tmp_path, suppress):
+        import hermes_otel.live_store as ls_mod
+
+        monkeypatch.setattr(ls_mod, "_default_db_path", lambda: str(tmp_path / "live.db"))
+        provider, ls = self._init_live_only(monkeypatch, suppress)
+        try:
+            # Same tracer name the MCP SDK uses, resolved through this provider.
+            tracer = provider.get_tracer("mcp-python-sdk")
+            _emit_mcp_request(tracer, "ping")
+            _emit_mcp_request(tracer, "ping", error=True)
+            _emit_mcp_request(tracer, "tools/list")
+            names = sorted(s["name"] for s in ls.get_live_store().spans())
+            if suppress:
+                assert names == ["MCP send ping", "MCP send tools/list"]  # only the FAILED ping
+                statuses = {s["name"]: s["status"] for s in ls.get_live_store().spans()}
+                assert statuses["MCP send ping"] == "ERROR"
+            else:
+                assert names == ["MCP send ping", "MCP send ping", "MCP send tools/list"]
+        finally:
+            provider.shutdown()
+            ls._LIVE_STORE = None

--- a/tests/unit/test_mcp_ping_filter.py
+++ b/tests/unit/test_mcp_ping_filter.py
@@ -10,13 +10,14 @@ installs — so every keepalive ``ping`` became a standalone one-span
 from unittest.mock import patch
 
 import pytest
-from hermes_otel.plugin_config import HermesOtelConfig, load_config
-from hermes_otel.tracer import HermesOTelPlugin, _is_mcp_keepalive_ping, _MCPPingFilterProcessor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import SpanKind, Status, StatusCode
+
+from hermes_otel.plugin_config import HermesOtelConfig, load_config
+from hermes_otel.tracer import HermesOTelPlugin, _is_mcp_keepalive_ping, _MCPPingFilterProcessor
 
 # Exactly what mcp/shared/jsonrpc_dispatcher.py emits for a keepalive.
 _PING_ATTRS = {"mcp.method.name": "ping", "jsonrpc.request.id": "42"}
@@ -150,8 +151,13 @@ class TestInitWiring:
 
     def _init_live_only(self, monkeypatch, suppress: bool):
         for var in (
-            "OTEL_PHOENIX_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_LANGFUSE_ENDPOINT",
-            "LANGSMITH_TRACING", "OTEL_SIGNOZ_ENDPOINT", "OTEL_JAEGER_ENDPOINT", "OTEL_TEMPO_ENDPOINT",
+            "OTEL_PHOENIX_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "OTEL_LANGFUSE_ENDPOINT",
+            "LANGSMITH_TRACING",
+            "OTEL_SIGNOZ_ENDPOINT",
+            "OTEL_JAEGER_ENDPOINT",
+            "OTEL_TEMPO_ENDPOINT",
         ):
             monkeypatch.delenv(var, raising=False)
         import hermes_otel.live_store as ls

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -69,6 +69,7 @@ Each of these overrides the corresponding field in `config.yaml`. See [`config.y
 | `HERMES_OTEL_SKILL_SPANS` | `skill_spans` | bool |
 | `HERMES_OTEL_DASHBOARD_LIVE` | `dashboard_live` | bool |
 | `HERMES_OTEL_DASHBOARD_LIVE_MAX_SPANS` | `dashboard_live_max_spans` | int |
+| `HERMES_OTEL_SUPPRESS_MCP_PING_SPANS` | `suppress_mcp_ping_spans` | bool |
 
 ## Paths
 

--- a/website/docs/configuration/yaml.md
+++ b/website/docs/configuration/yaml.md
@@ -126,6 +126,18 @@ skill_spans: true
 
 See [Span hierarchy → skill.*](/architecture/span-hierarchy#skill) for the span shape and attributes.
 
+## MCP keepalive pings
+
+```yaml
+# MCP Python SDK 2.x (Hermes v0.21.0+) emits an OTel span for every MCP
+# request, including the `ping` Hermes sends on each idle keepalive interval
+# per connection. Each one lands as a standalone one-span "MCP send ping"
+# trace. True drops the successful pings before any exporter or the live
+# store sees them; failed pings (error status) are always kept.
+# Env: HERMES_OTEL_SUPPRESS_MCP_PING_SPANS. Default: true.
+suppress_mcp_ping_spans: true
+```
+
 ## Lifecycle / cleanup
 
 ```yaml


### PR DESCRIPTION
Fixes #62.

## Problem

Hermes v0.21.0 upgraded the MCP Python SDK to 2.x, which instruments every outbound JSON-RPC request with an OpenTelemetry CLIENT span (`mcp/shared/_otel.py`, tracer name `mcp-python-sdk`). The SDK's tracer resolves through the **global** `TracerProvider` — the one hermes-otel installs — so those spans flow into every span processor the plugin wires up: the OTLP exporters *and* the live dashboard store.

Hermes sends a `ping` on every idle keepalive interval, per MCP connection (`tools/mcp_tool.py`, default 180 s, floor 5 s). Each ping has no active parent span, so it lands as a standalone one-span trace named `MCP send ping` with `mcp.method.name=ping`. With several servers, profiles, or a long-running gateway, they bury real agent activity in the Live and Traces views and in every backend.

## Reproduction

Isolated `HERMES_HOME`, one local Streamable HTTP MCP server, `keepalive_interval: 5`, one `hermes chat --oneshot` turn that idles for 40 s in a terminal tool call and then calls one MCP tool. Traces exported to a k3s Phoenix and mirrored into the live store:

| | traces | `MCP send ping` spans | real agent trace |
|---|---|---|---|
| v1.1.0 (before) | 27 | 23 (all root, all `UNSET` status) | 1 |
| this PR (after) | 4 | 0 | 1 |

The `MCP send initialize`, `MCP send tools/list` and `MCP send tools/call echo` spans are untouched in both runs, and the MCP server's access log confirms the pings were still sent.

Failed pings: the filter passes any ping whose status is `ERROR` (unit-tested with an `InMemorySpanExporter`). One nuance worth knowing when reading traces: MCP SDK 2.0.0 sets `ERROR` only for exceptions raised *inside* its span block (transport write failures, `fail_after` request timeouts, caller cancellation). A JSON-RPC error *outcome*, including the synthetic `CONNECTION_CLOSED` the dispatcher injects when the transport tears down, is raised **after** the span has ended, so those pings end `UNSET` and are dropped like any other. In two additional runs (server killed mid-turn; a TCP proxy frozen then killed with a ping in flight) Hermes detected the dead connection through the transport and surfaced it as a burst of `MCP send initialize` reconnect spans plus its own `keepalive failed` log line, which remain visible. Also observed: once a ping times out on Hermes' side it switches that connection's keepalive to `tools/list`, which this PR deliberately does not filter (it is indistinguishable from real discovery).

## Fix

- `tracer.py`: a small delegating `_MCPPingFilterProcessor` that skips a span at `on_end` when `_is_mcp_keepalive_ping(span)` — i.e. `mcp.method.name == "ping"` (span name `MCP send ping` as fallback) **and** the status is not `ERROR`. Every processor the plugin attaches (live store + one `BatchSpanProcessor` per backend) is wrapped by the same `_attach()` helper, so the dashboard and all backends agree on what a trace list looks like. Dropped at the processor, the span never reaches an exporter queue or the SQLite live store.
- `plugin_config.py`: `suppress_mcp_ping_spans: bool = True`, YAML + `HERMES_OTEL_SUPPRESS_MCP_PING_SPANS`. Set `false` to see every ping while debugging a server.
- Docs: README, `config.yaml.example`, website `configuration/yaml.md` and `environment-variables.md`.

Why a processor wrapper rather than a `Sampler`: sampling decisions are made at span start, before the outcome is known, so a sampler could not keep failed pings. The wrapper sees the finished span.

Why default-on: successful keepalive pings carry no information about agent activity and are pure ingestion/storage cost. Failed ones are always kept. Users who want them get them with one line of config.

## Tests

`tests/unit/test_mcp_ping_filter.py` (13 tests): predicate cases, filter behaviour with an `InMemorySpanExporter` (successful ping dropped, failed ping exported, other MCP requests exported, lifecycle delegation), config default/YAML/env parsing, and `init()` wiring with the live store for both settings. Full suite: 676 passed, 3 skipped. `scripts/scan_plugin_artifact.py`: safe.

## Follow-ups (not in this PR)

- The reporter's preferred UX also included a dashboard checkbox to reveal hidden pings, and the dashboard's backend config lookup only searched `plugins/hermes_otel/config.yaml` rather than the documented `$HERMES_HOME/hermes_otel.yaml`. Both are addressed in the follow-up PR #65.
