### PR TITLE
fix: recover session_id from turn_id on dispatch paths without session_id

### DIFF
--- a/hermes_otel/hooks.py
+++ b/hermes_otel/hooks.py
@@ -851,7 +851,6 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
         # Explicit session attrs so backend session queries group this span
         # even when session_id was recovered from turn_id rather than passed.
         attributes.setdefault("session.id", truncate_string(session_id, 200))
-        attributes.setdefault("session_id", truncate_string(session_id, 200))
         attributes.update(_gen_ai_attributes(session_id, "execute_tool", kwargs))
         attributes.update(_correlation_attributes(tracer, session_id, kwargs))
         attributes.update(_session_sender_attributes(tracer, session_id))
@@ -946,7 +945,6 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
         session_id = session_id_from_turn_id(kwargs.get("turn_id"))
     if session_id:
         attributes.setdefault("session.id", truncate_string(session_id, 200))
-        attributes.setdefault("session_id", truncate_string(session_id, 200))
         attributes.update(_gen_ai_attributes(session_id, "execute_tool", kwargs))
         attributes.update(_correlation_attributes(tracer, session_id, kwargs))
         attributes.update(_session_sender_attributes(tracer, session_id))

--- a/hermes_otel/hooks.py
+++ b/hermes_otel/hooks.py
@@ -841,7 +841,17 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
 
     # Summary roll-up (requires session_id to bucket into the right turn).
     session_id = kwargs.get("session_id")
+    if not session_id:
+        # Some dispatch paths (subagents, registry tools, batch workers) emit
+        # tool hooks without a session_id. turn_id is "<session_id>:<task_id>:<hex>"
+        # — recover the session so the span joins the session's parent stack
+        # (and therefore its trace) instead of starting an orphan trace.
+        session_id = session_id_from_turn_id(kwargs.get("turn_id"))
     if session_id:
+        # Explicit session attrs so backend session queries group this span
+        # even when session_id was recovered from turn_id rather than passed.
+        attributes.setdefault("session.id", truncate_string(session_id, 200))
+        attributes.setdefault("session_id", truncate_string(session_id, 200))
         attributes.update(_gen_ai_attributes(session_id, "execute_tool", kwargs))
         attributes.update(_correlation_attributes(tracer, session_id, kwargs))
         attributes.update(_session_sender_attributes(tracer, session_id))
@@ -930,7 +940,13 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
 
     # Summary roll-up
     session_id = kwargs.get("session_id")
+    if not session_id:
+        # Match on_pre_tool_call: recover the session from turn_id so the
+        # closing span joins the session's parent stack/trace.
+        session_id = session_id_from_turn_id(kwargs.get("turn_id"))
     if session_id:
+        attributes.setdefault("session.id", truncate_string(session_id, 200))
+        attributes.setdefault("session_id", truncate_string(session_id, 200))
         attributes.update(_gen_ai_attributes(session_id, "execute_tool", kwargs))
         attributes.update(_correlation_attributes(tracer, session_id, kwargs))
         attributes.update(_session_sender_attributes(tracer, session_id))
@@ -1267,6 +1283,13 @@ def on_pre_api_request(
     debug_log(f"  tracer.is_enabled={tracer.is_enabled}")
     if not tracer.is_enabled:
         return
+
+    if not session_id:
+        # Some dispatch paths (subagents, batch workers) emit api hooks without
+        # a session_id. turn_id is "<session_id>:<task_id>:<hex>" — recover the
+        # session so the api span nests in the session's trace instead of
+        # starting an orphan trace.
+        session_id = session_id_from_turn_id(kwargs.get("turn_id"))
 
     tracer.sweep_expired_turns()
 


### PR DESCRIPTION
## Summary
- Some dispatch paths (subagents, registry tools, batch workers) emit tool/API hooks without a `session_id`, so those spans started orphan traces instead of joining the session's trace.
- `turn_id` is `<session_id>:<task_id>:<hex>` — recover the session from it in `on_pre_tool_call`, `on_post_tool_call`, and `on_pre_api_request`.
- Set explicit `session.id`/`session_id` attributes when recovered so backend session queries group the span correctly.

## Test Plan
- [x] `uv run pytest`: 657 passed; the 5 failures in `test_config_path_resolution.py`/`test_dashboard_config_path.py` are pre-existing on clean `main`.