### PR TITLE
feat(metrics): export prompt cache hit rate inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,27 @@ Tested with:
 
 Any OTLP HTTP endpoint should work.
 
+### Prompt-cache hit rate
+
+The plugin exports provider-reported cache usage as two low-cardinality counters:
+
+- `hermes.prompt_cache.tokens`, split by `cache_result=hit|miss`
+- `hermes.prompt_cache.observations`, split by whether each observed request hit or missed
+
+Compute the weighted token hit rate from counter rates (or deltas), not by averaging
+per-request percentages:
+
+```text
+rate(tokens{cache_result="hit"})
+────────────────────────────────────────────────────────
+rate(tokens{cache_result="hit"}) + rate(tokens{cache_result="miss"})
+```
+
+`miss` includes uncached input and cache-write tokens. The metric is omitted when a
+provider did not report cache-read metadata, so unknown support is not rendered as a
+zero-percent hit rate. This requires a Hermes hook payload with
+`usage.available_fields.cache_read_tokens=true`.
+
 - For Phoenix see [docker-compose/phoenix.yaml](docker-compose/phoenix.yaml)
 - For Langfuse see [https://langfuse.com/self-hosting/deployment/docker-compose](https://langfuse.com/self-hosting/deployment/docker-compose)
 - For Langsmith see [https://smith.langchain.com/](https://smith.langchain.com/)

--- a/hermes_otel/hooks.py
+++ b/hermes_otel/hooks.py
@@ -220,6 +220,44 @@ def _record_usage_metrics(tracer, totals: Dict[str, int], base_attrs: Dict[str, 
             tracer.record_metric("token_usage", v, {**base_attrs, "token_type": label})
 
 
+def _record_prompt_cache_metrics(
+    tracer,
+    totals: Dict[str, int],
+    available_fields: Any,
+    base_attrs: Dict[str, Any],
+) -> None:
+    """Record cache hit/miss token counters when the provider reported cache usage.
+
+    Hermes normalizes ``prompt_tokens`` to the uncached portion. Cache writes are
+    also misses, so the weighted token hit rate is ``hit / (hit + miss)``.
+    Missing availability metadata is unknown rather than a zero-percent hit rate.
+    """
+    cache_read = totals["cache_read_tokens"]
+    cache_read_available = isinstance(available_fields, dict) and available_fields.get(
+        "cache_read_tokens"
+    )
+    # A positive count proves that the provider reported the field, including on
+    # Hermes releases predating ``available_fields``. Only an explicit zero needs
+    # the presence bit to avoid treating unsupported metadata as a cache miss.
+    if not cache_read_available and not cache_read:
+        return
+
+    cache_miss = totals["prompt_tokens"] + totals["cache_write_tokens"]
+    if cache_read:
+        tracer.record_metric(
+            "prompt_cache_tokens", cache_read, {**base_attrs, "cache_result": "hit"}
+        )
+    if cache_miss:
+        tracer.record_metric(
+            "prompt_cache_tokens", cache_miss, {**base_attrs, "cache_result": "miss"}
+        )
+    tracer.record_metric(
+        "prompt_cache_observations",
+        1,
+        {**base_attrs, "cache_result": "hit" if cache_read else "miss"},
+    )
+
+
 def _genai_metric_dims(
     model: Any,
     provider: Any,
@@ -1446,6 +1484,12 @@ def on_post_api_request(
         if session_id:
             metric_attrs["session_id"] = session_id
         _record_usage_metrics(tracer, totals, metric_attrs)
+        _record_prompt_cache_metrics(
+            tracer,
+            totals,
+            usage.get("available_fields"),
+            {"model": model, "provider": provider, "api_mode": api_mode},
+        )
 
         # OTel GenAI spec token-usage histogram (dual-write; low cardinality).
         if tracer.config.emit_genai_metrics:

--- a/hermes_otel/tracer.py
+++ b/hermes_otel/tracer.py
@@ -260,6 +260,8 @@ class HermesOTelPlugin:
         self._meter_provider = None
         self._session_count = None
         self._token_usage = None
+        self._prompt_cache_tokens = None
+        self._prompt_cache_observations = None
         self._cost_usage = None
         self._tool_duration = None
         self._message_count = None
@@ -665,6 +667,16 @@ class HermesOTelPlugin:
             "hermes.token.usage",
             description="Tokens consumed by type",
         )
+        self._prompt_cache_tokens = self._meter.create_counter(
+            "hermes.prompt_cache.tokens",
+            unit="{token}",
+            description="Prompt tokens by cache result",
+        )
+        self._prompt_cache_observations = self._meter.create_counter(
+            "hermes.prompt_cache.observations",
+            unit="{request}",
+            description="Requests with provider-reported prompt-cache usage",
+        )
         self._cost_usage = self._meter.create_counter(
             "hermes.cost.usage",
             description="USD cost per message",
@@ -951,6 +963,12 @@ class HermesOTelPlugin:
             self._session_count.add(1, attrs)
         elif name == "token_usage":
             self._token_usage.add(int(value), attrs)
+        elif name == "prompt_cache_tokens":
+            if self._prompt_cache_tokens is not None:
+                self._prompt_cache_tokens.add(int(value), attrs)
+        elif name == "prompt_cache_observations":
+            if self._prompt_cache_observations is not None:
+                self._prompt_cache_observations.add(1, attrs)
         elif name == "cost_usage":
             self._cost_usage.add(value, attrs)
         elif name == "tool_duration":

--- a/tests/integration/test_metrics_pipeline.py
+++ b/tests/integration/test_metrics_pipeline.py
@@ -137,6 +137,54 @@ class TestTokenUsageMetric:
         # 100 (input) + 50 (output) = 150
         assert value == 150
 
+    def test_prompt_cache_metrics_distinguish_reported_usage_from_unknown(
+        self, inmemory_otel_with_metrics
+    ):
+        _, metric_reader, _ = inmemory_otel_with_metrics
+
+        _api_call(
+            usage={
+                "prompt_tokens": 30,
+                "output_tokens": 5,
+                "cache_read_tokens": 70,
+                "cache_write_tokens": 10,
+                "available_fields": {"cache_read_tokens": True},
+            }
+        )
+
+        tokens = _get_metric(metric_reader, "hermes.prompt_cache.tokens")
+        values = {point.attributes["cache_result"]: point.value for point in _points(tokens)}
+        assert values == {"hit": 70, "miss": 40}
+        assert _get_metric_value(metric_reader, "hermes.prompt_cache.observations") == 1
+
+        _api_call(
+            session_id="unknown",
+            usage={"prompt_tokens": 100, "output_tokens": 5, "cache_read_tokens": 0},
+        )
+
+        values = {point.attributes["cache_result"]: point.value for point in _points(tokens)}
+        assert values == {"hit": 70, "miss": 40}
+        assert _get_metric_value(metric_reader, "hermes.prompt_cache.observations") == 1
+
+    def test_explicit_zero_cache_read_is_an_observed_miss(self, inmemory_otel_with_metrics):
+        _, metric_reader, _ = inmemory_otel_with_metrics
+
+        _api_call(
+            usage={
+                "prompt_tokens": 100,
+                "output_tokens": 5,
+                "cache_read_tokens": 0,
+                "available_fields": {"cache_read_tokens": True},
+            }
+        )
+
+        tokens = _get_metric(metric_reader, "hermes.prompt_cache.tokens")
+        assert [(point.attributes["cache_result"], point.value) for point in _points(tokens)] == [
+            ("miss", 100)
+        ]
+        observations = _get_metric(metric_reader, "hermes.prompt_cache.observations")
+        assert [point.attributes["cache_result"] for point in _points(observations)] == ["miss"]
+
     def test_reasoning_token_type_recorded(self, inmemory_otel_with_metrics):
         _, metric_reader, _ = inmemory_otel_with_metrics
 


### PR DESCRIPTION
## Summary

- export `hermes.prompt_cache.tokens` with `cache_result=hit|miss`
- export `hermes.prompt_cache.observations` for provider-reported cache usage
- keep model/provider/API-mode dimensions bounded and omit per-session identifiers
- document the weighted token hit-rate calculation

## Semantics

The weighted token hit rate is:

```text
rate(tokens{cache_result="hit"})
/
(rate(tokens{cache_result="hit"}) + rate(tokens{cache_result="miss"}))
```

Cache writes count as misses. Metrics are omitted when provider metadata is unavailable rather than reporting a false 0% hit rate.

Explicit-zero detection uses the additive Hermes hook contract proposed in NousResearch/hermes-agent#108249.

## Verification

- full suite: 773 passed, 3 skipped, 6 deselected
- Ruff and Black checks passed
- focused metric integration suite: 14 passed
- live OTLP/HTTP export into Sigiro returned:
  - hit tokens: 70
  - miss tokens: 40
  - observations: 1
- `git diff --check` passed
- call-flow and adversarial reviews found no correctness issues
