### PR TITLE
fix: make Hermes skill telemetry discoverable and correct

### DIFF
--- a/hermes_otel/__init__.py
+++ b/hermes_otel/__init__.py
@@ -88,8 +88,27 @@ def register(ctx):
             ctx.register_skill(
                 "observability",
                 skill_path,
-                description="Turn on and understand OpenTelemetry observability for this Hermes agent.",
+                description=(
+                    "Use for historical Hermes behavior, skill/tool usage, latency, errors, or cost. "
+                    "Configure and query this agent's OpenTelemetry."
+                ),
             )
             debug_log("registered bundled skill: hermes_otel:observability")
     except Exception:
         debug_log("register_skill unavailable; skipping bundled observability skill")
+
+    # Plugin skills are explicit-load only and therefore do not appear in
+    # Hermes' <available_skills> catalog. Give the model one bounded discovery
+    # hint so it knows telemetry is an available evidence source.
+    try:
+        ctx.register_system_prompt_section(
+            "hermes-otel.discovery",
+            "This Hermes agent exports OpenTelemetry through hermes-otel. For questions about "
+            "past agent behavior—including skill/tool usage, model calls, latency, errors, "
+            "retries, or cost—prefer the exported telemetry over logs or session-file inference. "
+            "Load `hermes_otel:observability` before querying the configured backend.",
+            max_chars=400,
+        )
+        debug_log("registered hermes-otel telemetry discovery prompt")
+    except AttributeError:
+        debug_log("register_system_prompt_section unavailable; skipping telemetry discovery prompt")

--- a/hermes_otel/helpers.py
+++ b/hermes_otel/helpers.py
@@ -135,7 +135,7 @@ def extract_tool_result_status(result: Any) -> Optional[str]:
 # Matches /skills/<name>/ and /skills/<name>/SKILL.md etc.
 # Deliberately does NOT match /optional-skills/<name>/references/ or similar
 # overlapping directory layouts.
-_SKILL_PATH_RE = re.compile(r"(?:^|[/\\])skills[/\\]([A-Za-z0-9_\-]+)(?:[/\\]|$)")
+_SKILL_PATH_RE = re.compile(r"(?:^|/)skills/([A-Za-z0-9_./-]+)(?:/|$)")
 
 
 def infer_skill_name(args: Optional[Dict[str, Any]]) -> Optional[str]:
@@ -160,10 +160,18 @@ def infer_skill_name_from_text(text: str) -> Optional[str]:
     """Extract a skill name from a free-form string containing a /skills/ path."""
     if not isinstance(text, str):
         return None
-    match = _SKILL_PATH_RE.search(text)
+    match = _SKILL_PATH_RE.search(text.replace("\\", "/"))
     if not match:
         return None
-    return match.group(1)
+    relative = match.group(1).strip("/")
+    parts = relative.split("/")
+    if parts[-1].lower() == "skill.md":
+        parts.pop()
+    # categorized skills are safely identifiable from their canonical SKILL.md
+    # path; retain the category/name instead of collapsing it to the category.
+    if len(parts) > 1 and relative.lower().endswith("/skill.md"):
+        return "/".join(parts)
+    return parts[0] if parts else None
 
 
 # Argument keys the ``skill_view`` tool may carry the skill name under.
@@ -195,7 +203,7 @@ def detect_skill(tool_name: Optional[str], args: Optional[Dict[str, Any]]):
                 continue
             # The value may be a bare name, a plugin-namespaced name, or (rarely)
             # a /skills/ path — handle all three.
-            name = infer_skill_name_from_text(v) or v.split(":")[-1].split("/")[0].strip()
+            name = infer_skill_name_from_text(v) or v.split(":")[-1].strip("/")
             if name:
                 return name, "skill_view"
     name = infer_skill_name(args)

--- a/hermes_otel/hooks.py
+++ b/hermes_otel/hooks.py
@@ -829,6 +829,11 @@ def _open_skill_span(tracer, session_id: str, skill: str, source: str, kwargs: d
     debug_log(f"  skill span opened: {skill} (source={source})")
 
 
+def _tool_call_id(task_id: str, kwargs: dict) -> str:
+    """Use Hermes's tool-call id when available, with old-core fallback."""
+    return str(kwargs.get("tool_call_id") or task_id)
+
+
 def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
     """Start a tool span before the tool executes."""
     debug_log(f"pre_tool_call fired: tool={tool_name}")
@@ -839,14 +844,15 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
 
     tracer.sweep_expired_turns()
 
-    key = f"{tool_name}:{task_id}"
+    tool_call_id = _tool_call_id(task_id, kwargs)
+    key = f"{tool_name}:{tool_call_id}"
     tracer.sessions.record_tool_start(key, time.perf_counter())
 
     # OpenInference attributes — Phoenix Info panel
     attributes: Dict[str, Any] = {
         "tool.name": tool_name,
         "gen_ai.tool.name": tool_name,
-        "gen_ai.tool.call.id": truncate_string(task_id, 200),
+        "gen_ai.tool.call.id": truncate_string(tool_call_id, 200),
     }
     preview = _preview(
         json.dumps(args) if args else "{}",
@@ -892,8 +898,6 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
         summary.add_target(target)
         summary.add_command(command)
         summary.add_skill(skill)
-        if skill and tracer.config.skill_spans:
-            _open_skill_span(tracer, session_id, skill, skill_source, kwargs)
 
     tracer.start_span(
         name=f"tool.{tool_name}",
@@ -913,7 +917,8 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
     if not tracer.is_enabled:
         return
 
-    key = f"{tool_name}:{task_id}"
+    tool_call_id = _tool_call_id(task_id, kwargs)
+    key = f"{tool_name}:{tool_call_id}"
     debug_log(f"  ending span: key={key}")
 
     start_time = tracer.sessions.pop_tool_start(key)
@@ -929,7 +934,7 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
     # Build final attributes — OpenInference conventions for Phoenix Info
     attributes: Dict[str, Any] = {
         "gen_ai.tool.name": tool_name,
-        "gen_ai.tool.call.id": truncate_string(task_id, 200),
+        "gen_ai.tool.call.id": truncate_string(tool_call_id, 200),
     }
     if start_time:
         attributes.update(_tool_host_utilization_attributes(tracer, start_time, ended_at))
@@ -944,7 +949,12 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
             result_json = {}
 
     # Determine outcome taxonomy
-    outcome = extract_tool_result_status(result_json) or "completed"
+    hook_status = kwargs.get("status")
+    outcome = (
+        hook_status.strip().lower()
+        if isinstance(hook_status, str) and hook_status.strip()
+        else extract_tool_result_status(result_json) or "completed"
+    )
     attributes["hermes.tool.outcome"] = outcome
 
     # Preserve existing error.message attribute when outcome == error
@@ -982,6 +992,17 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
         attributes.update(_turn_attributes(tracer, session_id))
         summary = tracer.sessions.get_or_create(session_id).turn_summary
         summary.add_outcome(outcome)
+        skill, skill_source = detect_skill(tool_name, args)
+        if skill and skill_source and tracer.config.skill_spans:
+            # skill_view reports success explicitly; file reads instead succeed
+            # unless Hermes reports a terminal failure through the hook/result.
+            succeeded = (
+                result_json.get("success") is True
+                if skill_source == "skill_view"
+                else outcome not in {"error", "blocked", "timeout", "cancelled"}
+            )
+            if succeeded:
+                _open_skill_span(tracer, session_id, skill, skill_source, kwargs)
 
     # Map outcome to span status. Only "error" is ERROR; other non-ok outcomes
     # (timeout, blocked, ...) are OK to avoid polluting error rates.

--- a/hermes_otel/session_state.py
+++ b/hermes_otel/session_state.py
@@ -116,9 +116,9 @@ class SessionState:
     Held by :class:`HermesOTelPlugin` so test reset is just singleton
     re-creation — tests never need to reach into module globals.
 
-    Tool timings are keyed by ``f"{tool_name}:{task_id}"`` (task-scoped,
-    not session-scoped) so they live in their own dict alongside the
-    session aggregators.
+    Tool timings are keyed by ``f"{tool_name}:{tool_call_id}"`` (with the
+    legacy task id as fallback), not session-scoped, so they live in their own
+    dict alongside the session aggregators.
     """
 
     # Upper bound on remembered turn counters for sessions whose aggregator has

--- a/hermes_otel/skills/observability/SKILL.md
+++ b/hermes_otel/skills/observability/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: observability
 description: >-
-  Turn on and understand OpenTelemetry observability for THIS Hermes agent via
-  the hermes-otel plugin — choose a backend, configure export, and read the
-  traces, metrics, and logs your agent produces. Use when a user asks "can I see
-  what my agent is doing", "set up tracing/metrics for Hermes", "where do my
-  traces go", or wants to debug agent behavior with telemetry.
+  Configure or query OpenTelemetry for THIS Hermes agent via hermes-otel. Use
+  for historical agent behavior, skill/tool invocation counts, model calls,
+  latency, errors, retries, cost, or questions such as "why did my agent do
+  this?", "how often was this skill read?", and "what is slow?"
 ---
 
 # Observability for your Hermes agent
@@ -24,7 +23,7 @@ as OpenTelemetry spans, metrics, and logs to any OTLP/HTTP backend.
 A trace per turn, shaped like:
 
 ```
-agent                      ← the turn
+agent or cron              ← the turn
 ├── skill.<name>           ← a loaded skill (load → turn end; overlaps OK)
 └── llm.<model>
     └── api.<model>        ← one HTTP round-trip
@@ -45,15 +44,15 @@ dashboards work out of the box.
    ```
 2. **Run a backend.** Easiest local pick: OpenObserve or Grafana LGTM (traces +
    metrics + logs). Phoenix is great for LLM-span inspection (traces only).
-3. **Point the plugin at it** in `~/.hermes/plugins/hermes_otel/config.yaml`
-   (copy from `config.yaml.example`):
+3. **Point the plugin at it** in the durable user configuration file
+   `~/.hermes/hermes_otel.yaml`:
    ```yaml
    project_name: my-hermes
    backends:
      - type: openobserve
        endpoint: http://localhost:5080/api/default/v1/traces
-       user: root@example.com
-       password: Complexpass#123
+       user_env: OPENOBSERVE_USER
+       password_env: OPENOBSERVE_PASSWORD
        metrics: true
    ```
 
@@ -73,6 +72,35 @@ Not seeing data? The usual suspects:
   process exits; widen the time range.
 - **Nothing at all** — check the startup banner connected; check the endpoint
   port and that the backend container is up.
+
+## Analyze existing agent behavior first
+
+When the question is about what Hermes did historically, query the configured
+telemetry backend before searching logs or parsing session dumps. Logs are useful
+for failures that happened before export; they are not the primary usage ledger.
+
+Start by establishing the observed window and denominator. A count without the
+retention window and number of turns is misleading. Skill loads are represented
+by `skill.<name>` spans; `tool.skill_view` counts all skill-loading calls.
+
+Use the configured backend's query UI or API and inspect one narrow trace before
+writing aggregates. Backend-specific query syntax, authentication, and table or
+index names belong in that backend's documentation, not this portable skill.
+
+For frequency analysis:
+
+- Bound every query to an explicit retention window.
+- Project only the span name, timestamp, trace ID, and attributes needed.
+- Count `skill.<name>` spans for individual skill loads.
+- Count `agent` and `cron` root spans for the turn denominator.
+- Avoid fetching full captured prompts or tool results across many spans.
+
+Report the retention window, total turns/traces, and exact span filter with every
+frequency claim. A skill span proves the skill loaded; it does not prove the
+model considered every other skill and rejected it. For missed-invocation
+analysis, compare the root `agent` or `cron` span's input and
+`hermes.turn.skills` fields against the skill catalog, then manually verify
+high-confidence mismatches.
 
 ## Key configuration knobs
 

--- a/tests/integration/test_skill_spans.py
+++ b/tests/integration/test_skill_spans.py
@@ -26,9 +26,14 @@ def _one(spans, name):
 def _load_skill(session_id, skill, task="sk1", tool="skill_view", args=None):
     """Fire a pre/post tool pair that loads a skill."""
     args = args if args is not None else {"name": skill}
+    result = '{"success": true}' if tool == "skill_view" else '{"content": "loaded"}'
     on_pre_tool_call(tool_name=tool, args=args, task_id=task, session_id=session_id)
     on_post_tool_call(
-        tool_name=tool, args=args, result="loaded", task_id=task, session_id=session_id
+        tool_name=tool,
+        args=args,
+        result=result,
+        task_id=task,
+        session_id=session_id,
     )
 
 
@@ -65,6 +70,66 @@ class TestSkillSpanBasics:
 
         skill = _one(exporter.get_finished_spans(), "skill.deploy")
         assert dict(skill.attributes)["hermes.skill.source"] == "path_match"
+
+    def test_failed_skill_load_does_not_open_span(self, inmemory_otel_setup):
+        exporter, _ = inmemory_otel_setup
+        on_session_start(session_id="s1", model="gpt-4", platform="cli")
+        on_pre_tool_call(
+            tool_name="skill_view",
+            args={"name": "axolotl"},
+            task_id="sk1",
+            session_id="s1",
+        )
+        on_post_tool_call(
+            tool_name="skill_view",
+            args={"name": "axolotl"},
+            result='{"success": false, "error": "missing"}',
+            task_id="sk1",
+            session_id="s1",
+        )
+        on_session_end(
+            session_id="s1", completed=True, interrupted=False, model="gpt-4", platform="cli"
+        )
+
+        assert _spans_named(exporter.get_finished_spans(), "skill.axolotl") == []
+
+    def test_parallel_skill_loads_keep_results_with_their_tool_call(self, inmemory_otel_setup):
+        exporter, _ = inmemory_otel_setup
+        on_session_start(session_id="s1", model="gpt-4", platform="cli")
+        shared = {"task_id": "task-1", "session_id": "s1"}
+        on_pre_tool_call(
+            tool_name="skill_view", args={"name": "missing"}, tool_call_id="call-a", **shared
+        )
+        on_pre_tool_call(
+            tool_name="skill_view", args={"name": "loaded"}, tool_call_id="call-b", **shared
+        )
+        on_post_tool_call(
+            tool_name="skill_view",
+            args={"name": "missing"},
+            result='{"success": false, "error": "not found"}',
+            tool_call_id="call-a",
+            **shared,
+        )
+        on_post_tool_call(
+            tool_name="skill_view",
+            args={"name": "loaded"},
+            result='{"success": true}',
+            tool_call_id="call-b",
+            **shared,
+        )
+        on_session_end(
+            session_id="s1", completed=True, interrupted=False, model="gpt-4", platform="cli"
+        )
+
+        spans = exporter.get_finished_spans()
+        tools = {
+            dict(span.attributes)["gen_ai.tool.call.id"]: span
+            for span in _spans_named(spans, "tool.skill_view")
+        }
+        assert dict(tools["call-a"].attributes)["error.message"] == "not found"
+        assert "error.message" not in tools["call-b"].attributes
+        assert _spans_named(spans, "skill.missing") == []
+        assert len(_spans_named(spans, "skill.loaded")) == 1
 
     def test_interrupted_turn_marks_result_status(self, inmemory_otel_setup):
         exporter, _ = inmemory_otel_setup

--- a/tests/unit/test_bundled_skill.py
+++ b/tests/unit/test_bundled_skill.py
@@ -2,16 +2,20 @@
 
 from pathlib import Path
 
+import pytest
+
 import hermes_otel
 
 
 class FakeCtx:
     """Minimal PluginContext stand-in recording hook/skill registrations."""
 
-    def __init__(self, support_skills: bool = True):
+    def __init__(self, support_skills: bool = True, support_prompt_sections: bool = True):
         self.hooks = []
         self.skills = []
+        self.prompt_sections = []
         self._support_skills = support_skills
+        self._support_prompt_sections = support_prompt_sections
 
     def register_hook(self, name, callback):
         self.hooks.append(name)
@@ -22,6 +26,21 @@ class FakeCtx:
         if not self._support_skills:
             raise AttributeError("register_skill")
         self.skills.append((name, Path(path), description))
+
+    def register_system_prompt_section(self, section_id, content, **kwargs):
+        if not self._support_prompt_sections:
+            raise AttributeError("register_system_prompt_section")
+        self.prompt_sections.append((section_id, content, kwargs))
+
+
+class LegacyCtx:
+    """Older Hermes context with neither skill nor prompt-section APIs."""
+
+    def __init__(self):
+        self.hooks = []
+
+    def register_hook(self, name, callback):
+        self.hooks.append(name)
 
 
 def _enabled_tracer(monkeypatch):
@@ -53,11 +72,42 @@ def test_register_registers_bundled_skill(monkeypatch):
     assert registered.exists()
 
 
+def test_register_advertises_telemetry_as_behavioral_evidence(monkeypatch):
+    _enabled_tracer(monkeypatch)
+    ctx = FakeCtx()
+    hermes_otel.register(ctx)
+
+    [(section_id, content, options)] = ctx.prompt_sections
+    assert section_id == "hermes-otel.discovery"
+    assert "skill/tool usage" in content
+    assert "hermes_otel:observability" in content
+    assert options == {"max_chars": 400}
+
+
 def test_register_is_forward_compatible_without_register_skill(monkeypatch):
     _enabled_tracer(monkeypatch)
     ctx = FakeCtx(support_skills=False)
     # Must not raise even though register_skill blows up.
     hermes_otel.register(ctx)
     assert ctx.skills == []
+    assert ctx.prompt_sections[0][0] == "hermes-otel.discovery"
     # Hooks still registered — skill failure doesn't abort registration.
     assert "pre_tool_call" in ctx.hooks
+
+
+def test_register_is_forward_compatible_without_prompt_sections(monkeypatch):
+    _enabled_tracer(monkeypatch)
+    ctx = LegacyCtx()
+    hermes_otel.register(ctx)
+    assert "pre_tool_call" in ctx.hooks
+
+
+def test_register_does_not_hide_prompt_registration_failures(monkeypatch):
+    _enabled_tracer(monkeypatch)
+
+    class BrokenPromptCtx(FakeCtx):
+        def register_system_prompt_section(self, section_id, content, **kwargs):
+            raise RuntimeError("prompt registry is broken")
+
+    with pytest.raises(RuntimeError, match="prompt registry is broken"):
+        hermes_otel.register(BrokenPromptCtx())

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -167,6 +167,30 @@ class TestInferSkillName:
     def test_target_key(self):
         assert infer_skill_name({"target": "/repo/skills/deployer/README"}) == "deployer"
 
+    def test_categorized_skill_path_preserves_relative_name(self):
+        assert (
+            infer_skill_name(
+                {"path": "/home/user/skills/software-development/code-review/SKILL.md"}
+            )
+            == "software-development/code-review"
+        )
+
+    def test_windows_categorized_skill_path_preserves_relative_name(self):
+        assert (
+            infer_skill_name(
+                {"path": r"C:\Users\me\skills\software-development\code-review\SKILL.md"}
+            )
+            == "software-development/code-review"
+        )
+
+    def test_categorized_skill_view_name_preserves_relative_name(self):
+        from hermes_otel.helpers import detect_skill
+
+        assert detect_skill("skill_view", {"name": "software-development/code-review"}) == (
+            "software-development/code-review",
+            "skill_view",
+        )
+
     def test_no_path_returns_none(self):
         assert infer_skill_name({"command": "ls"}) is None
 

--- a/tests/unit/test_hooks_callbacks.py
+++ b/tests/unit/test_hooks_callbacks.py
@@ -224,6 +224,12 @@ class TestOnPreToolCall:
         on_pre_tool_call(tool_name="bash", args={}, task_id="t1")
         assert mock_tracer.sessions.has_tool_start("bash:t1")
 
+    def test_uses_tool_call_id_for_key_and_attribute(self, mock_tracer):
+        on_pre_tool_call(tool_name="bash", args={}, task_id="task-1", tool_call_id="call-1")
+        assert mock_tracer.start_span.call_args[1]["key"] == "bash:call-1"
+        assert mock_tracer.start_span.call_args[1]["attributes"]["gen_ai.tool.call.id"] == "call-1"
+        assert mock_tracer.sessions.has_tool_start("bash:call-1")
+
     def test_noop_when_disabled(self, disabled_tracer):
         on_pre_tool_call(tool_name="bash", args={}, task_id="t1")
         disabled_tracer.start_span.assert_not_called()
@@ -286,6 +292,18 @@ class TestOnPostToolCall:
         mock_tracer.sessions.record_tool_start("bash:t1", 1000.0)
         on_post_tool_call(tool_name="bash", args={}, result="ok", task_id="t1")
         assert not mock_tracer.sessions.has_tool_start("bash:t1")
+
+    def test_uses_tool_call_id_to_end_matching_span(self, mock_tracer):
+        mock_tracer.sessions.record_tool_start("bash:call-1", 1000.0)
+        on_post_tool_call(
+            tool_name="bash",
+            args={},
+            result="output",
+            task_id="task-1",
+            tool_call_id="call-1",
+        )
+        assert mock_tracer.end_span.call_args[0][0] == "bash:call-1"
+        assert mock_tracer.end_span.call_args[1]["attributes"]["gen_ai.tool.call.id"] == "call-1"
 
     def test_noop_when_disabled(self, disabled_tracer):
         on_post_tool_call(tool_name="bash", args={}, result="ok", task_id="t1")


### PR DESCRIPTION
## What changed

- Preserve skill/tool telemetry identity across nested spans.
- Register a bounded system-prompt hint when hermes-otel is enabled so Hermes knows historical behavior should be answered from telemetry.
- Broaden the bundled observability skill to cover skill/tool usage, latency, errors, retries, and cost.
- Document backend-neutral analysis principles, retention-window denominators, cron roots, durable configuration, and environment-backed credentials.
- Retain compatibility with older Hermes versions that lack plugin skill or prompt-section APIs.

## Verification

- `uv run pytest -q`: 781 passed, 3 skipped, 6 deselected.
- `uv run ruff check hermes_otel/__init__.py tests/unit/test_bundled_skill.py`: passed.
- `uv run black --check hermes_otel/__init__.py tests/unit/test_bundled_skill.py`: passed.
- `uv build`: produced the wheel and source distribution.
- Four independent compatibility, test, telemetry-semantics, and architecture reviews completed; findings incorporated.
