### PR TITLE
feat: add profile-aware telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ subdirectory (~40 files) rather than the whole repository, so docs, tests and th
 Compose stacks never land in `~/.hermes/plugins/`. It unpacks to `~/.hermes/plugins/hermes_otel/`
 either way, and Hermes auto-discovers it via `plugin.yaml`.
 
+For a named profile, run the same command in that profile and enable it there:
+
+```bash
+hermes -p work plugins install briancaffey/hermes-otel/hermes_otel --enable
+```
+
+Hermes controls plugin activation per profile through each profile's
+`plugins.enabled` / `plugins.disabled` config. hermes-otel then reads that
+profile's own `$HERMES_HOME/hermes_otel.yaml` and exports `profile.name` on its
+OTel Resource, so traces, metrics, and logs can be filtered by profile.
+
 The OTel dependencies must then be installed into the **hermes-agent virtual environment**
 (where `hermes` itself runs) — Hermes never installs plugin dependencies for you:
 
@@ -367,13 +378,15 @@ The plugin prints only essential startup messages (backend connected/failed, hoo
 export HERMES_OTEL_DEBUG=true
 ```
 
-Debug output is written to `~/.hermes/plugins/hermes_otel/debug.log` and does not clutter hermes stdout.
+Debug output is written to
+`$HERMES_HOME/plugins/hermes_otel/debug.log` (the active profile) and does not
+clutter hermes stdout.
 
 **Priority order:** LangSmith (if `LANGSMITH_TRACING=true`) > Langfuse (if credentials set) > SigNoz (`OTEL_SIGNOZ_ENDPOINT`) > Uptrace (`OTEL_UPTRACE_ENDPOINT` + DSN) > OpenObserve (`OTEL_OPENOBSERVE_ENDPOINT` + creds) > Parseable (`OTEL_PARSEABLE_ENDPOINT` + `PARSEABLE_API_KEY`) > Weave (`WANDB_API_KEY` + `WANDB_ENTITY` + `WANDB_PROJECT`) > Honeycomb (`HONEYCOMB_API_KEY`) > Jaeger (`OTEL_JAEGER_ENDPOINT`) > Tempo (`OTEL_TEMPO_ENDPOINT`) > Phoenix (`OTEL_PHOENIX_ENDPOINT`).
 
 ### Shaping knobs — `config.yaml` and `HERMES_OTEL_*` env vars
 
-Backend selection stays env-var-driven (above). For telemetry **shaping** — sampling, preview size, resource attributes, TTL, extra headers — you can also use a YAML file at `~/.hermes/hermes_otel.yaml` (or wherever `HERMES_OTEL_CONFIG` points). The legacy location inside the plugin directory still works, but a reinstall replaces that directory.
+Backend selection stays env-var-driven (above). For telemetry **shaping** — sampling, preview size, resource attributes, TTL, extra headers — you can also use a YAML file at `$HERMES_HOME/hermes_otel.yaml` (for the default profile, `~/.hermes/hermes_otel.yaml`) or wherever `HERMES_OTEL_CONFIG` points. The legacy location inside the active profile's plugin directory still works, but a reinstall replaces that directory.
 
 **Precedence (per-field):** `HERMES_OTEL_*` env var > `config.yaml` value > default.
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -29,6 +29,8 @@
 
 # Free-form key/value pairs merged into the OTel Resource of every span.
 # Good for deployment tags (env, region, team).
+# `profile.name` is reserved and set automatically from the active Hermes
+# profile so traces, metrics, and logs can be separated in shared backends.
 # resource_attributes:
 #   deployment: prod
 #   region: us-east-1

--- a/hermes_otel/__init__.py
+++ b/hermes_otel/__init__.py
@@ -14,18 +14,24 @@ def register(ctx):
     # does not trigger the relative imports.
     from . import hooks
     from .debug_utils import configure_default_handler, debug_log, logger
-    from .tracer import get_tracer
+    from .profile_context import profile_name_from_context
+    from .tracer import get_tracer, release_tracer
 
     # Install stderr handler on the hermes_otel logger unless the host app
     # has already wired up its own. Keeps the "✓ backend connected" banner
     # visible without forcing downstream apps to configure logging.
     configure_default_handler()
 
-    tracer = get_tracer()
+    tracer = get_tracer(profile_name=profile_name_from_context(ctx))
     tracer.init()
 
     if not tracer.is_enabled:
         return
+
+    try:
+        ctx.on_unload(lambda: release_tracer(tracer))
+    except Exception:
+        debug_log("on_unload unavailable; relying on process-exit cleanup")
 
     # Core hooks (always available)
     ctx.register_hook("pre_tool_call", hooks.on_pre_tool_call)

--- a/hermes_otel/dashboard/backends/__init__.py
+++ b/hermes_otel/dashboard/backends/__init__.py
@@ -36,6 +36,19 @@ def find_adapter_class(backend_type: str) -> Optional[Type[BackendAdapter]]:
     return None
 
 
+def _active_hermes_home() -> Path:
+    """Resolve the active profile home without importing the plugin package."""
+    try:
+        from hermes_constants import get_hermes_home
+
+        return Path(get_hermes_home()).expanduser()
+    except (ImportError, AttributeError):
+        pass
+
+    env_home = os.environ.get("HERMES_HOME", "").strip()
+    return Path(env_home).expanduser() if env_home else Path.home() / ".hermes"
+
+
 # ── Config loader ──────────────────────────────────────────────────────
 
 
@@ -53,8 +66,7 @@ def _candidate_config_paths() -> List[Path]:
     override = os.environ.get("HERMES_OTEL_CONFIG", "").strip()
     if override:
         paths.append(Path(override).expanduser())
-    env_home = os.environ.get("HERMES_HOME", "").strip()
-    home = Path(env_home).expanduser() if env_home else Path.home() / ".hermes"
+    home = _active_hermes_home()
     paths.append(home / "hermes_otel.yaml")
     here = Path(__file__).resolve().parent  # dashboard/backends/
     plugin_root = here.parent.parent  # plugin root (…/hermes_otel/)

--- a/hermes_otel/debug_utils.py
+++ b/hermes_otel/debug_utils.py
@@ -21,7 +21,8 @@ import logging
 import os
 import sys
 
-_DEBUG_LOG = os.path.expanduser("~/.hermes/plugins/hermes_otel/debug.log")
+from .profile_context import active_hermes_home
+
 _DEBUG_ENABLED = os.getenv("HERMES_OTEL_DEBUG", "").strip().lower() in {
     "1",
     "true",
@@ -42,7 +43,8 @@ def debug_log(msg: str) -> None:
     if not _DEBUG_ENABLED:
         return
     try:
-        with open(_DEBUG_LOG, "a", encoding="utf-8") as f:
+        debug_log_path = active_hermes_home() / "plugins" / "hermes_otel" / "debug.log"
+        with debug_log_path.open("a", encoding="utf-8") as f:
             f.write(f"{msg}\n")
     except Exception:
         pass

--- a/hermes_otel/hooks.py
+++ b/hermes_otel/hooks.py
@@ -12,7 +12,6 @@ routed through the tracer singleton so test reset is just
 from __future__ import annotations
 
 import json
-import os
 import time
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Dict, List, Optional, TypedDict
@@ -32,6 +31,7 @@ from .helpers import (
     to_optional_int,
     truncate_string,
 )
+from .profile_context import active_hermes_home
 from .session_state import TurnSummary
 from .tracer import get_tracer
 
@@ -808,11 +808,11 @@ def _open_skill_span(tracer, session_id: str, skill: str, source: str, kwargs: d
     if tracer.spans.has_skill_span(session_id, skill):
         return  # already active this turn — keep the first window open
     key = f"skill:{session_id}:{skill}"
-    home = os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
+    home = active_hermes_home()
     attributes: Dict[str, Any] = {
         "hermes.skill.name": skill,
         "hermes.skill.source": source,
-        "hermes.skill.path": os.path.join(home, "skills", skill),
+        "hermes.skill.path": str(home / "skills" / skill),
         "hermes.span_kind": "skill",
         "gen_ai.skill.name": skill,
     }

--- a/hermes_otel/live_store.py
+++ b/hermes_otel/live_store.py
@@ -28,11 +28,13 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from .profile_context import active_hermes_home
+
 
 def _default_db_path() -> str:
-    # Next to this module so the gateway and dashboard processes (both loading
-    # the plugin from the same install dir) resolve the SAME file.
-    return str(Path(__file__).resolve().parent / "live.db")
+    # The gateway and dashboard resolve the same active profile home even when
+    # this package is installed globally as an entry point.
+    return str(active_hermes_home() / "plugins" / "hermes_otel" / "live.db")
 
 
 class LiveStore:
@@ -40,6 +42,7 @@ class LiveStore:
 
     def __init__(self, db_path: Optional[str] = None, max_rows: int = 4000) -> None:
         self.db_path = db_path or _default_db_path()
+        Path(self.db_path).expanduser().parent.mkdir(parents=True, exist_ok=True)
         self.max_rows = max(10, int(max_rows))
         self._local = threading.local()
         self._writes = 0
@@ -170,9 +173,10 @@ class LiveStore:
             pass
 
 
-# Per-process singleton; both processes point at the same SQLite file (default
-# path), so they share data without sharing memory.
+# Per-profile process cache; separate gateway/dashboard processes still point
+# at the same profile-specific SQLite file, so they share data without memory.
 _LIVE_STORE: Optional[LiveStore] = None
+_LIVE_STORES: Dict[str, LiveStore] = {}
 _LIVE_LOCK = threading.Lock()
 
 
@@ -182,7 +186,7 @@ def get_live_store(
     max_rows: int = 4000,
     **_ignored: Any,
 ) -> Optional[LiveStore]:
-    """Return the process-wide :class:`LiveStore`.
+    """Return the active profile's process-local :class:`LiveStore`.
 
     ``create=True`` lazily builds it (the tracer, when ``dashboard_live`` is on).
     The dashboard API calls with ``create=True`` too (read side) so the file is
@@ -190,14 +194,20 @@ def get_live_store(
     SQLite backend can't be opened at all.
     """
     global _LIVE_STORE
-    if _LIVE_STORE is None and create:
-        with _LIVE_LOCK:
-            if _LIVE_STORE is None:
-                try:
-                    _LIVE_STORE = LiveStore(
-                        db_path=db_path or os.environ.get("HERMES_OTEL_LIVE_DB"),
-                        max_rows=max_rows,
-                    )
-                except Exception:  # pragma: no cover
-                    return None
-    return _LIVE_STORE
+    selected_path = db_path or os.environ.get("HERMES_OTEL_LIVE_DB") or _default_db_path()
+    store_key = str(Path(selected_path).expanduser().resolve())
+
+    with _LIVE_LOCK:
+        # Preserve direct singleton injection used by embedders and tests.
+        if _LIVE_STORE is not None and _LIVE_STORE not in _LIVE_STORES.values():
+            _LIVE_STORES[store_key] = _LIVE_STORE
+
+        store = _LIVE_STORES.get(store_key)
+        if store is None and create:
+            try:
+                store = LiveStore(db_path=store_key, max_rows=max_rows)
+                _LIVE_STORES[store_key] = store
+            except Exception:  # pragma: no cover
+                return None
+        _LIVE_STORE = store
+        return store

--- a/hermes_otel/log_handler.py
+++ b/hermes_otel/log_handler.py
@@ -23,10 +23,12 @@ attribute before adding a new one.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from .backends import _ResolvedBackend
 from .debug_utils import debug_log, logger
+from .profile_context import active_hermes_home
 
 try:
     # opentelemetry-sdk emits a DeprecationWarning on LoggingHandler import
@@ -53,6 +55,23 @@ except ImportError:  # pragma: no cover - exercised only when SDK missing
 # Marker attribute stamped on handlers we install so idempotent reinstalls
 # can locate and remove prior copies without affecting unrelated handlers.
 _HANDLER_MARKER = "_hermes_otel_log_handler"
+_HANDLER_KIND = "_hermes_otel_log_handler_kind"
+_ORIGINAL_LOG_LEVEL = "_hermes_otel_original_log_level"
+
+
+class _ProfileHomeFilter(logging.Filter):
+    """Keep a profile's root logger handler from exporting sibling-profile logs."""
+
+    def __init__(self, profile_home: str) -> None:
+        super().__init__()
+        self._profile_home = str(Path(profile_home).expanduser().resolve())
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            return str(active_hermes_home().resolve()) == self._profile_home
+        except Exception:
+            return False
+
 
 # Loggers whose records we refuse to forward to the OTLP logs pipeline.
 # Two reasons each of these is on the list:
@@ -155,6 +174,7 @@ def install_handler(
     processors: List[Tuple[Any, "_ResolvedBackend"]],
     level: int,
     attach_logger: Optional[str] = None,
+    profile_home: Optional[Path] = None,
 ) -> Optional["LoggerProvider"]:
     """Wire a :class:`LoggerProvider` + :class:`LoggingHandler` onto Python logging.
 
@@ -172,6 +192,7 @@ def install_handler(
         attach_logger: Logger name to attach the handler to. ``None``
             means the root logger (captures everything). Pass e.g.
             ``"hermes_otel"`` to scope capture to plugin logs only.
+        profile_home: Active Hermes home whose records this handler exports.
 
     Returns the ``LoggerProvider`` so the tracer can keep a reference for
     ``force_flush`` / ``shutdown``. Returns ``None`` when logs are disabled,
@@ -186,16 +207,11 @@ def install_handler(
 
     handler = LoggingHandler(level=level, logger_provider=provider)
     handler.addFilter(_ExcludeOTelInternal())
-    setattr(handler, _HANDLER_MARKER, True)
+    scoped_home = profile_home or active_hermes_home()
+    handler.addFilter(_ProfileHomeFilter(str(scoped_home)))
 
     target = logging.getLogger(attach_logger) if attach_logger else logging.getLogger()
-    _remove_prior_handlers(target)
-    target.addHandler(handler)
-    # Ensure records actually reach the handler — Python filters at the
-    # logger level before dispatching to handlers, so a root logger left
-    # at WARNING would silently drop INFO/DEBUG even with a DEBUG handler.
-    if target.level == logging.NOTSET or target.level > level:
-        target.setLevel(level)
+    attach_profile_handler(target, handler, scoped_home, kind="otel")
 
     debug_log(
         f"log_handler installed: target={attach_logger or 'root'} "
@@ -204,15 +220,73 @@ def install_handler(
     return provider
 
 
-def _remove_prior_handlers(target: logging.Logger) -> None:
+def _managed_handlers(target: logging.Logger) -> List[logging.Handler]:
+    return [h for h in target.handlers if getattr(h, _HANDLER_MARKER, None)]
+
+
+def _sync_target_level(target: logging.Logger) -> None:
+    """Keep the logger permissive enough for its profile handlers, then restore it."""
+    handlers = _managed_handlers(target)
+    original_level = getattr(target, _ORIGINAL_LOG_LEVEL, None)
+    if handlers:
+        if original_level is None:
+            original_level = target.level
+            setattr(target, _ORIGINAL_LOG_LEVEL, original_level)
+        handler_level = min(handler.level for handler in handlers)
+        if original_level == logging.NOTSET and target.parent is not None:
+            target.setLevel(handler_level)
+        else:
+            target.setLevel(min(original_level, handler_level))
+    elif original_level is not None:
+        target.setLevel(original_level)
+        delattr(target, _ORIGINAL_LOG_LEVEL)
+
+
+def _remove_prior_handlers(
+    target: logging.Logger,
+    profile_home: Path,
+    kind: Optional[str] = None,
+) -> None:
     """Strip any marker-tagged handlers we installed previously.
 
     Only touches handlers we own — leaves the consumer's own handlers
     (stderr, file, syslog, ...) alone.
     """
+    marker = str(profile_home.expanduser().resolve())
     for h in list(target.handlers):
-        if getattr(h, _HANDLER_MARKER, False):
+        installed_for = getattr(h, _HANDLER_MARKER, None)
+        installed_kind = getattr(h, _HANDLER_KIND, None)
+        if (installed_for is True or installed_for == marker) and (
+            kind is None or installed_kind == kind
+        ):
             target.removeHandler(h)
+    _sync_target_level(target)
+
+
+def attach_profile_handler(
+    target: logging.Logger,
+    handler: logging.Handler,
+    profile_home: Path,
+    kind: str,
+) -> None:
+    """Attach one profile-owned handler and maintain the target logger level."""
+    _remove_prior_handlers(target, profile_home, kind=kind)
+    if not _managed_handlers(target) and not hasattr(target, _ORIGINAL_LOG_LEVEL):
+        setattr(target, _ORIGINAL_LOG_LEVEL, target.level)
+    setattr(handler, _HANDLER_MARKER, str(profile_home.expanduser().resolve()))
+    setattr(handler, _HANDLER_KIND, kind)
+    target.addHandler(handler)
+    _sync_target_level(target)
+
+
+def remove_handler(
+    attach_logger: Optional[str],
+    profile_home: Path,
+    kind: Optional[str] = None,
+) -> None:
+    """Remove profile-owned handlers without disturbing sibling profiles."""
+    target = logging.getLogger(attach_logger) if attach_logger else logging.getLogger()
+    _remove_prior_handlers(target, profile_home, kind=kind)
 
 
 def resolve_level(name: Optional[str], default: int = logging.INFO) -> int:

--- a/hermes_otel/plugin_config.py
+++ b/hermes_otel/plugin_config.py
@@ -26,26 +26,18 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from .debug_utils import logger
+from .profile_context import active_hermes_home
 
 Scalar = Union[str, int, float, bool]
 
 
 def hermes_home() -> Path:
-    """``$HERMES_HOME`` if set, else ``~/.hermes`` — matching Hermes itself."""
-    raw = os.environ.get("HERMES_HOME", "").strip()
-    return Path(raw).expanduser() if raw else Path.home() / ".hermes"
+    """Return the active profile's Hermes home."""
+    return active_hermes_home()
 
 
 # Environment variable holding an explicit config file path.
 CONFIG_PATH_ENV = "HERMES_OTEL_CONFIG"
-
-# Outside the plugin directory, so it survives `hermes plugins install --force`
-# (which replaces the plugin directory wholesale — see issue #55).
-DURABLE_CONFIG_PATH = hermes_home() / "hermes_otel.yaml"
-
-# The historical location: inside the plugin directory. Still read, so existing
-# installs keep working, but it is wiped by a reinstall.
-DEFAULT_CONFIG_PATH = hermes_home() / "plugins" / "hermes_otel" / "config.yaml"
 
 
 def resolve_config_path() -> Optional[Path]:
@@ -60,7 +52,13 @@ def resolve_config_path() -> Optional[Path]:
     if override:
         return Path(override).expanduser()
 
-    durable, legacy = DURABLE_CONFIG_PATH, DEFAULT_CONFIG_PATH
+    home = hermes_home()
+    # Outside the plugin directory, so it survives
+    # `hermes plugins install --force` (see issue #55).
+    durable = home / "hermes_otel.yaml"
+    # Historical location: still read for compatibility, but replaced on
+    # reinstall because it lives inside the plugin directory.
+    legacy = home / "plugins" / "hermes_otel" / "config.yaml"
     if durable.exists():
         if legacy.exists():
             logger.warning(

--- a/hermes_otel/profile_context.py
+++ b/hermes_otel/profile_context.py
@@ -1,0 +1,32 @@
+"""Compatibility helpers for Hermes profile-scoped runtime state."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+
+def active_hermes_home() -> Path:
+    """Return the active Hermes home, including context-local profile overrides."""
+    try:
+        from hermes_constants import get_hermes_home
+
+        return Path(get_hermes_home()).expanduser()
+    except (ImportError, AttributeError):
+        pass
+
+    raw = os.environ.get("HERMES_HOME", "").strip()
+    return Path(raw).expanduser() if raw else Path.home() / ".hermes"
+
+
+def profile_name_from_context(ctx: Any) -> str:
+    """Return the host-provided profile name with an older-Hermes fallback."""
+    try:
+        profile_name = ctx.profile_name
+    except Exception:
+        return "default"
+
+    if not isinstance(profile_name, str) or not profile_name.strip():
+        return "default"
+    return profile_name.strip()

--- a/hermes_otel/tracer.py
+++ b/hermes_otel/tracer.py
@@ -18,13 +18,16 @@ from __future__ import annotations
 import atexit
 import logging
 import os
+import threading
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from . import backends as _backends
 from .backends import _TRACES_ONLY, _ResolvedBackend
 from .debug_utils import debug_log, logger
 from .plugin_config import BackendConfig, HermesOtelConfig, load_config
+from .profile_context import active_hermes_home
 from .session_state import SessionState
 
 # Re-exported for tests (conftest resets _PARENT_STACK between runs).
@@ -72,6 +75,10 @@ def _serialize_span(span: Any) -> Dict[str, Any]:
         status = span.status.status_code.name  # OK / ERROR / UNSET
     except Exception:
         status = "UNSET"
+    resource = getattr(span, "resource", None)
+    resource_attrs = getattr(resource, "attributes", None) or {}
+    attributes = {k: _attr_value(v) for k, v in resource_attrs.items()}
+    attributes.update({k: _attr_value(v) for k, v in (span.attributes or {}).items()})
     return {
         "trace_id": format(ctx.trace_id, "032x"),
         "span_id": format(ctx.span_id, "016x"),
@@ -81,7 +88,7 @@ def _serialize_span(span: Any) -> Dict[str, Any]:
         "end_time_unix_nano": end,
         "duration_ms": round((end - start) / 1e6, 3) if (end and start) else None,
         "status": status,
-        "attributes": {k: _attr_value(v) for k, v in (span.attributes or {}).items()},
+        "attributes": attributes,
     }
 
 
@@ -229,7 +236,11 @@ class HermesOTelPlugin:
         "agent": "AGENT",
     }
 
-    def __init__(self, config: Optional[HermesOtelConfig] = None):
+    def __init__(
+        self,
+        config: Optional[HermesOtelConfig] = None,
+        profile_name: str = "default",
+    ):
         self.tracer = None
         self.spans = SpanTracker()
         # Per-session aggregators for hook callbacks (token totals, I/O,
@@ -239,6 +250,7 @@ class HermesOTelPlugin:
         self._initialized = False
         # True when the in-process live store (zero-config dashboard) is wired.
         self._live_active = False
+        self._live_store = None
         self._live_log_handler = None
         # OTLP fan-out: one BatchSpanProcessor + one PeriodicExportingMetricReader
         # per backend. The singular ``_span_processor`` / ``_metric_reader``
@@ -247,6 +259,8 @@ class HermesOTelPlugin:
         self._span_processors: List[Any] = []
         self._metric_readers: List[Any] = []
         self._log_processors: List[Any] = []
+        self._tracer_provider = None
+        self._tracer_provider_is_global = False
         self._span_processor = None
         self._metric_reader = None
         self._backend_summaries: List[str] = []
@@ -258,6 +272,7 @@ class HermesOTelPlugin:
         # Metrics
         self._meter = None
         self._meter_provider = None
+        self._meter_provider_is_global = False
         self._session_count = None
         self._token_usage = None
         self._cost_usage = None
@@ -297,6 +312,8 @@ class HermesOTelPlugin:
         # Guards against double-registering the atexit flush handler when
         # init() is called multiple times (e.g. in tests / plugin reload).
         self._atexit_registered: bool = False
+        self.profile_name = profile_name
+        self.profile_home = active_hermes_home()
 
     # ── Initialization entry point ───────────────────────────────────────
 
@@ -468,6 +485,7 @@ class HermesOTelPlugin:
         project_name = self.config.project_name or os.getenv("OTEL_PROJECT_NAME", "").strip()
         if project_name:
             attrs["openinference.project.name"] = project_name
+        attrs["profile.name"] = self.profile_name
         # host.name lets the host/GPU series join the traces they were sampled
         # alongside (and a Collector's hostmetrics series, if one runs too).
         if self.config.host_metrics and not attrs.get("host.name"):
@@ -527,6 +545,7 @@ class HermesOTelPlugin:
             # the dashboard renders the agent's activity even with no OTLP
             # backend configured — install the plugin, open the tab, see traces.
             self._live_active = False
+            self._live_store = None
             if self.config.dashboard_live and _LiveSpanProcessor is not None:
                 from .live_store import get_live_store
 
@@ -537,6 +556,7 @@ class HermesOTelPlugin:
                 if store is not None:
                     _attach(_LiveSpanProcessor(store))
                     self._live_active = True
+                    self._live_store = store
                     # Tail agent logs into the live store too (Logs tab), opt-in
                     # via capture_logs so we don't capture the root logger by default.
                     if self.config.capture_logs:
@@ -554,10 +574,14 @@ class HermesOTelPlugin:
                             h.setLevel(lvl)
                             # Filter the chattiest config/probe loggers regardless.
                             h.addFilter(_LiveLogNoiseFilter())
-                            target.addHandler(h)
+                            h.addFilter(_lh._ProfileHomeFilter(str(self.profile_home)))
+                            _lh.attach_profile_handler(
+                                target,
+                                h,
+                                self.profile_home,
+                                kind="live",
+                            )
                             self._live_log_handler = h
-                            if target.level == logging.NOTSET or target.level > lvl:
-                                target.setLevel(lvl)
                         except Exception as e:  # pragma: no cover
                             debug_log(f"live log handler not installed: {e}")
 
@@ -616,7 +640,9 @@ class HermesOTelPlugin:
                 self._metric_reader = self._metric_readers[0]
 
             trace.set_tracer_provider(provider)
-            self.tracer = trace.get_tracer("hermes-otel-plugin")
+            self._tracer_provider = provider
+            self._tracer_provider_is_global = trace.get_tracer_provider() is provider
+            self.tracer = provider.get_tracer("hermes-otel-plugin")
 
             if metric_readers and _METRICS_AVAILABLE:
                 self._meter_provider = MeterProvider(
@@ -624,7 +650,10 @@ class HermesOTelPlugin:
                     metric_readers=metric_readers,
                 )
                 metrics.set_meter_provider(self._meter_provider)
-                self._meter = metrics.get_meter("hermes-otel-plugin")
+                self._meter_provider_is_global = (
+                    metrics.get_meter_provider() is self._meter_provider
+                )
+                self._meter = self._meter_provider.get_meter("hermes-otel-plugin")
                 self._create_metric_instruments()
                 debug_log(f"Metrics initialized for {len(metric_readers)} backend(s)")
 
@@ -778,6 +807,7 @@ class HermesOTelPlugin:
                 sampler.stop()
             except Exception:  # pragma: no cover — shutdown must never raise
                 pass
+            self._host_metrics = None
 
     @property
     def host_metrics(self) -> Optional[Any]:
@@ -790,9 +820,7 @@ class HermesOTelPlugin:
         if not self._live_active:
             return
         try:
-            from .live_store import get_live_store
-
-            store = get_live_store()
+            store = self._live_store
             if store is None:
                 return
             ts = sample.wall_ns
@@ -915,6 +943,7 @@ class HermesOTelPlugin:
             processors=processors,
             level=level,
             attach_logger=self.config.log_attach_logger,
+            profile_home=self.profile_home,
         )
         if self._logger_provider is None:
             return
@@ -934,9 +963,7 @@ class HermesOTelPlugin:
             try:
                 import time as _time
 
-                from .live_store import get_live_store
-
-                store = get_live_store()
+                store = self._live_store
                 if store is not None:
                     store.add_metric(name, value, attributes or {}, _time.time_ns())
             except Exception:  # pragma: no cover — never break the hot path
@@ -1206,6 +1233,69 @@ class HermesOTelPlugin:
         atexit.register(self.stop_host_metrics)
         self._atexit_registered = True
 
+    def shutdown(self) -> None:
+        """Release this profile's handlers, samplers, and telemetry providers."""
+        self.stop_host_metrics()
+
+        target = logging.getLogger(self.config.log_attach_logger or None)
+        if self._live_log_handler is not None:
+            try:
+                from . import log_handler
+
+                log_handler.remove_handler(
+                    self.config.log_attach_logger,
+                    self.profile_home,
+                    kind="live",
+                )
+            except Exception:
+                target.removeHandler(self._live_log_handler)
+            self._live_log_handler = None
+
+        try:
+            from . import log_handler
+
+            log_handler.remove_handler(
+                self.config.log_attach_logger,
+                self.profile_home,
+                kind="otel",
+            )
+        except Exception:
+            pass
+
+        self._force_flush()
+        providers = [self._logger_provider]
+        if not self._meter_provider_is_global:
+            providers.append(self._meter_provider)
+        if not self._tracer_provider_is_global:
+            providers.append(self._tracer_provider)
+        for provider in providers:
+            if provider is not None:
+                try:
+                    provider.shutdown()
+                except Exception:
+                    pass
+        self._logger_provider = None
+        self._meter_provider = None
+        self._tracer_provider = None
+        self._meter_provider_is_global = False
+        self._tracer_provider_is_global = False
+        self._log_processors.clear()
+        self._metric_readers.clear()
+        self._span_processors.clear()
+        self._span_processor = None
+        self._metric_reader = None
+        self._meter = None
+        self._live_store = None
+        self._live_active = False
+        self.tracer = None
+        self._langsmith = None
+
+        if self._atexit_registered:
+            atexit.unregister(self._force_flush)
+            atexit.unregister(self.stop_host_metrics)
+            self._atexit_registered = False
+        self._initialized = False
+
     @property
     def is_enabled(self) -> bool:
         return self._initialized
@@ -1213,11 +1303,39 @@ class HermesOTelPlugin:
 
 # Module-level singleton
 _tracer = None
+_tracers_by_home: Dict[Path, HermesOTelPlugin] = {}
+_tracers_lock = threading.RLock()
 
 
-def get_tracer() -> HermesOTelPlugin:
-    """Get or create the singleton tracer instance."""
+def get_tracer(profile_name: Optional[str] = None) -> HermesOTelPlugin:
+    """Get or create the tracer for the active Hermes profile."""
     global _tracer
-    if _tracer is None:
-        _tracer = HermesOTelPlugin()
-    return _tracer
+    profile_home = active_hermes_home().expanduser().resolve()
+
+    with _tracers_lock:
+        # Preserve direct singleton injection used by embedders and older tests.
+        if _tracer is not None and _tracer not in _tracers_by_home.values():
+            _tracers_by_home[profile_home] = _tracer
+
+        tracer = _tracers_by_home.get(profile_home)
+        if tracer is None:
+            tracer = HermesOTelPlugin(
+                profile_name=profile_name or "default",
+            )
+            _tracers_by_home[profile_home] = tracer
+        elif profile_name is not None and not tracer.is_enabled:
+            tracer.profile_name = profile_name
+        _tracer = tracer
+        return tracer
+
+
+def release_tracer(tracer: HermesOTelPlugin) -> None:
+    """Shut down and forget one profile's tracer instance."""
+    global _tracer
+    with _tracers_lock:
+        for profile_home, candidate in list(_tracers_by_home.items()):
+            if candidate is tracer:
+                del _tracers_by_home[profile_home]
+        if _tracer is tracer:
+            _tracer = None
+    tracer.shutdown()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,14 +30,13 @@ def _reset_otel_state(monkeypatch, tmp_path_factory):
     config (which can define backends and change the init() code path
     unexpectedly).
     """
+    import hermes_otel.live_store as live_store_mod
     import hermes_otel.plugin_config as plugin_config_mod
     import hermes_otel.tracer as tracer_mod
 
     isolated = tmp_path_factory.mktemp("isolated-config")
-    monkeypatch.setattr(plugin_config_mod, "DEFAULT_CONFIG_PATH", isolated / "nonexistent.yaml")
-    monkeypatch.setattr(
-        plugin_config_mod, "DURABLE_CONFIG_PATH", isolated / "nonexistent-durable.yaml"
-    )
+    monkeypatch.setattr(live_store_mod, "active_hermes_home", lambda: isolated)
+    monkeypatch.setattr(plugin_config_mod, "active_hermes_home", lambda: isolated)
     monkeypatch.delenv(plugin_config_mod.CONFIG_PATH_ENV, raising=False)
 
     def _reset():
@@ -46,7 +45,10 @@ def _reset_otel_state(monkeypatch, tmp_path_factory):
             # Never leak a host-metrics sampler thread across tests.
             current.stop_host_metrics()
         tracer_mod._tracer = None
+        tracer_mod._tracers_by_home.clear()
         tracer_mod._PARENT_STACK.set(None)
+        live_store_mod._LIVE_STORE = None
+        live_store_mod._LIVE_STORES.clear()
 
     _reset()
     yield

--- a/tests/integration/test_host_metrics_pipeline.py
+++ b/tests/integration/test_host_metrics_pipeline.py
@@ -132,9 +132,7 @@ class TestLifecycle:
 
 
 class TestLiveStoreMirror:
-    def test_readings_are_mirrored_when_live_store_active(
-        self, inmemory_otel_with_metrics, monkeypatch
-    ):
+    def test_readings_are_mirrored_when_live_store_active(self, inmemory_otel_with_metrics):
         _exporter, _reader, plugin = inmemory_otel_with_metrics
         seen = []
 
@@ -142,10 +140,8 @@ class TestLiveStoreMirror:
             def add_metric(self, name, value, attrs, ts):
                 seen.append((name, value, ts))
 
-        import hermes_otel.live_store as ls
-
-        monkeypatch.setattr(ls, "get_live_store", lambda: _Store())
         plugin._live_active = True
+        plugin._live_store = _Store()
         plugin._mirror_host_sample(_sample(gpus=[GpuReading(0, 0.75, None, None)]))
         assert seen == [
             ("process.cpu.utilization", 0.3, 1_700_000_000_000_000_000),

--- a/tests/integration/test_live_store_pipeline.py
+++ b/tests/integration/test_live_store_pipeline.py
@@ -24,13 +24,21 @@ def live_plugin(tmp_path):
     ls._LIVE_STORE = LiveStore(db_path=str(tmp_path / "live.db"))  # fresh tmp store
     store = get_live_store()
 
-    provider = TracerProvider(resource=Resource.create({"service.name": "live-test"}))
+    provider = TracerProvider(
+        resource=Resource.create(
+            {
+                "service.name": "live-test",
+                "profile.name": "work",
+            }
+        )
+    )
     provider.add_span_processor(_LiveSpanProcessor(store))
 
     plugin = HermesOTelPlugin()
     plugin.tracer = provider.get_tracer("live-test")
     plugin._initialized = True
     plugin._live_active = True
+    plugin._live_store = store
     plugin.config = HermesOtelConfig(dashboard_live=True)
 
     prev = tracer_mod._tracer
@@ -65,6 +73,7 @@ class TestLivePipeline:
         assert len(agent["trace_id"]) == 32 and len(agent["span_id"]) == 16
         assert agent["status"] in ("OK", "UNSET")
         assert agent["attributes"].get("hermes.session.kind") == "session"
+        assert agent["attributes"]["profile.name"] == "work"
         # tool span is a child (has a parent in the same trace)
         tool = next(s for s in spans if s["name"] == "tool.bash")
         assert tool["parent_span_id"] is not None

--- a/tests/integration/test_skill_spans.py
+++ b/tests/integration/test_skill_spans.py
@@ -33,7 +33,13 @@ def _load_skill(session_id, skill, task="sk1", tool="skill_view", args=None):
 
 
 class TestSkillSpanBasics:
-    def test_skill_view_opens_span_under_agent_root(self, inmemory_otel_setup):
+    def test_skill_view_opens_span_under_agent_root(
+        self, inmemory_otel_setup, monkeypatch, tmp_path
+    ):
+        from hermes_otel import hooks
+
+        profile_home = tmp_path / "profiles" / "work"
+        monkeypatch.setattr(hooks, "active_hermes_home", lambda: profile_home)
         exporter, _ = inmemory_otel_setup
         on_session_start(session_id="s1", model="gpt-4", platform="cli")
         _load_skill("s1", "axolotl")
@@ -50,6 +56,7 @@ class TestSkillSpanBasics:
         assert attrs["hermes.span_kind"] == "skill"
         assert attrs["gen_ai.skill.name"] == "axolotl"
         assert attrs["hermes.skill.result_status"] == "completed"
+        assert attrs["hermes.skill.path"] == str(profile_home / "skills" / "axolotl")
         # Nested under the turn root, not the tool span.
         assert _parent_span_id(skill) == agent.context.span_id
 

--- a/tests/unit/test_bundled_skill.py
+++ b/tests/unit/test_bundled_skill.py
@@ -11,7 +11,9 @@ class FakeCtx:
     def __init__(self, support_skills: bool = True):
         self.hooks = []
         self.skills = []
+        self.unload_callbacks = []
         self._support_skills = support_skills
+        self.profile_name = "default"
 
     def register_hook(self, name, callback):
         self.hooks.append(name)
@@ -23,6 +25,9 @@ class FakeCtx:
             raise AttributeError("register_skill")
         self.skills.append((name, Path(path), description))
 
+    def on_unload(self, callback):
+        self.unload_callbacks.append(callback)
+
 
 def _enabled_tracer(monkeypatch):
     class _T:
@@ -31,7 +36,10 @@ def _enabled_tracer(monkeypatch):
         def init(self):
             return True
 
-    monkeypatch.setattr("hermes_otel.tracer.get_tracer", lambda: _T())
+        def shutdown(self):
+            pass
+
+    monkeypatch.setattr("hermes_otel.tracer.get_tracer", lambda profile_name=None: _T())
 
 
 def test_bundled_skill_file_exists_and_parses():
@@ -51,6 +59,7 @@ def test_register_registers_bundled_skill(monkeypatch):
     # The path it registered must actually exist.
     registered = next(p for n, p, _ in ctx.skills if n == "observability")
     assert registered.exists()
+    assert len(ctx.unload_callbacks) == 1
 
 
 def test_register_is_forward_compatible_without_register_skill(monkeypatch):
@@ -60,4 +69,65 @@ def test_register_is_forward_compatible_without_register_skill(monkeypatch):
     hermes_otel.register(ctx)
     assert ctx.skills == []
     # Hooks still registered — skill failure doesn't abort registration.
+    assert "pre_tool_call" in ctx.hooks
+
+
+def test_register_passes_profile_name_to_tracer(monkeypatch):
+    captured = {}
+
+    class _T:
+        is_enabled = False
+
+        def init(self):
+            return False
+
+    def _get_tracer(profile_name=None):
+        captured["profile_name"] = profile_name
+        return _T()
+
+    monkeypatch.setattr("hermes_otel.tracer.get_tracer", _get_tracer)
+    ctx = FakeCtx()
+    ctx.profile_name = "work"
+
+    hermes_otel.register(ctx)
+
+    assert captured["profile_name"] == "work"
+
+
+def test_register_falls_back_for_older_hermes_context(monkeypatch):
+    captured = {}
+
+    class LegacyCtx:
+        pass
+
+    class _T:
+        is_enabled = False
+
+        def init(self):
+            return False
+
+    def _get_tracer(profile_name=None):
+        captured["profile_name"] = profile_name
+        return _T()
+
+    monkeypatch.setattr("hermes_otel.tracer.get_tracer", _get_tracer)
+
+    hermes_otel.register(LegacyCtx())
+
+    assert captured["profile_name"] == "default"
+
+
+def test_register_remains_compatible_without_profile_or_unload_api(monkeypatch):
+    class LegacyCtx:
+        def __init__(self):
+            self.hooks = []
+
+        def register_hook(self, name, callback):
+            self.hooks.append(name)
+
+    _enabled_tracer(monkeypatch)
+    ctx = LegacyCtx()
+
+    hermes_otel.register(ctx)
+
     assert "pre_tool_call" in ctx.hooks

--- a/tests/unit/test_config_path_resolution.py
+++ b/tests/unit/test_config_path_resolution.py
@@ -9,11 +9,14 @@ durable location outside the plugin directory, plus an explicit env override.
 
 from __future__ import annotations
 
+import sys
+import types
 from pathlib import Path
 
 import pytest
 
 from hermes_otel import plugin_config as pc
+from hermes_otel.profile_context import active_hermes_home
 
 CONFIG = "project_name: from-{}\n"
 
@@ -25,8 +28,7 @@ def locations(tmp_path, monkeypatch):
     (home / "plugins" / "hermes_otel").mkdir(parents=True)
     durable = home / "hermes_otel.yaml"
     legacy = home / "plugins" / "hermes_otel" / "config.yaml"
-    monkeypatch.setattr(pc, "DURABLE_CONFIG_PATH", durable)
-    monkeypatch.setattr(pc, "DEFAULT_CONFIG_PATH", legacy)
+    monkeypatch.setattr(pc, "active_hermes_home", lambda: home)
     monkeypatch.delenv(pc.CONFIG_PATH_ENV, raising=False)
     return {"home": home, "durable": durable, "legacy": legacy, "tmp": tmp_path}
 
@@ -77,6 +79,10 @@ class TestResolveConfigPath:
 
 
 class TestHermesHome:
+    @pytest.fixture(autouse=True)
+    def _restore_home_resolver(self, monkeypatch):
+        monkeypatch.setattr(pc, "active_hermes_home", active_hermes_home)
+
     def test_defaults_to_dot_hermes_in_home(self, monkeypatch):
         monkeypatch.delenv("HERMES_HOME", raising=False)
         assert pc.hermes_home() == Path.home() / ".hermes"
@@ -92,6 +98,15 @@ class TestHermesHome:
     def test_blank_hermes_home_falls_back(self, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", "  ")
         assert pc.hermes_home() == Path.home() / ".hermes"
+
+    def test_uses_host_profile_context(self, monkeypatch, tmp_path):
+        profile_home = tmp_path / "profiles" / "work"
+        hermes_constants = types.ModuleType("hermes_constants")
+        hermes_constants.get_hermes_home = lambda: profile_home
+        monkeypatch.setitem(sys.modules, "hermes_constants", hermes_constants)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default"))
+
+        assert pc.hermes_home() == profile_home
 
 
 class TestLoadConfigUsesResolution:
@@ -112,3 +127,24 @@ class TestLoadConfigUsesResolution:
 
     def test_no_config_anywhere_yields_defaults(self, locations):
         assert pc.load_config().project_name == pc.HermesOtelConfig().project_name
+
+    def test_switches_config_with_active_profile(self, monkeypatch, tmp_path):
+        default_home = tmp_path / "default"
+        work_home = tmp_path / "profiles" / "work"
+        default_home.mkdir(parents=True)
+        work_home.mkdir(parents=True)
+        (default_home / "hermes_otel.yaml").write_text("enabled: false\n")
+        (work_home / "hermes_otel.yaml").write_text(
+            "enabled: true\n"
+            "backends:\n"
+            "  - type: phoenix\n"
+            "    endpoint: http://work:6006/v1/traces\n"
+        )
+        active = {"home": default_home}
+        monkeypatch.setattr(pc, "active_hermes_home", lambda: active["home"])
+
+        assert pc.load_config().enabled is False
+        active["home"] = work_home
+        work_config = pc.load_config()
+        assert work_config.enabled is True
+        assert work_config.backends[0].endpoint == "http://work:6006/v1/traces"

--- a/tests/unit/test_dashboard_config_path.py
+++ b/tests/unit/test_dashboard_config_path.py
@@ -34,7 +34,7 @@ import backends as dash_backends  # noqa: E402
 @pytest.fixture(autouse=True)
 def _isolated_env(monkeypatch, tmp_path):
     monkeypatch.delenv("HERMES_OTEL_CONFIG", raising=False)
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(dash_backends, "_active_hermes_home", lambda: tmp_path / "home")
     # Keep the legacy in-plugin config.yaml out of the picture.
     monkeypatch.setattr(
         dash_backends,
@@ -79,3 +79,18 @@ def test_env_override_wins(monkeypatch, tmp_path):
 def test_nothing_found(tmp_path):
     assert dash_backends.resolve_config_path() is None
     assert dash_backends.candidate_config_paths()[0] == tmp_path / "home" / "hermes_otel.yaml"
+
+
+def test_switches_with_active_profile(monkeypatch, tmp_path):
+    default_home = tmp_path / "default"
+    work_home = tmp_path / "profiles" / "work"
+    default_home.mkdir(parents=True)
+    work_home.mkdir(parents=True)
+    (default_home / "hermes_otel.yaml").write_text("backends: []\n")
+    (work_home / "hermes_otel.yaml").write_text("backends: []\n")
+    active = {"home": default_home}
+    monkeypatch.setattr(dash_backends, "_active_hermes_home", lambda: active["home"])
+
+    assert dash_backends.resolve_config_path() == default_home / "hermes_otel.yaml"
+    active["home"] = work_home
+    assert dash_backends.resolve_config_path() == work_home / "hermes_otel.yaml"

--- a/tests/unit/test_debug_utils.py
+++ b/tests/unit/test_debug_utils.py
@@ -1,0 +1,15 @@
+"""Tests for profile-scoped debug logging."""
+
+from hermes_otel import debug_utils
+
+
+def test_debug_log_uses_active_profile_home(monkeypatch, tmp_path):
+    profile_home = tmp_path / "profiles" / "work"
+    log_dir = profile_home / "plugins" / "hermes_otel"
+    log_dir.mkdir(parents=True)
+    monkeypatch.setattr(debug_utils, "_DEBUG_ENABLED", True)
+    monkeypatch.setattr(debug_utils, "active_hermes_home", lambda: profile_home)
+
+    debug_utils.debug_log("profile-scoped")
+
+    assert (log_dir / "debug.log").read_text() == "profile-scoped\n"

--- a/tests/unit/test_install_artifact.py
+++ b/tests/unit/test_install_artifact.py
@@ -57,6 +57,7 @@ class TestArtifactContents:
             "span_tracker.py",
             "session_state.py",
             "helpers.py",
+            "profile_context.py",
             "plugin_config.py",
             "backends.py",
             "live_store.py",

--- a/tests/unit/test_live_store.py
+++ b/tests/unit/test_live_store.py
@@ -1,5 +1,7 @@
 """Unit tests for the SQLite-backed live store (zero-config dashboard)."""
 
+from pathlib import Path
+
 import pytest
 
 from hermes_otel.live_store import LiveStore, get_live_store
@@ -108,7 +110,39 @@ class TestLiveStore:
 
         ls._LIVE_STORE = None
         assert get_live_store(create=False) is None
-        a = get_live_store(create=True, db_path=str(tmp_path / "s.db"))
-        b = get_live_store(create=False)
+        db_path = str(tmp_path / "s.db")
+        a = get_live_store(create=True, db_path=db_path)
+        b = get_live_store(create=False, db_path=db_path)
         assert a is b is not None
         ls._LIVE_STORE = None  # cleanup
+
+    def test_stores_are_partitioned_by_active_profile(self, monkeypatch, tmp_path):
+        import hermes_otel.live_store as ls
+
+        default_home = tmp_path / "default"
+        work_home = tmp_path / "profiles" / "work"
+        (default_home / "plugins" / "hermes_otel").mkdir(parents=True)
+        (work_home / "plugins" / "hermes_otel").mkdir(parents=True)
+        active = {"home": default_home}
+        monkeypatch.setattr(ls, "active_hermes_home", lambda: active["home"])
+
+        default_store = get_live_store(create=True)
+        default_store.add_span({"name": "default-span"})
+        active["home"] = work_home
+        work_store = get_live_store(create=True)
+
+        assert work_store is not default_store
+        assert work_store.spans() == []
+        assert [span["name"] for span in default_store.spans()] == ["default-span"]
+
+    def test_default_store_creates_missing_profile_directory(self, monkeypatch, tmp_path):
+        import hermes_otel.live_store as ls
+
+        profile_home = tmp_path / "profiles" / "work"
+        monkeypatch.setattr(ls, "active_hermes_home", lambda: profile_home)
+
+        profile_store = get_live_store(create=True)
+        profile_store.add_span({"name": "created"})
+
+        assert Path(profile_store.db_path).is_file()
+        assert [span["name"] for span in profile_store.spans()] == ["created"]

--- a/tests/unit/test_log_handler.py
+++ b/tests/unit/test_log_handler.py
@@ -162,6 +162,8 @@ def clean_root_logger():
     for h in list(root.handlers):
         if getattr(h, log_handler._HANDLER_MARKER, False):
             root.removeHandler(h)
+    if hasattr(root, log_handler._ORIGINAL_LOG_LEVEL):
+        delattr(root, log_handler._ORIGINAL_LOG_LEVEL)
     root.setLevel(saved_level)
     # Preserve handlers the test framework may have added.
     for h in list(root.handlers):
@@ -247,6 +249,29 @@ class TestInstallHandler:
         ]
         assert len(markers) == 1, "should replace, not stack, prior installs"
 
+    def test_keeps_handlers_for_different_profiles(self, clean_root_logger, tmp_path):
+        default_home = tmp_path / "default"
+        work_home = tmp_path / "profiles" / "work"
+        log_handler.install_handler(
+            resource=self._resource(),
+            processors=self._fake_processors(),
+            level=logging.INFO,
+            profile_home=default_home,
+        )
+        log_handler.install_handler(
+            resource=self._resource(),
+            processors=self._fake_processors(),
+            level=logging.INFO,
+            profile_home=work_home,
+        )
+
+        markers = [
+            getattr(h, log_handler._HANDLER_MARKER, None)
+            for h in clean_root_logger.handlers
+            if getattr(h, log_handler._HANDLER_MARKER, None)
+        ]
+        assert markers == [str(default_home.resolve()), str(work_home.resolve())]
+
     def test_raises_target_level_to_match_handler(self, clean_root_logger):
         clean_root_logger.setLevel(logging.ERROR)
         log_handler.install_handler(
@@ -265,6 +290,42 @@ class TestInstallHandler:
         )
         # We only LOWER the effective level — never raise it.
         assert clean_root_logger.level == logging.DEBUG
+
+    def test_named_logger_does_not_inherit_a_higher_parent_level(self, clean_root_logger, tmp_path):
+        clean_root_logger.setLevel(logging.WARNING)
+        target = logging.getLogger("hermes_otel_test_profile_level")
+        target.setLevel(logging.NOTSET)
+        profile_home = tmp_path / "profiles" / "work"
+        try:
+            log_handler.install_handler(
+                resource=self._resource(),
+                processors=self._fake_processors(),
+                level=logging.INFO,
+                attach_logger=target.name,
+                profile_home=profile_home,
+            )
+
+            assert target.level == logging.INFO
+            assert target.isEnabledFor(logging.INFO)
+        finally:
+            log_handler.remove_handler(target.name, profile_home)
+
+        assert target.level == logging.NOTSET
+
+    def test_restores_target_level_after_last_profile_is_removed(self, clean_root_logger, tmp_path):
+        clean_root_logger.setLevel(logging.WARNING)
+        profile_home = tmp_path / "profiles" / "work"
+        log_handler.install_handler(
+            resource=self._resource(),
+            processors=self._fake_processors(),
+            level=logging.DEBUG,
+            profile_home=profile_home,
+        )
+        assert clean_root_logger.level == logging.DEBUG
+
+        log_handler.remove_handler(None, profile_home)
+
+        assert clean_root_logger.level == logging.WARNING
 
 
 # ── OTel-internal filter ────────────────────────────────────────────────────
@@ -576,6 +637,19 @@ class TestExcludeOTelInternalFilter:
         assert f.filter(self._record("hermes_otel.hooks", level=logging.INFO)) is True
         assert f.filter(self._record("hermes.gateway", level=logging.INFO)) is True
         assert f.filter(self._record("myapp.module", level=logging.INFO)) is True
+
+
+class TestProfileHomeFilter:
+    def test_keeps_only_records_from_its_profile(self, monkeypatch, tmp_path):
+        work_home = tmp_path / "profiles" / "work"
+        active = {"home": work_home}
+        monkeypatch.setattr(log_handler, "active_hermes_home", lambda: active["home"])
+        profile_filter = log_handler._ProfileHomeFilter(str(work_home))
+        record = logging.LogRecord("app", logging.INFO, __file__, 1, "test", (), None)
+
+        assert profile_filter.filter(record) is True
+        active["home"] = tmp_path / "profiles" / "personal"
+        assert profile_filter.filter(record) is False
 
 
 # ── tracer wiring ──────────────────────────────────────────────────────────

--- a/tests/unit/test_profile_context.py
+++ b/tests/unit/test_profile_context.py
@@ -1,0 +1,58 @@
+"""Profile compatibility helpers."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+from hermes_otel.profile_context import active_hermes_home, profile_name_from_context
+
+
+def test_active_home_prefers_hermes_context(monkeypatch, tmp_path):
+    profile_home = tmp_path / "profiles" / "work"
+    hermes_constants = types.ModuleType("hermes_constants")
+    hermes_constants.get_hermes_home = lambda: profile_home
+    monkeypatch.setitem(sys.modules, "hermes_constants", hermes_constants)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default"))
+
+    assert active_hermes_home() == profile_home
+
+
+def test_active_home_falls_back_to_environment(monkeypatch, tmp_path):
+    monkeypatch.setitem(sys.modules, "hermes_constants", None)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "custom"))
+
+    assert active_hermes_home() == tmp_path / "custom"
+
+
+def test_active_home_falls_back_to_default(monkeypatch):
+    monkeypatch.setitem(sys.modules, "hermes_constants", None)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+
+    assert active_hermes_home() == Path.home() / ".hermes"
+
+
+def test_profile_name_uses_host_context():
+    ctx = types.SimpleNamespace(profile_name="work")
+
+    assert profile_name_from_context(ctx) == "work"
+
+
+def test_profile_name_falls_back_for_older_context():
+    assert profile_name_from_context(object()) == "default"
+
+
+def test_profile_name_falls_back_when_property_fails():
+    class BrokenContext:
+        @property
+        def profile_name(self):
+            raise RuntimeError("unsupported")
+
+    assert profile_name_from_context(BrokenContext()) == "default"
+
+
+def test_profile_name_falls_back_for_blank_value():
+    ctx = types.SimpleNamespace(profile_name=" ")
+
+    assert profile_name_from_context(ctx) == "default"

--- a/tests/unit/test_tracer_init.py
+++ b/tests/unit/test_tracer_init.py
@@ -1,7 +1,7 @@
 """Tests for HermesOTelPlugin.init() environment detection logic."""
 
 import base64
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -75,6 +75,32 @@ class TestInitPhoenix:
                 assert plugin._live_active is True
             finally:
                 ls._LIVE_STORE = None  # don't leak the singleton into other tests
+
+    def test_profile_instances_keep_independent_tracer_resources(self, monkeypatch):
+        _clear_backend_env(monkeypatch)
+        import hermes_otel.live_store as ls
+
+        default_plugin = HermesOTelPlugin(
+            config=HermesOtelConfig(dashboard_live=True),
+            profile_name="default",
+        )
+        work_plugin = HermesOTelPlugin(
+            config=HermesOtelConfig(dashboard_live=True),
+            profile_name="work",
+        )
+        with patch("hermes_otel.tracer.trace.set_tracer_provider"):
+            try:
+                assert default_plugin.init() is True
+                assert work_plugin.init() is True
+            finally:
+                ls._LIVE_STORE = None
+
+        default_resource = dict(default_plugin.tracer.resource.attributes)
+        work_resource = dict(work_plugin.tracer.resource.attributes)
+        assert default_resource["profile.name"] == "default"
+        assert work_resource["profile.name"] == "work"
+        default_plugin.shutdown()
+        work_plugin.shutdown()
 
     def test_init_with_explicit_endpoint_arg(self, monkeypatch):
         _clear_backend_env(monkeypatch)
@@ -421,6 +447,90 @@ class TestConfigDisabled:
             mock_otlp.assert_not_called()
 
 
+class TestShutdown:
+    def test_releases_profile_resources(self, monkeypatch):
+        plugin = HermesOTelPlugin(
+            config=HermesOtelConfig(capture_logs=True),
+            profile_name="work",
+        )
+        tracer_provider = MagicMock()
+        meter_provider = MagicMock()
+        logger_provider = MagicMock()
+        host_metrics = MagicMock()
+        plugin._tracer_provider = tracer_provider
+        plugin._meter_provider = meter_provider
+        plugin._logger_provider = logger_provider
+        plugin._host_metrics = host_metrics
+        plugin._langsmith = MagicMock()
+        plugin._initialized = True
+        plugin._atexit_registered = True
+
+        with (
+            patch("hermes_otel.log_handler.remove_handler") as remove_handler,
+            patch("hermes_otel.tracer.atexit.unregister") as unregister,
+        ):
+            plugin.shutdown()
+
+        host_metrics.stop.assert_called_once()
+        assert remove_handler.call_args_list == [
+            call(None, plugin.profile_home, kind="otel"),
+        ]
+        tracer_provider.shutdown.assert_called_once()
+        meter_provider.shutdown.assert_called_once()
+        logger_provider.shutdown.assert_called_once()
+        assert unregister.call_count == 2
+        assert plugin.is_enabled is False
+        assert plugin._langsmith is None
+
+    def test_keeps_process_global_providers_alive_on_profile_unload(self):
+        plugin = HermesOTelPlugin(profile_name="default")
+        tracer_provider = MagicMock()
+        meter_provider = MagicMock()
+        plugin._tracer_provider = tracer_provider
+        plugin._tracer_provider_is_global = True
+        plugin._meter_provider = meter_provider
+        plugin._meter_provider_is_global = True
+
+        plugin.shutdown()
+
+        tracer_provider.shutdown.assert_not_called()
+        meter_provider.shutdown.assert_not_called()
+
+
+class TestProfileTracerRegistry:
+    def test_get_tracer_is_keyed_by_active_profile_home(self, monkeypatch, tmp_path):
+        import hermes_otel.tracer as tracer_mod
+
+        active = {"home": tmp_path / "default"}
+        monkeypatch.setattr(tracer_mod, "active_hermes_home", lambda: active["home"])
+
+        default_tracer = tracer_mod.get_tracer(profile_name="default")
+        active["home"] = tmp_path / "profiles" / "work"
+        work_tracer = tracer_mod.get_tracer(profile_name="work")
+
+        assert work_tracer is not default_tracer
+        assert default_tracer.profile_name == "default"
+        assert work_tracer.profile_name == "work"
+        assert default_tracer.profile_home == tmp_path / "default"
+        assert work_tracer.profile_home == tmp_path / "profiles" / "work"
+
+    def test_release_tracer_removes_only_its_profile(self, monkeypatch, tmp_path):
+        import hermes_otel.tracer as tracer_mod
+
+        active = {"home": tmp_path / "default"}
+        monkeypatch.setattr(tracer_mod, "active_hermes_home", lambda: active["home"])
+        default_tracer = tracer_mod.get_tracer(profile_name="default")
+        active["home"] = tmp_path / "profiles" / "work"
+        work_tracer = tracer_mod.get_tracer(profile_name="work")
+        work_tracer.shutdown = MagicMock()
+
+        tracer_mod.release_tracer(work_tracer)
+
+        work_tracer.shutdown.assert_called_once()
+        assert default_tracer in tracer_mod._tracers_by_home.values()
+        assert work_tracer not in tracer_mod._tracers_by_home.values()
+
+
 class TestResourceAttributes:
     def test_resource_attributes_merged(self, monkeypatch):
         _clear_backend_env(monkeypatch)
@@ -453,6 +563,30 @@ class TestResourceAttributes:
         assert attrs["region"] == "us-east-1"
         assert attrs["team"] == "platform"
         assert attrs["openinference.project.name"] == "cfg-project"
+        assert attrs["profile.name"] == "default"
+
+    def test_profile_name_is_added_to_resource(self):
+        plugin = HermesOTelPlugin(
+            config=HermesOtelConfig(dashboard_live=False),
+            profile_name="work",
+        )
+
+        attrs = dict(plugin._build_resource().attributes)
+
+        assert attrs["profile.name"] == "work"
+
+    def test_active_profile_overrides_configured_resource_attribute(self):
+        plugin = HermesOTelPlugin(
+            config=HermesOtelConfig(
+                dashboard_live=False,
+                resource_attributes={"profile.name": "wrong-profile"},
+            ),
+            profile_name="work",
+        )
+
+        attrs = dict(plugin._build_resource().attributes)
+
+        assert attrs["profile.name"] == "work"
 
     def test_resource_attributes_override_global_tags(self, monkeypatch):
         _clear_backend_env(monkeypatch)

--- a/website/docs/architecture/attributes.md
+++ b/website/docs/architecture/attributes.md
@@ -83,7 +83,13 @@ Set on the OTel `Resource` and therefore stamped on **every** span:
 | `service.version` | `hermes-otel` plugin version |
 | `otel.scope.name` | `hermes-otel` |
 | `openinference.project.name` | Same as `service.name` |
+| `profile.name` | Active Hermes profile (`default`, a named profile id, or `custom`) |
 | *plus* any `resource_attributes:` / `global_tags:` from `config.yaml` |
+
+`profile.name` is host-derived and authoritative: a same-named value under
+`resource_attributes` is replaced with the active profile. Because it is a
+Resource attribute rather than a metric label, it identifies traces, metrics,
+and logs without adding a high-cardinality dimension to every instrument.
 
 ## Why dual-convention rather than pick one?
 

--- a/website/docs/architecture/overview.md
+++ b/website/docs/architecture/overview.md
@@ -107,7 +107,7 @@ Every path below is relative to `hermes_otel/` — the package directory that `h
 | `session_state.py` | Per-session aggregation for turn summary |
 | `plugin_config.py` | Config file + env-var parsing with precedence |
 | `helpers.py` | `_safe_str`, `_to_int`, `_detect_session_kind`, preview clipping |
-| `debug_utils.py` | Optional debug log to `~/.hermes/plugins/hermes_otel/debug.log` |
+| `debug_utils.py` | Optional debug log to `$HERMES_HOME/plugins/hermes_otel/debug.log` |
 | `langsmith_backend.py` | LangSmith-specific translation (not OTLP) |
 
 ## Next

--- a/website/docs/backends/multi-backend.md
+++ b/website/docs/backends/multi-backend.md
@@ -146,4 +146,6 @@ Enable debug logging:
 export HERMES_OTEL_DEBUG=true
 ```
 
-Per-backend export attempts, queue depths, and retry counts show up in `~/.hermes/plugins/hermes_otel/debug.log`. See [Debug logging](/development/debug-logging).
+Per-backend export attempts, queue depths, and retry counts show up in
+`$HERMES_HOME/plugins/hermes_otel/debug.log`. See
+[Debug logging](/development/debug-logging).

--- a/website/docs/backends/phoenix.md
+++ b/website/docs/backends/phoenix.md
@@ -71,7 +71,8 @@ Phoenix accepts OTLP metrics in addition to traces. The plugin's token/tool/cost
 
 - Check the endpoint includes `/v1/traces` — Phoenix doesn't redirect from the collector root.
 - Confirm the container is listening: `curl -I http://localhost:6006` should return `200`.
-- Turn on debug logging: `export HERMES_OTEL_DEBUG=true`, run a Hermes turn, check `~/.hermes/plugins/hermes_otel/debug.log` for the OTLP POST response.
+- Turn on debug logging: `export HERMES_OTEL_DEBUG=true`, run a Hermes turn,
+  check `$HERMES_HOME/plugins/hermes_otel/debug.log` for the OTLP POST response.
 
 **"Spans are missing input/output previews"**
 

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -76,14 +76,14 @@ Each of these overrides the corresponding field in `config.yaml`. See [`config.y
 | Var | Effect |
 |---|---|
 | `HERMES_OTEL_CONFIG` | Explicit path to the config file. Highest precedence — see [Where does `config.yaml` live?](/configuration/overview). |
-| `HERMES_HOME` | Hermes' home directory (default `~/.hermes`). The plugin resolves its config and plugin directory under it. |
-| `HERMES_OTEL_LIVE_DB` | Path to the live dashboard's SQLite store. Point it outside the plugin directory to keep it across upgrades. |
+| `HERMES_HOME` | Hermes' home directory (default `~/.hermes`). The plugin also honors Hermes' context-local home override when serving multiplexed profiles. |
+| `HERMES_OTEL_LIVE_DB` | Process-wide path override for the live dashboard's SQLite store. Leave unset for profile isolation; set it outside the plugin directory to keep it across upgrades. |
 
 ## Debug / diagnostics
 
 | Var | Effect |
 |---|---|
-| `HERMES_OTEL_DEBUG` | `true` enables per-span debug log to `~/.hermes/plugins/hermes_otel/debug.log`. See [Debug logging](/development/debug-logging). |
+| `HERMES_OTEL_DEBUG` | `true` enables per-span debug log to `$HERMES_HOME/plugins/hermes_otel/debug.log`. See [Debug logging](/development/debug-logging). |
 
 ## Boolean parsing
 
@@ -108,5 +108,8 @@ HERMES_OTEL_SAMPLE_RATE=0.25
 Or export them in your shell profile (`~/.bashrc`, `~/.zshrc`) for a global default.
 
 :::tip
-Prefer `~/.hermes/.env` for per-machine config. Per-shell exports are fine for experimentation but drift from what you've committed to `config.yaml`.
+Prefer the active profile's `$HERMES_HOME/.env` for per-profile secrets and
+`$HERMES_HOME/hermes_otel.yaml` for per-profile plugin settings. Per-shell
+exports and `HERMES_OTEL_CONFIG` are process-wide, so multiplexed profiles
+cannot use them for differing values.
 :::

--- a/website/docs/configuration/overview.md
+++ b/website/docs/configuration/overview.md
@@ -35,6 +35,15 @@ Three locations, checked in this order:
 
 If both 2 and 3 exist, 2 wins and the plugin logs a warning naming the shadowed copy.
 
+`$HERMES_HOME` is resolved from Hermes' active profile at runtime, including
+context-local profile switches in a multiplex process. A named profile such as
+`work` therefore reads `~/.hermes/profiles/work/hermes_otel.yaml`, while the
+default profile reads `~/.hermes/hermes_otel.yaml`.
+
+`HERMES_OTEL_CONFIG` is an explicit process-wide override. Do not set it when
+profiles in the same multiplex process need different hermes-otel
+configuration.
+
 A fully-annotated template ships in the repository as `config.yaml.example`:
 
 ```bash
@@ -84,7 +93,14 @@ Set `backends:` in `config.yaml` with one or more entries. Env-var detection is 
 
 ## Disabling the plugin without uninstalling
 
-Two options:
+Hermes itself controls whether the plugin is loaded for a profile:
+
+```bash
+hermes -p work plugins enable hermes_otel
+hermes -p personal plugins disable hermes_otel
+```
+
+Once loaded, hermes-otel also has a profile-local kill switch:
 
 ```bash
 export HERMES_OTEL_ENABLED=false     # Env-var kill switch
@@ -96,4 +112,7 @@ Or in `config.yaml`:
 enabled: false
 ```
 
-Either way, `register()` returns early after the kill-switch check. No spans are created, no hooks are attached, no OTel SDK is loaded. Flip it back on to restart.
+With `enabled: false`, `register()` returns early after the kill-switch check.
+No spans are created, no hooks are attached, and no OTel SDK is loaded. The
+environment variable is process-wide; use the profile-local YAML or Hermes'
+native plugin commands when multiplexed profiles need different states.

--- a/website/docs/configuration/yaml.md
+++ b/website/docs/configuration/yaml.md
@@ -10,6 +10,11 @@ A fully-annotated example ships in the repository as `config.yaml.example`. This
 
 Location: `$HERMES_HOME/hermes_otel.yaml` (recommended), or `$HERMES_OTEL_CONFIG`, or the legacy `$HERMES_HOME/plugins/hermes_otel/config.yaml` — see [Where does config.yaml live?](/configuration/overview). Parsed only if `pyyaml` is installed in the Hermes venv.
 
+`$HERMES_HOME` follows the active Hermes profile. For example, profile `work`
+uses `~/.hermes/profiles/work/hermes_otel.yaml`. The explicit
+`HERMES_OTEL_CONFIG` override is process-wide, so leave it unset when
+multiplexed profiles need different files.
+
 ## Project / resource attributes
 
 ```yaml
@@ -23,6 +28,7 @@ global_tags:
   team: platform
 
 # Takes precedence over `global_tags` on key conflict.
+# `profile.name` is reserved and always reflects the active Hermes profile.
 resource_attributes:
   env: prod
   region: us-east-1

--- a/website/docs/development/debug-logging.md
+++ b/website/docs/development/debug-logging.md
@@ -17,10 +17,14 @@ export HERMES_OTEL_DEBUG=true
 Then restart Hermes. The log file is:
 
 ```
-~/.hermes/plugins/hermes_otel/debug.log
+$HERMES_HOME/plugins/hermes_otel/debug.log
 ```
 
-It's append-only — old entries stick around until you delete the file. No rotation; if you use debug mode for long periods, `rm debug.log` occasionally or pipe through `logrotate`.
+`$HERMES_HOME` follows the active profile, so a named profile writes to a path
+such as `~/.hermes/profiles/work/plugins/hermes_otel/debug.log`. The file is
+append-only — old entries stick around until you delete it. No rotation; if you
+use debug mode for long periods, remove it occasionally or pipe through
+`logrotate`.
 
 ## What gets logged
 
@@ -70,7 +74,7 @@ If a secret is logged unredacted, that's a bug — open an issue.
 ```bash
 export HERMES_OTEL_DEBUG=true
 # Run one Hermes turn
-tail -f ~/.hermes/plugins/hermes_otel/debug.log
+tail -f "$HERMES_HOME/plugins/hermes_otel/debug.log"
 ```
 
 Look for:
@@ -100,4 +104,5 @@ unset HERMES_OTEL_DEBUG
 export HERMES_OTEL_DEBUG=false
 ```
 
-Restart Hermes. The file isn't deleted on disable; `rm ~/.hermes/plugins/hermes_otel/debug.log` to clean up.
+Restart Hermes. The file isn't deleted on disable; remove
+`$HERMES_HOME/plugins/hermes_otel/debug.log` to clean up.

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -35,6 +35,27 @@ alongside the plugin:
 Hermes deliberately never installs plugin dependencies for you; it prints them at install time and
 leaves the venv to you.
 
+### Named profiles
+
+Plugins are installed and enabled per Hermes profile. To use hermes-otel in a
+named profile, target that profile when installing:
+
+```bash
+hermes -p work plugins install briancaffey/hermes-otel/hermes_otel --enable
+```
+
+Hermes' native `plugins.enabled` / `plugins.disabled` settings decide whether
+the plugin loads for each profile. No hermes-otel-specific profile allowlist is
+needed. Each enabled profile reads its own
+`$HERMES_HOME/hermes_otel.yaml` (for example,
+`~/.hermes/profiles/work/hermes_otel.yaml`) and exports its profile id as the
+OTel Resource attribute `profile.name`.
+
+`hermes profile create work --clone-all` also copies installed plugins and
+their activation config. A plain `--clone` copies configuration but not the
+plugin directory. The live dashboard database is likewise profile-scoped at
+`$HERMES_HOME/plugins/hermes_otel/live.db`.
+
 :::note What actually gets installed
 About 40 files / 500 KB: the Python modules, `plugin.yaml`, the bundled skill and the dashboard tab.
 The docs site, test suite and example Compose stacks stay in the repository — they are development
@@ -67,8 +88,11 @@ mv ~/.hermes/plugins/hermes_otel/config.yaml ~/.hermes/hermes_otel.yaml
 export HERMES_OTEL_LIVE_DB=~/.hermes/hermes_otel.live.db
 ```
 
-`$HERMES_HOME/hermes_otel.yaml` is read automatically — see
+The active profile's `$HERMES_HOME/hermes_otel.yaml` is read automatically — see
 [Where does `config.yaml` live?](/configuration/overview).
+
+`HERMES_OTEL_LIVE_DB` is a process-wide override. Leave it unset when
+multiplexed profiles need isolated live-dashboard data.
 :::
 
 ### Coming from an install made before v0.12

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -103,5 +103,7 @@ Each span carries:
 - **Understand what each span means?** → [Architecture](/architecture/overview)
 
 :::info Something not showing up?
-Enable debug logging — `export HERMES_OTEL_DEBUG=true` — and check `~/.hermes/plugins/hermes_otel/debug.log`. Per-span start/end, parent nesting, token counts, and HTTP payloads all land there.
+Enable debug logging — `export HERMES_OTEL_DEBUG=true` — and check
+`$HERMES_HOME/plugins/hermes_otel/debug.log`. Per-span start/end, parent
+nesting, token counts, and HTTP payloads all land there.
 :::

--- a/website/docs/reference/env-vars.md
+++ b/website/docs/reference/env-vars.md
@@ -77,7 +77,7 @@ See [OTel logs](/configuration/logs) for behavior.
 
 | Var | Value | Effect |
 |---|---|---|
-| `HERMES_OTEL_DEBUG` | `true`/`false` | Enables debug log at `~/.hermes/plugins/hermes_otel/debug.log` |
+| `HERMES_OTEL_DEBUG` | `true`/`false` | Enables debug log at `$HERMES_HOME/plugins/hermes_otel/debug.log` |
 
 ## Boolean accepted values
 

--- a/website/docs/reference/limitations.md
+++ b/website/docs/reference/limitations.md
@@ -76,6 +76,11 @@ Setting `LANGSMITH_TRACING=true` short-circuits the `backends:` list entirely. Y
 
 Why: LangSmith uses its own HTTP Run API rather than OTLP; its transport doesn't fit into the OTel `BatchSpanProcessor` shape.
 
+The same distinction applies to profile identity: `profile.name` is an OTel
+Resource attribute and therefore accompanies OTLP traces, metrics, and logs.
+LangSmith runs do not have an OTel Resource, so they do not receive this
+attribute.
+
 Workaround if you need both: run the OTel Collector and have it route traces to LangSmith's OTLP-compatible beta ingest, if/when LangSmith ships one.
 
 ## Weave is trace-ingest only
@@ -94,9 +99,22 @@ Because `wandb.entity` and `wandb.project` are Resource attributes on the
 shared `TracerProvider`, one Hermes process can route to one Weave project at a
 time. Multiple configured Weave entries must agree on those values.
 
+## Process-global auto-instrumentation in multiplex mode
+
+hermes-otel creates profile-local tracer and meter providers for the spans and
+metrics emitted by its hooks. Third-party libraries that instrument themselves
+through OpenTelemetry's process-global provider, however, can bind only to the
+first provider installed in a multiplex process. Their spans may therefore
+carry the first profile's Resource. That first provider remains alive until
+process exit because OpenTelemetry does not allow replacing it; shutting it
+down on a profile reload would permanently disable MCP and other global
+auto-instrumentation. Run profiles in separate processes when strict isolation
+or per-profile disablement of third-party auto-instrumented spans is required.
+
 ## Debug log has no rotation
 
-Enabling `HERMES_OTEL_DEBUG=true` appends to `~/.hermes/plugins/hermes_otel/debug.log` forever. No rotation, no size cap.
+Enabling `HERMES_OTEL_DEBUG=true` appends to
+`$HERMES_HOME/plugins/hermes_otel/debug.log` forever. No rotation, no size cap.
 
 Deliberate: the debug log is meant for troubleshooting, not routine operation. If you want persistent debug logs, pipe through `logrotate` or rm the file weekly.
 

--- a/website/docs/reference/span-attributes.md
+++ b/website/docs/reference/span-attributes.md
@@ -18,6 +18,7 @@ Attributes marked **optional** are only set when the underlying data is availabl
 | `service.version` | `hermes-otel` plugin version |
 | `otel.scope.name` | `hermes-otel` |
 | `openinference.project.name` | Same as `service.name` |
+| `profile.name` | Active Hermes profile (`default`, a named profile id, or `custom`) |
 | `wandb.entity` | W&B Weave routing (when configured) |
 | `wandb.project` | W&B Weave routing (when configured) |
 | `telemetry.sdk.*` | Set by OTel SDK |


### PR DESCRIPTION
Export the active Hermes profile as an OTel resource attribute and isolate profile configuration, providers, logs, live stores, and unload lifecycle.