### PR TITLE
feat: governance approval provenance in traces

### DIFF
--- a/hermes_otel/helpers.py
+++ b/hermes_otel/helpers.py
@@ -221,21 +221,62 @@ def session_id_from_turn_id(turn_id: Any) -> str:
 
 
 _APPROVAL_GRANT_CHOICES = frozenset({"once", "session", "always"})
+# Smart-guardian verdicts arrive as ``smart_<verdict>`` choices with
+# decided_by="aux_llm" (tools/approval_smart.py). smart_approve IS a grant
+# (the tool ran); smart_deny/smart_escalate are not.
+_SMART_GRANT_CHOICES = frozenset({"smart_approve"})
+_SMART_CHOICES = frozenset({"smart_approve", "smart_deny", "smart_escalate"})
 
 
-def classify_approval_choice(choice: Any) -> Dict[str, Any]:
+def classify_approval_choice(choice: Any, decided_by: Any = None) -> Dict[str, Any]:
     """Normalize an approval ``choice`` into telemetry fields.
 
     ``choice`` is one of ``once`` / ``session`` / ``always`` / ``deny`` /
-    ``timeout``. The first three are grants; ``timeout`` is flagged distinctly.
-    A denied or timed-out approval is a legitimate human outcome, not an error.
+    ``timeout``, or a smart-guardian verdict ``smart_approve`` /
+    ``smart_deny`` / ``smart_escalate`` fired with decided_by="aux_llm".
+    Grants (incl. smart_approve) set ``granted``; ``timeout`` is flagged
+    distinctly. A denied or timed-out approval is a legitimate human
+    outcome, not an error.
     """
     c = (choice or "").strip().lower() if isinstance(choice, str) else ""
+    by = (decided_by or "").strip().lower() if isinstance(decided_by, str) else ""
+    granted = c in _APPROVAL_GRANT_CHOICES or c in _SMART_GRANT_CHOICES
     return {
         "choice": c,
-        "granted": c in _APPROVAL_GRANT_CHOICES,
+        "granted": granted,
         "timed_out": c == "timeout",
+        # Who decided: "aux_llm" (smart guardian) vs. the default human
+        # answer. Empty when the caller didn't say.
+        "decided_by": by or ("aux_llm" if c in _SMART_CHOICES else ""),
     }
+
+
+# Floor blocks (approvals.deny globs, hardline list, sudo-stdin guard) never
+# fire the approval hooks — the block dict collapses into the terminal error
+# envelope (status "blocked") before post_tool_call sees it. The message
+# prefix is the stable surface for classifying which floor fired.
+# ponytail: message-prefix matching; if hermes grows a structured
+# floor-reason field, switch to that.
+_FLOOR_SIGNATURES = (
+    ("user-defined deny rule", "deny_rule"),
+    ("hardline", "hardline"),
+    ("sudo -S", "sudo_stdin_guard"),
+)
+
+
+def classify_floor_block(block_message: Any) -> Optional[str]:
+    """Return which governance floor blocked a command, or None.
+
+    ``block_message`` is the terminal error envelope's ``error``/``output``
+    text. Only ``BLOCKED``-prefixed floor messages match; anything else
+    (ordinary command failures) returns None.
+    """
+    if not isinstance(block_message, str) or not block_message.startswith("BLOCKED"):
+        return None
+    for signature, floor in _FLOOR_SIGNATURES:
+        if signature in block_message:
+            return floor
+    return "unknown_floor"
 
 
 # ── Sub-agent / delegation ───────────────────────────────────────────────────

--- a/hermes_otel/hooks.py
+++ b/hermes_otel/hooks.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional, TypedDict
 from .debug_utils import debug_log
 from .helpers import (
     classify_approval_choice,
+    classify_floor_block,
     clip_preview,
     coerce_bool,
     detect_skill,
@@ -947,6 +948,19 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
     outcome = extract_tool_result_status(result_json) or "completed"
     attributes["hermes.tool.outcome"] = outcome
 
+    # Governance provenance: floor blocks (approvals.deny globs, hardline
+    # list, sudo-stdin guard) never fire the approval hooks — the block dict
+    # is collapsed into this error envelope before post_tool_call sees it.
+    # Mark who blocked directly on the tool span.
+    if outcome == "blocked" and isinstance(result_json, dict):
+        floor = classify_floor_block(
+            result_json.get("error") or result_json.get("output") or ""
+        )
+        if floor:
+            attributes["hermes.approval.choice"] = "denied_by_floor"
+            attributes["hermes.approval.decided_by"] = "hard_floor"
+            attributes["hermes.approval.floor"] = floor
+
     # Preserve existing error.message attribute when outcome == error
     has_error = outcome == "error"
     error_msg = ""
@@ -1085,13 +1099,16 @@ def on_post_approval_response(
     pk = truncate_string(pattern_key, 200) or "command"
     key = _approval_span_key(session_id, tool_call_id, pk)
 
-    verdict = classify_approval_choice(choice)
+    verdict = classify_approval_choice(choice, kwargs.get("decided_by"))
     attributes: Dict[str, Any] = {
         "hermes.approval.granted": verdict["granted"],
         "hermes.approval.timed_out": verdict["timed_out"],
     }
     if verdict["choice"]:
         attributes["hermes.approval.choice"] = verdict["choice"]
+    if verdict["decided_by"]:
+        # Provenance: human answer vs. smart-guardian (aux LLM) verdict.
+        attributes["hermes.approval.decided_by"] = verdict["decided_by"]
 
     start = tracer.spans.pop_approval_start(key)
     duration_ms = None

--- a/tests/unit/test_hooks_helpers.py
+++ b/tests/unit/test_hooks_helpers.py
@@ -4,6 +4,7 @@ import pytest
 
 from hermes_otel.helpers import (
     classify_approval_choice,
+    classify_floor_block,
     detect_skill,
     session_id_from_turn_id,
     truncate_string,
@@ -37,13 +38,14 @@ class TestClassifyApprovalChoice:
     def test_grants(self):
         for c in ("once", "session", "always"):
             v = classify_approval_choice(c)
-            assert v == {"choice": c, "granted": True, "timed_out": False}
+            assert v == {"choice": c, "granted": True, "timed_out": False, "decided_by": ""}
 
     def test_deny_is_not_granted_not_timeout(self):
         assert classify_approval_choice("deny") == {
             "choice": "deny",
             "granted": False,
             "timed_out": False,
+            "decided_by": "",
         }
 
     def test_timeout_flagged(self):
@@ -53,6 +55,54 @@ class TestClassifyApprovalChoice:
     def test_empty_or_none(self):
         assert classify_approval_choice(None)["choice"] == ""
         assert classify_approval_choice("")["granted"] is False
+
+    def test_smart_approve_is_grant_by_aux_llm(self):
+        v = classify_approval_choice("smart_approve")
+        assert v["granted"] is True
+        assert v["decided_by"] == "aux_llm"
+
+    def test_smart_deny_not_granted(self):
+        v = classify_approval_choice("smart_deny")
+        assert v["granted"] is False
+        assert v["decided_by"] == "aux_llm"
+
+    def test_smart_escalate_not_granted(self):
+        v = classify_approval_choice("smart_escalate")
+        assert v["granted"] is False
+        assert v["decided_by"] == "aux_llm"
+
+    def test_explicit_decided_by_wins(self):
+        assert classify_approval_choice("once", decided_by="aux_llm")["decided_by"] == "aux_llm"
+
+    def test_human_choice_decided_by_empty(self):
+        assert classify_approval_choice("once")["decided_by"] == ""
+
+
+class TestClassifyFloorBlock:
+    def test_deny_rule(self):
+        msg = ("BLOCKED: this command matches the user-defined deny rule "
+               "'*grc-app*' (approvals.deny in config.yaml).")
+        assert classify_floor_block(msg) == "deny_rule"
+
+    def test_hardline(self):
+        assert classify_floor_block("BLOCKED (hardline): fork bomb.") == "hardline"
+
+    def test_sudo_stdin_guard(self):
+        msg = "BLOCKED: piping detected. Do not pipe passwords to 'sudo -S'."
+        assert classify_floor_block(msg) == "sudo_stdin_guard"
+
+    def test_unknown_blocked_is_still_a_floor(self):
+        assert classify_floor_block("BLOCKED: something else") == "unknown_floor"
+
+    def test_ordinary_error_is_not_a_floor(self):
+        assert classify_floor_block("Command denied: flagged as dangerous.") is None
+
+    def test_command_failure_is_not_a_floor(self):
+        assert classify_floor_block("command not found: foo") is None
+
+    def test_empty_and_none(self):
+        assert classify_floor_block("") is None
+        assert classify_floor_block(None) is None
 
 
 class TestDetectSkill:


### PR DESCRIPTION
## What

Completes the approval audit trail in Phoenix so every governance decision — human, smart guardian, or hard floor — answers "who decided, and why?" on the span.

Two provenance gaps fixed:

1. **Smart-guardian verdicts are misclassified.** `tools/approval_smart.py` fires `post_approval_response` with `choice=f"smart_{verdict}"` and `decided_by="aux_llm"`, but `_APPROVAL_GRANT_CHOICES` does not know `smart_approve` — an auto-approved command lands in Phoenix with `granted=false`. `smart_approve` IS a grant (the tool ran).

2. **Floor blocks are invisible.** `approvals.deny` globs, the hardline blocklist and the sudo-stdin guard never fire the approval hooks — the block dict collapses into the terminal error envelope (`status: "blocked"`) before `post_tool_call` sees it. A hard-floor denial appeared only as an anonymous `blocked` outcome with no record of who blocked it.

## Changes

- `classify_approval_choice(choice, decided_by=None)` — recognizes `smart_approve/deny/escalate`; returned dict gains `decided_by` (`"aux_llm"` for smart verdicts, else the explicit value, else empty for human answers). Backwards compatible.
- `on_post_approval_response` — exports `hermes.approval.decided_by` on the approval span.
- `classify_floor_block(block_message)` — classifies `BLOCKED`-prefixed terminal envelopes into `deny_rule | hardline | sudo_stdin_guard | unknown_floor` (message-prefix matching; switch to a structured floor-reason field if hermes ever grows one).
- `on_post_tool_call` — on a blocked outcome, stamps the tool span with `hermes.approval.choice=denied_by_floor`, `decided_by=hard_floor`, and the classified floor — the same span-level provenance approval-gated commands already get.

## Verification

- New span attributes verified end to end against a live Phoenix instance: a command matching an `approvals.deny` glob produces a `tool.terminal` span with `outcome=blocked, choice=denied_by_floor, decided_by=hard_floor, floor=deny_rule`.
- Unit tests extended (`TestClassifyApprovalChoice`, `TestClassifyFloorBlock`); full unit suite: 584 passed, no new failures vs. baseline (the 43 pre-existing failures in my minimal venv are missing optional deps, identical on unpatched `main`).

## Notes

- Attribute naming follows the existing `hermes.approval.*` namespace.
- `capture_previews` redaction concerns do not apply: the new attributes are enums/short labels, not command content (command previews keep their existing policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)